### PR TITLE
feat(frontend): Implement Matrix-Themed Thermal Radar & Real-Time SignalR Telemetry

### DIFF
--- a/backend/Services/LibreThermalProvider.cs
+++ b/backend/Services/LibreThermalProvider.cs
@@ -1,6 +1,7 @@
 ﻿using BlackSharp.Core.Extensions;
 using GSInteractiveDeviceAnalyzer.Interfaces;
 using GSInteractiveDeviceAnalyzer.Models;
+using System.Runtime.Versioning;
 #if WINDOWS
 using LibreHardwareMonitor.Hardware;
 #endif

--- a/frontend/gs_anlyzer_ui/lib/models/thermal_telemetry.dart
+++ b/frontend/gs_anlyzer_ui/lib/models/thermal_telemetry.dart
@@ -1,0 +1,55 @@
+class ThermalTelemetry {
+  final double? cpuPackageCelsius;
+  final List<double> coreCelsius;
+  final double? motherBoardCelsius;
+  final double? chipsetCelsius;
+  final double? nvmeCelsius;
+  final double? cpuPowerWatts;
+  final bool isThermalThrottling;
+  final int? cpuFanRpm;
+  final int? chassisFan1Rpm;
+  final int? chassisFan2Rpm;
+  final int? pumpRpm;
+  final double? gpuCoreCelsius;
+  final double? gpuHotspotCelsius;
+  final double? gpuVramCelsius;
+  final int? gpuFanRpm;
+
+  ThermalTelemetry({
+    this.cpuPackageCelsius,
+    this.coreCelsius = const [],
+    this.motherBoardCelsius,
+    this.chipsetCelsius,
+    this.nvmeCelsius,
+    this.cpuPowerWatts,
+    this.isThermalThrottling = false,
+    this.cpuFanRpm,
+    this.chassisFan1Rpm,
+    this.chassisFan2Rpm,
+    this.pumpRpm,
+    this.gpuCoreCelsius,
+    this.gpuHotspotCelsius,
+    this.gpuVramCelsius,
+    this.gpuFanRpm,
+});
+
+  factory ThermalTelemetry.fromJson(Map<String, dynamic> json) {
+    return ThermalTelemetry(
+      cpuPackageCelsius: (json['cpuPackageCelsius'] as num?)?.toDouble(),
+      coreCelsius: (json['coreCelsius'] as List<dynamic>?)?.map((e) => (e as num).toDouble()).toList() ?? [],
+      motherBoardCelsius: (json['motherBoardCelsius'] as num?)?.toDouble(),
+      chipsetCelsius: (json['chipsetCelsius'] as num?)?.toDouble(),
+      nvmeCelsius: (json['nvmeCelsius'] as num?)?.toDouble(),
+      cpuPowerWatts: (json['cpuPowerWatts'] as num?)?.toDouble(),
+      isThermalThrottling: json['isThermalThrottling'] as bool? ?? false,
+      cpuFanRpm: json['cpuFanRpm'] as int?,
+      chassisFan1Rpm: json['chassisFan1Rpm'] as int?,
+      chassisFan2Rpm: json['chassisFan2Rpm'] as int?,
+      pumpRpm: json['pumpRpm'] as int?,
+      gpuCoreCelsius: (json['gpuCoreCelsius'] as num?)?.toDouble(),
+      gpuHotspotCelsius: (json['gpuHotspotCelsius'] as num?)?.toDouble(),
+      gpuVramCelsius: (json['gpuVramCelsius'] as num?)?.toDouble(),
+      gpuFanRpm: json['gpuFanRpm'] as int?,
+    );
+  }
+}

--- a/frontend/gs_anlyzer_ui/lib/providers/navigation_provider.dart
+++ b/frontend/gs_anlyzer_ui/lib/providers/navigation_provider.dart
@@ -6,6 +6,7 @@ enum AppRoute {
   memory,
   storage,
   network,
+  thermal,
 }
 
 final navigationProvider = StateProvider<AppRoute>((ref) => AppRoute.storage);

--- a/frontend/gs_anlyzer_ui/lib/providers/thermal_provider.dart
+++ b/frontend/gs_anlyzer_ui/lib/providers/thermal_provider.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:signalr_netcore/signalr_client.dart';
+import 'package:gs_analyzer_ui/models/thermal_telemetry.dart';
+import 'package:gs_analyzer_ui/services/api_service.dart';
+
+class ThermalNotifier extends StateNotifier<ThermalTelemetry?> {
+  HubConnection? _hubConnection;
+  final ApiService _apiService = ApiService();
+
+  ThermalNotifier(): super(null) {
+    _fetchInitialSnapshot();
+    _initSignalR();
+}
+
+  Future<void> _fetchInitialSnapshot() async {
+    try {
+      final snapshot = await _apiService.getCurrentThermals();
+      if (snapshot != null) {
+        // Instantly populate the UI while SignalR is still waking up
+        state = ThermalTelemetry.fromJson(snapshot);
+        print("🦅🔥 THERMAL RADAR: Instant Snapshot Loaded!");
+      }
+    } catch (e) {
+      print("Failed to load initial thermal snapshot: $e");
+    }
+  }
+
+Future<void> _initSignalR() async {
+    final serverUrl = 'http://localhost:5200/systemHub';
+
+    _hubConnection = HubConnectionBuilder().withUrl(serverUrl).withAutomaticReconnect().build();
+
+    _hubConnection?.on("ReceiveThermalTelemetry", _handleThermalUpdate);
+
+    try {
+      await _hubConnection?.start();
+      print('THERMAL RADAR CONNECTED TO SYSTEM HUB!');
+    } catch (e) {
+      print('TELEMETRY ERROR: Failed to connect thermal Radar: $e');
+    }
+  }
+
+  void _handleThermalUpdate(List<dynamic>? arguments) {
+    if (arguments != null && arguments.isNotEmpty) {
+      try {
+        final data = arguments.first as Map<String, dynamic>;
+        state = ThermalTelemetry.fromJson(data);
+      } catch (e) {
+        print('THERMAL PAYLOAD CRASH: $e');
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _hubConnection?.stop();
+    super.dispose();
+  }
+}
+
+final thermalProvider = StateNotifierProvider<ThermalNotifier, ThermalTelemetry?>((ref) {
+  return ThermalNotifier();
+});

--- a/frontend/gs_anlyzer_ui/lib/screen/master_layout.dart
+++ b/frontend/gs_anlyzer_ui/lib/screen/master_layout.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gs_analyzer_ui/providers/navigation_provider.dart';
 import 'package:gs_analyzer_ui/screen/analyzer_dashboard.dart';
 import 'package:gs_analyzer_ui/screen/ram_scannner_screen.dart';
+import 'package:gs_analyzer_ui/screen/thermal_module_screen.dart';
 import 'package:gs_analyzer_ui/utils/hud_theme.dart';
 import 'package:gs_analyzer_ui/widgets/global_sidebar_widget.dart';
 
@@ -40,6 +41,9 @@ class MasterLayout extends ConsumerWidget {
 
       case AppRoute.network:
         return const Center(child: Text('NETWORK MODULE OFFLINE', style: HudTheme.headerCyan,));
+
+        case AppRoute.thermal:
+        return const ThermalModuleScreen();
 
       case AppRoute.dashboard:
         default:

--- a/frontend/gs_anlyzer_ui/lib/screen/thermal_module_screen.dart
+++ b/frontend/gs_anlyzer_ui/lib/screen/thermal_module_screen.dart
@@ -1,5 +1,8 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gs_analyzer_ui/providers/cpu_provider.dart';
 import 'package:gs_analyzer_ui/providers/thermal_provider.dart';
 import 'package:gs_analyzer_ui/models/thermal_telemetry.dart';
 import 'package:gs_analyzer_ui/utils/hud_theme.dart';
@@ -18,6 +21,7 @@ class _ThermalModuleScreenState extends ConsumerState<ThermalModuleScreen> {
   @override
   Widget build(BuildContext context) {
     final telemetry = ref.watch(thermalProvider);
+    final cpuState = ref.watch(cpuProvider);
 
     return Padding(
       padding: const EdgeInsets.all(24.0),
@@ -41,7 +45,7 @@ class _ThermalModuleScreenState extends ConsumerState<ThermalModuleScreen> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  _buildCpuSection(telemetry),
+                  _buildCpuSection(telemetry, cpuState),
                   const SizedBox(height: 16),
 
                   if (telemetry.motherBoardCelsius != null || telemetry.chipsetCelsius != null) ... [
@@ -74,7 +78,7 @@ class _ThermalModuleScreenState extends ConsumerState<ThermalModuleScreen> {
     return (t.cpuFanRpm ?? 0) > 0 || (t.chassisFan1Rpm ?? 0) > 0 || (t.chassisFan2Rpm ?? 0) > 0 || (t.pumpRpm ?? 0) > 0;
   }
 
-  Widget _buildCpuSection(ThermalTelemetry telemetry) {
+  Widget _buildCpuSection(ThermalTelemetry telemetry, dynamic cpuState) {
     return _ThermalSection(
       title: 'CPU',
       icon: Icons.memory_outlined,
@@ -94,8 +98,12 @@ class _ThermalModuleScreenState extends ConsumerState<ThermalModuleScreen> {
                   decoration: BoxDecoration(color: HudTheme.accentRed.withValues(alpha: 0.2), border: Border.all(color: HudTheme.accentRed), borderRadius: BorderRadius.circular(4)),
                   child: const Text('THROTTLING', style: HudTheme.actionRed),
                 ),
-              Text(
-                'POWER: ${telemetry.cpuPowerWatts?.toStringAsFixed(1) ?? 'N/A'} W',
+              // Later is i can access the power directly from the hardware
+              // Text(
+              //   'POWER: ${telemetry.cpuPowerWatts?.toStringAsFixed(1) ?? 'N/A'} W',
+              //   style: HudTheme.statGreen,
+                Text(
+                'POWER: ${_getDisplayPower(telemetry, cpuState)}',
                 style: HudTheme.statGreen,
               ),
             ],
@@ -231,6 +239,40 @@ class _ThermalModuleScreenState extends ConsumerState<ThermalModuleScreen> {
         )
       ],
     );
+  }
+
+  String _getDisplayPower(ThermalTelemetry telemetry, dynamic cpuState) {
+    if (telemetry.cpuPowerWatts != null && telemetry.cpuPowerWatts! > 0) {
+      return '${telemetry.cpuPowerWatts!.toStringAsFixed(1)} W';
+    }
+
+    if (cpuState != null) {
+      const double maxTdp = 45.0;
+      const double idlePower = 5.0;
+      const double turboPower = 90.0;
+      const double baseFrequency = 2.6;
+
+      double loadFactor = cpuState.averageLoad / 100.0;
+      double currentGhz = cpuState.currentFrequencyGhz;
+
+      double freqFactor = 1.0;
+      if (currentGhz > 0) {
+        freqFactor = math.pow((currentGhz / baseFrequency), 2.5).toDouble();
+      }
+
+      double estimatePower = idlePower + ((maxTdp - idlePower) * loadFactor * freqFactor);
+
+      if (telemetry.isThermalThrottling) {
+        estimatePower *= 0.65;
+      }
+
+      if (estimatePower > turboPower) {
+        estimatePower = turboPower;
+      }
+      return '~${estimatePower.toStringAsFixed(1)} W';
+    }
+
+    return 'N/A W';
   }
 }
 

--- a/frontend/gs_anlyzer_ui/lib/screen/thermal_module_screen.dart
+++ b/frontend/gs_anlyzer_ui/lib/screen/thermal_module_screen.dart
@@ -1,0 +1,296 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gs_analyzer_ui/providers/thermal_provider.dart';
+import 'package:gs_analyzer_ui/models/thermal_telemetry.dart';
+import 'package:gs_analyzer_ui/utils/hud_theme.dart';
+import 'package:gs_analyzer_ui/utils/hud_label.dart';
+
+class ThermalModuleScreen extends ConsumerStatefulWidget {
+  const ThermalModuleScreen({super.key});
+
+  @override
+  ConsumerState<ThermalModuleScreen> createState() => _ThermalModuleScreenState();
+}
+
+class _ThermalModuleScreenState extends ConsumerState<ThermalModuleScreen> {
+  bool _isAdvancedExpanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final telemetry = ref.watch(thermalProvider);
+
+    return Padding(
+      padding: const EdgeInsets.all(24.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'THERMAL RADAR MODULE', style: HudTheme.headerCyan
+          ),
+          const SizedBox(height: 24),
+
+          if (telemetry == null)
+            const Expanded(
+              child: Center(
+                child: CircularProgressIndicator(color: HudTheme.accentAmber),
+              ),
+            )
+          else
+            Expanded(
+              child: SingleChildScrollView(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  _buildCpuSection(telemetry),
+                  const SizedBox(height: 16),
+
+                  if (telemetry.motherBoardCelsius != null || telemetry.chipsetCelsius != null) ... [
+                    _buildBoardSection(telemetry),
+                    const SizedBox(height: 16,)
+                  ],
+
+                  if (telemetry.nvmeCelsius != null) ...[
+                    _buildStorageSection(telemetry),
+                    const SizedBox(height: 16),
+                  ],
+
+                  if (_hasActiveFans(telemetry)) ...[
+                    _buildFansSection(telemetry),
+                    const SizedBox(height: 16),
+                  ],
+
+                  _buildAdvancedSection(),
+                  const SizedBox(height: 24),
+                ],
+              ),
+            )
+          ),
+        ],
+      )
+    );
+  }
+
+  bool _hasActiveFans(ThermalTelemetry t) {
+    return (t.cpuFanRpm ?? 0) > 0 || (t.chassisFan1Rpm ?? 0) > 0 || (t.chassisFan2Rpm ?? 0) > 0 || (t.pumpRpm ?? 0) > 0;
+  }
+
+  Widget _buildCpuSection(ThermalTelemetry telemetry) {
+    return _ThermalSection(
+      title: 'CPU',
+      icon: Icons.memory_outlined,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                'PKG: ${telemetry.cpuPackageCelsius?.toStringAsFixed(1) ?? 'N/A'}°C',
+                style: const TextStyle(color: HudTheme.accentCyan, fontSize: 28, fontWeight: FontWeight.bold, fontFamily: HudTheme.fontCore),
+              ),
+              if (telemetry.isThermalThrottling)
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+                  decoration: BoxDecoration(color: HudTheme.accentRed.withValues(alpha: 0.2), border: Border.all(color: HudTheme.accentRed), borderRadius: BorderRadius.circular(4)),
+                  child: const Text('THROTTLING', style: HudTheme.actionRed),
+                ),
+              Text(
+                'POWER: ${telemetry.cpuPowerWatts?.toStringAsFixed(1) ?? 'N/A'} W',
+                style: HudTheme.statGreen,
+              ),
+            ],
+          ),
+
+          if (telemetry.coreCelsius.isNotEmpty) ... [
+            const SizedBox(height: 16),
+            SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Row(
+                children: telemetry.coreCelsius.asMap().entries.map((entry) {
+                  return Padding(
+                    padding: const EdgeInsetsGeometry.only(right: 8.0),
+                    child: _ThermalChip(label: 'C${entry.key}', celsius: entry.value),
+                  );
+                }).toList(),
+              ),
+            )
+          ]
+        ],
+      )
+    );
+  }
+
+  Widget _buildBoardSection(ThermalTelemetry telemetry) {
+    return _ThermalSection(
+      title: 'BOARD',
+      icon: Icons.developer_board_outlined,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          if (telemetry.motherBoardCelsius != null)
+            Text('MOBO: ${telemetry.motherBoardCelsius}°C', style: HudTheme.bodyText.copyWith(color: HudTheme.textMain, fontSize: 16)),
+
+          if (telemetry.chipsetCelsius != null)
+            Text('CHIPSET: ${telemetry.chipsetCelsius}°C', style: HudTheme.bodyText.copyWith(color: HudTheme.textMain, fontSize: 16)),
+        ],
+      )
+    );
+  }
+
+  Widget _buildStorageSection(ThermalTelemetry telemetry) {
+    return _ThermalSection(
+      title: 'STORAGE',
+      icon: Icons.storage_outlined,
+      child: Text(
+        'NAME: ${telemetry.nvmeCelsius}°C',
+        style: HudTheme.bodyText.copyWith(color: HudTheme.textMain, fontSize: 16),
+      )
+    );
+  }
+
+  Widget _buildFansSection(ThermalTelemetry telemetry) {
+    return _ThermalSection(
+      title: 'FANS',
+      icon: Icons.air_outlined,
+      child: Wrap(
+        spacing: 24,
+        runSpacing: 12,
+        children: [
+          if ((telemetry.cpuFanRpm ?? 0) > 0) _buildFanRow('CPU_FAN', telemetry.cpuFanRpm!),
+          if((telemetry.chassisFan1Rpm ?? 0) > 0) _buildFanRow('CHA_FAN1', telemetry.chassisFan1Rpm!),
+          if((telemetry.chassisFan2Rpm ?? 0) > 0) _buildFanRow('CHA_FAN2', telemetry.chassisFan2Rpm!),
+          if((telemetry.pumpRpm ?? 0) > 0) _buildFanRow('PUMP', telemetry.pumpRpm!)
+        ],
+      )
+    );
+  }
+
+  Widget _buildFanRow(String label, int rpm) {
+    Color rpmColor = HudTheme.accentGreen;
+    if (rpm > 3500) rpmColor = HudTheme.accentRed;
+    else if (rpm > 2000) rpmColor = HudTheme.accentAmber;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        HudLabel('$label: '),
+        Text('$rpm RPM', style: HudTheme.statGreen.copyWith(color: rpmColor))
+      ],
+    );
+  }
+
+  Widget _buildAdvancedSection() {
+    return Container(
+      decoration: HudTheme.hudPanelDecoration,
+      child: Theme(
+        data: Theme.of(context).copyWith(dividerColor: Colors.transparent),
+        child: ExpansionTile(
+          collapsedIconColor: HudTheme.textDim,
+          iconColor: HudTheme.accentCyan,
+          onExpansionChanged: (expanded) => setState(() =>
+            _isAdvancedExpanded = expanded),
+          title: Row(
+            children: [
+              Icon(Icons.tune_outlined, color: _isAdvancedExpanded ? HudTheme.accentCyan : HudTheme.textDim, size: 20),
+              const SizedBox(width: 12),
+              HudLabel('ADVANCED', textAlign: TextAlign.left),
+            ],
+          ),
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(left: 24, right: 24, bottom: 24, top: 8),
+              child: Wrap(
+                spacing: 32,
+                runSpacing: 16,
+                children: [
+                  _buildAdvancedRow('GPU_CORE', 'N/A'),
+                  _buildAdvancedRow('GPU_HOTSPOT', 'N/A'),
+                  _buildAdvancedRow('VRAM_TEMP', 'N/A'),
+                  _buildAdvancedRow('GPU_FAN', 'N/A'),
+                ],
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAdvancedRow(String label, String value) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          '$label: ', style: HudTheme.labelMuted,
+        ),
+        Text(
+          '$value ', style: HudTheme.bodyText.copyWith(color: HudTheme.textDim),
+        ),
+        const Text(
+          '[v3.0]', style: TextStyle(color: Colors.white24, fontSize: 10, fontFamily: HudTheme.fontCore)
+        )
+      ],
+    );
+  }
+}
+
+class _ThermalSection extends StatelessWidget {
+  final String title;
+  final IconData icon;
+  final Widget child;
+
+  const _ThermalSection({required this.title, required this.icon, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(24),
+      decoration: HudTheme.hudPanelDecoration,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(icon, color: HudTheme.textDim, size: 20,),
+              const SizedBox(width: 12),
+              HudLabel(title)
+            ],
+          ),
+          const SizedBox(height: 16),
+          child,
+        ],
+      ),
+    );
+  }
+}
+
+class _ThermalChip extends StatelessWidget {
+  final String label;
+  final double celsius;
+  const _ThermalChip({required this.label, required this.celsius});
+
+  @override
+  Widget build(BuildContext context) {
+    Color tempColor = HudTheme.accentGreen;
+    if (celsius > 85) tempColor = HudTheme.accentRed;
+    else if (celsius > 70) tempColor = HudTheme.accentAmber;
+    return  Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: tempColor.withValues(alpha: 0.1),
+        border: Border.all(color: tempColor.withValues(alpha: 0.3)),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text('$label:', style: HudTheme.labelMuted,),
+          const SizedBox(width: 4),
+          Text('${celsius.toStringAsFixed(0)}°', style: HudTheme.statGreen.copyWith(color: tempColor,),
+          )
+        ],
+      ),
+    );
+  }
+}
+

--- a/frontend/gs_anlyzer_ui/lib/services/api_service.dart
+++ b/frontend/gs_anlyzer_ui/lib/services/api_service.dart
@@ -8,6 +8,7 @@ class ApiService {
   static  const String storageUrl = 'http://localhost:5200/api/storage';
   static const String telemetryUrl = 'http://localhost:5200/api/Telemetry';
   static const String nukeUrl = 'http://localhost:5200/api/nuke';
+  static const String thermalUrl = 'http://localhost:5200/api/thermal';
 
   Future<List<StorageNode>> scanDirectory(String path) async {
     final uri = Uri.parse('$storageUrl/scan').replace(queryParameters: {
@@ -175,6 +176,32 @@ class ApiService {
       }
     } else {
       throw Exception('Bridge Failed with Status: ${response.statusCode}');
+    }
+  }
+
+  Future<Map<String, dynamic>?> getCurrentThermals() async {
+    final uri = Uri.parse('$thermalUrl/current');
+    print('MATRIX BRIDGE: Requesting Instant Thermal Snapshot...');
+
+    try {
+      final response = await http.get(uri);
+
+      if (response.statusCode == 200) {
+        final jsonBody = jsonDecode(response.body);
+
+        if (jsonBody['success'] == true && jsonBody['data'] != null){
+          return jsonBody['data'] as Map<String, dynamic>;
+        } else {
+          print('THERMAL SNAPSHOT FAILED: ${jsonBody['message']}');
+          return null;
+        }
+      } else {
+        print('THERMAL SNAPSHOT FAILED: Status ${response.statusCode}');
+        return null;
+      }
+    } catch (e) {
+      print('THERMAL BRIDGE ERROR: $e');
+      return null;
     }
   }
 

--- a/frontend/gs_anlyzer_ui/lib/widgets/global_sidebar_widget.dart
+++ b/frontend/gs_anlyzer_ui/lib/widgets/global_sidebar_widget.dart
@@ -53,6 +53,7 @@ class GlobalSidebarWidget extends ConsumerWidget {
           _buildNavItem(ref, AppRoute.memory, 'MEMORY', Icons.bar_chart_outlined, currentRoute),
           _buildNavItem(ref, AppRoute.storage, 'STORAGE', Icons.storage_outlined, currentRoute),
           _buildNavItem(ref, AppRoute.network, 'NETWORK', Icons.account_tree_outlined, currentRoute),
+          _buildNavItem(ref, AppRoute.thermal, 'THERMAL', Icons.thermostat_outlined, currentRoute),
 
           const Spacer(),
 


### PR DESCRIPTION
## 🎯 Objective
This PR introduces the dedicated Thermal Module to the GSInteractiveDeviceAnalyzer frontend. It establishes a decoupled, real-time WebSocket connection to the C# backend and implements a highly adaptive UI that dynamically responds to hardware-level sensor locks (e.g., Dell VBS/Core Isolation).

## 🏗️ Architectural & UI Highlights
### 📡 Encapsulated SignalR Provider & Hybrid Bootstrapping

- ThermalNotifier (Riverpod): Implemented a dedicated StateNotifier that manages its own independent connection to the backend's systemHub, preventing bottlenecking on the global storage radio.

- Zero-Latency UI: Integrated a pre-fetch REST call (GET /api/thermal/current) via ApiService. The UI instantly paints a static thermal snapshot on load, smoothly transitioning to the live SignalR WebSocket stream (ReceiveThermalTelemetry) once the handshake completes.

### 👻 The "Ghost UI" Pattern

- Designed the ThermalModuleScreen to gracefully degrade. If the backend returns null for heavily fortified OEM sensors (like motherboard thermals or Embedded Controller Fan RPMs), the UI seamlessly collapses those sections without rendering broken 0 values or throwing null reference errors.

### 🧠 Dynamic Power Estimation Engine

- The Workaround: Since OEM hardware frequently blocks access to physical CPU RAPL (Power) registers, a cross-pollinated estimation algorithm was built into the UI.

- The Math: The UI actively watches both the thermalProvider and the cpuProvider. It calculates an exponential frequency curve (base vs. turbo boost) combined with the active CPU load to estimate dynamic wattage on the fly. It also applies an automatic 35% power-cut calculation if the isThermalThrottling flag is triggered.