### PR TITLE
Refactored the codebase and config the CI workflow 

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x' # Uses the latest major .NET version
+          dotnet-version: '10.0.x' # Matches the project's TargetFramework (net10.0)
 
       # Step C: Download all your NuGet packages (like SignalR)
       - name: Restore Dependencies

--- a/analysis_results.md
+++ b/analysis_results.md
@@ -1,0 +1,271 @@
+# 🦅 GS System Analyzer — Full Repository Analysis
+
+## 1. Project Overview
+
+**GS System Analyzer** is a cross-platform system telemetry & disk management desktop application with a "Cyber-HUD" aesthetic. It combines the functionality of Task Manager, TreeSize, and HWiNFO into a single open-source tool.
+
+| Aspect | Detail |
+|---|---|
+| **Status** | Pre-Beta v2.0 (targeting June 2026 public beta) |
+| **Backend** | ASP.NET Core 10 (C#), .NET 10 multi-target (`net10.0-windows;net10.0`) |
+| **Frontend** | Flutter/Dart with Riverpod state management |
+| **Communication** | REST API + SignalR WebSocket hub |
+| **Key Deps** | LibreHardwareMonitor, PerformanceCounter, fl_chart, signalr_netcore |
+
+---
+
+## 2. Architecture
+
+```mermaid
+graph TB
+    subgraph "Frontend — Flutter/Dart"
+        A["main.dart<br/>ProviderScope + MaterialApp"]
+        B["MasterLayout<br/>Sidebar + Screens"]
+        C["Riverpod Providers<br/>(13 providers)"]
+        D["ApiService<br/>REST calls"]
+        E["TelemetryService<br/>SignalR WebSocket"]
+    end
+
+    subgraph "Backend — ASP.NET Core 10"
+        F["Program.cs<br/>DI + Pipeline"]
+        G["Controllers (6)<br/>REST endpoints"]
+        H["SystemHub<br/>SignalR Hub"]
+        I["Engines (4)<br/>Background Services"]
+        J["Services (16)<br/>Business Logic"]
+        K["Models / DTOs"]
+        L["Interfaces (11)"]
+    end
+
+    A --> B
+    B --> C
+    C --> D
+    C --> E
+    D -->|HTTP REST| G
+    E -->|WebSocket| H
+    G --> J
+    I -->|Broadcast| H
+    J --> L
+    I --> L
+```
+
+### Core Architectural Rule
+> *"All OS-level work happens in C#, and data reaches Flutter only via SignalR streams or REST."*
+
+This is consistently upheld — the Flutter side never performs direct OS I/O.
+
+---
+
+## 3. Backend Deep-Dive
+
+### 3.1 Entry Point — [Program.cs](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/Program.cs)
+
+Minimal API bootstrap with DI registrations, CORS, controllers, and SignalR. Platform-conditional registration (Windows vs Linux) for CPU and thermal providers.
+
+### 3.2 Engine Layer
+
+| Engine | File | Role |
+|---|---|---|
+| **DiskScannerEngine** | [DiskScannerEngine.cs](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/Engine/DiskScannerEngine.cs) | Parallel directory scanning with `ConcurrentDictionary` cache, `FileSystemWatcher` live radar, JSON persistence, nuke/scan cancellation tokens |
+| **CpuSamplerEngine** | [CpuSamplerEngine.cs](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/Engine/CpuSamplerEngine.cs) | `BackgroundService` polling CPU metrics on a periodic timer, broadcasting via SignalR |
+| **RamMonitoringEngine** | [RamMonitoringEngine.cs](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/Engine/RamMonitoringEngine.cs) | On-demand RAM radar loop — top-N processes by working set, global memory metrics, process kill ("ExecuteOrder66") |
+| **ThermalMonitoringEngine** | [ThermalMonitoringEngine.cs](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/Engine/ThermalMonitoringEngine.cs) | `BackgroundService` polling thermal providers, broadcasting via SignalR |
+
+### 3.3 Controller Layer (6 controllers)
+
+| Controller | Route Prefix | Endpoints |
+|---|---|---|
+| [StorageController](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/Controllers/StorageController.cs) | `api/storage` | `POST scan`, `POST stream-sector`, `GET drive-stats`, `POST abort-scan`, `POST duplicates`, `GET scan-largefiles` |
+| [NukeController](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/Controllers/NukeController.cs) | `api/nuke` | `POST preview`, `DELETE execute`, `POST abort` |
+| [TelemetryController](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/Controllers/TelemetryController.cs) | `api/telemetry` | `POST ram/start`, `POST ram/stop`, `POST ram/kill`, `GET cpu-load` |
+| [ThermalController](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/Controllers/ThermalController.cs) | `api/thermal` | `GET current` |
+| [DrivesController](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/Controllers/DrivesController.cs) | `api/drives` | `GET` (list all drives) |
+| [SettingsController](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/Controllers/SettingsController.cs) | `api/settings` | `GET`, `GET defaults`, `POST`, `POST reset`, `PATCH partial` |
+
+### 3.4 Service Layer Highlights
+
+- **NukeProtocolService** — Batch deletion with `AggressiveObliterate` (strips all file attributes before recursive delete), cache invalidation up the tree, progress streaming over SignalR.
+- **DuplicateFileDetector** — Two-pass algorithm: O(n) size filter → parallel SHA-256 hashing via `ConcurrentDictionary`.
+- **LargeFileHunterService** — Min-heap (`PriorityQueue`) for efficient top-N tracking without sorting the full set.
+- **LibreThermalProvider** — 3-tier fallback: LibreHardwareMonitor → Dell OEM VBS → WMI. Last-good-payload cache for resilience.
+- **SettingsServices** — JSON-file persistence with atomic write (temp file + `File.Move`), hot-reload via `OnSettingsChanged` event.
+
+### 3.5 Background Workers
+
+- [DriveMonitorService](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/BackgroundWorkers/DriveMonitorService.cs) — Polls every 5s for hardware changes (USB plug/unplug), every 60s for disk-space alerts (>90% threshold), broadcasts via SignalR.
+
+### 3.6 Test Suite
+
+11 test files across 3 categories:
+
+| Category | Test Files |
+|---|---|
+| **Services** | `DuplicateFileDetectorTests`, `LargeFileHunterServiceTests`, `NukeProtocolServiceTests`, `DellOemTelemetryTests`, `SettingIntegrationTest` |
+| **Engines** | `LibreThermalProviderTests`, `LinuxCpuProviderTest`, `LinuxThermalProviderTest`, `WindowsCpuProviderTest` |
+| **Controllers** | `ScanControllerMultiDriveTests`, `SettingsContollerTest` |
+
+---
+
+## 4. Frontend Deep-Dive
+
+### 4.1 App Shell
+
+[main.dart](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/frontend/gs_anlyzer_ui/lib/main.dart) → `ProviderScope` → `MaterialApp` (dark theme) → [MasterLayout](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/frontend/gs_anlyzer_ui/lib/screen/master_layout.dart) (sidebar + screen switcher).
+
+### 4.2 Screen Inventory (7 screens)
+
+| Screen | Purpose | Status |
+|---|---|---|
+| `AnalyzerDashboard` | Storage explorer with directory tree, nuke protocol, duplicate/large file scanners | ✅ Live |
+| `CpuMetricsScreen` | Real-time CPU load, per-core groups, frequency | ✅ Live |
+| `RamScannerScreen` | Per-process RAM breakdown, kill processes | ✅ Live |
+| `ThermalModuleScreen` | CPU/GPU/Board/NVMe temps, fan RPMs, throttle detection | 🛠️ In Progress |
+| `SettingsScreen` | Full settings panel with validation | ✅ Live |
+| Network module | Placeholder | ⏳ Planned |
+| Main dashboard | Placeholder | ⏳ Planned |
+
+### 4.3 State Management — 13 Riverpod Providers
+
+Providers cover: navigation, directory tree, drive stats, CPU/RAM/thermal telemetry, duplicate/large file scanning, nuke protocol, settings, and storage mode.
+
+### 4.4 Design System — [HudTheme](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/frontend/gs_anlyzer_ui/lib/utils/hud_theme.dart)
+
+Custom "Cyber-HUD" design system with:
+- Dark base colors (`#161616`, `#1E1E1E`)
+- Cyan/green/red/amber accent palette
+- Monospace `Courier` typography
+- Glowing bordered panel decorations
+
+### 4.5 Communication Layer
+
+| Service | Transport | Purpose |
+|---|---|---|
+| [ApiService](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/frontend/gs_anlyzer_ui/lib/services/api_service.dart) | HTTP REST | Request-response operations (scan, nuke, settings) |
+| [TelemetryService](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/frontend/gs_anlyzer_ui/lib/services/telemetry_service.dart) | SignalR WebSocket | Real-time streaming (CPU, RAM, thermal, scan progress, radar alerts) |
+
+---
+
+## 5. CI/CD Pipeline
+
+Two GitHub Actions workflows:
+
+| Workflow | File | Runs On | Steps |
+|---|---|---|---|
+| `.NET Build & Test` | [dotnet-desktop.yml](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/.github/workflows/dotnet-desktop.yml) | `windows-latest` | Checkout → Setup .NET → Restore → Build → Test → Discord Notify |
+| `Dart Lint & Test` | [dart.yml](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/.github/workflows/dart.yml) | — | Flutter analysis & testing |
+
+---
+
+## 6. Bugs & Issues Found
+
+### 🔴 Critical
+
+| # | Location | Issue |
+|---|---|---|
+| 1 | [Program.cs:13+26](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/Program.cs#L13-L26) | **Duplicate DI registration** — `DiskScannerEngine` is registered as singleton **twice** (lines 13 and 26). Same for `LargeFileHunterService` (lines 29-30 and 59) and `NukeProtocolService` (lines 31 and 60). This wastes memory and could cause confusing DI resolution issues. |
+| 2 | [DuplicateFileDetector.cs:132](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/Services/DuplicateFileDetector.cs#L132) | **String literal instead of variable** — `file.FullName.Contains("appDataSegment", ...)` uses the literal string `"appDataSegment"` instead of the variable `appDataSegment`. This means AppData paths are **never** filtered out. |
+| 3 | [TelemetryService.dart:103](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/frontend/gs_anlyzer_ui/lib/services/telemetry_service.dart#L103) | **Logic inversion bug** — `if (arguments == null && arguments!.isEmpty)` should be `\|\|` not `&&`. With `&&`, if `arguments` is null, the `arguments!.isEmpty` is never reached (short-circuit), but if `arguments` is non-null, the null-check passes, and it tries `isEmpty`. This effectively never returns early on empty lists — and if arguments *is* null, it falls through and crashes on line 105. |
+| 4 | [dotnet-desktop.yml:29](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/.github/workflows/dotnet-desktop.yml#L29) | **CI SDK mismatch** — CI uses `dotnet-version: '8.0.x'` but the project targets `net10.0`. The CI build will fail or not test against the actual target framework. |
+
+### 🟡 Medium
+
+| # | Location | Issue |
+|---|---|---|
+| 5 | [DiskScannerEngine.cs:157-161](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/Engine/DiskScannerEngine.cs#L157-L161) | **Unused `EnumerationOptions`** — `option` is created but never passed to `dir.GetFiles()` on line 162. The options (including `IgnoreInaccessible`) are silently ignored. |
+| 6 | [StorageController.cs:49+58](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/Controllers/StorageController.cs#L49-L58) | **Duplicate `DirectoryStreamComplete`** — Sent both in the `try` block (line 49) and the `finally` block (line 58), meaning the client always receives it twice on success. |
+| 7 | [DiskScannerEngine.cs:24](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/Engine/DiskScannerEngine.cs#L24) | **Cache path is relative** — `_cacheFilePath = "scanner_memory.json"` resolves relative to the working directory, which varies depending on how the app is launched. This 63 MB file could end up in unexpected locations. Should use an absolute path (e.g., AppData). |
+| 8 | [ApiService.dart:77](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/frontend/gs_anlyzer_ui/lib/services/api_service.dart#L77) | **Wrong abort URL** — `abortNuke()` calls `$nukeUrl/nuke` instead of `$nukeUrl/abort`. The nuke abort signal will never reach the backend. |
+| 9 | [ApiService.dart:253](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/frontend/gs_anlyzer_ui/lib/services/api_service.dart#L253) | **Wrong HTTP method for reset** — Uses `http.delete` but the backend expects `POST` at `api/settings/reset`. Will return 405 Method Not Allowed. |
+| 10 | [WindowsCpuProvider.cs:81-83](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/Services/WindowsCpuProvider.cs#L81-L83) | **Hardcoded cache sizes** — L1/L2/L3 cache sizes are hardcoded strings instead of being read from the system. Will be wrong on most machines. |
+| 11 | [Program.cs:17-22](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/Program.cs#L17-L22) | **Overly permissive CORS** — `AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod()` in production is a security risk. Should be restricted to `http://localhost:*` or the Flutter app's origin. |
+| 12 | [StorageController.cs:20-21](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/Controllers/StorageController.cs#L20-L21) | **Scan endpoint mismatch** — `POST scan` expects `[FromBody] ScanRequest` but the Flutter `scanDirectory()` sends a `GET` with query parameters. These will never communicate correctly. |
+| 13 | [DriveMonitorService.cs:29](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/BackgroundWorkers/DriveMonitorService.cs#L29) | **Missing space in generic** — `ILogger<DriveMonitorService>logger` is missing a space. This compiles in C# but is a style issue that suggests it might have been a copy-paste artifact. |
+
+### 🟢 Low / Code Quality
+
+| # | Location | Issue |
+|---|---|---|
+| 14 | [DiskScannerEngine.cs:25](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/Engine/DiskScannerEngine.cs#L25) | Typo: `_liveRader` should be `_liveRadar` (used throughout the file) |
+| 15 | [SettingsServices.cs:11](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/Services/SettingsServices.cs#L11) | Typo: `_fileLoack` should be `_fileLock` |
+| 16 | [InteractiveAnalyzer.cs](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/InteractiveAnalyzer.cs) | Entire class is commented out — dead code from the original console UI. Should be removed. |
+| 17 | Multiple files | `FormatSize()` utility is duplicated in `NukeProtocolService`, `LargeFileHunterService`, and `DriveMonitorService`. Should be extracted to a shared utility. |
+| 18 | [DiskScannerEngine.cs:190-192](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/Engine/DiskScannerEngine.cs#L190-L192) | **Silent exception swallowing** — `catch (Exception e) { }` silently eats all errors in `GetDirectorySize`. At minimum, log the error. |
+| 19 | [ThermalMonitoringEngine.cs:34-43](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/Engine/ThermalMonitoringEngine.cs#L34-L43) | **Platform check at runtime** — The `if (Windows)` branch is checked on every tick despite being a compile-time constant. The non-Windows path returns an empty DTO instead of using the registered `LinuxThermalProvider`. |
+| 20 | Frontend | Extensive `print()` debug logging throughout production code (e.g., "MATRIX BRIDGE FIRING", "FEDEX BOX OPENED"). Should use a proper logging framework or be gated behind a debug flag. |
+| 21 | [DiskOperationsService.cs:42](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/Services/DiskOperationsService.cs#L42) | **Sync-over-async** — `.GetAwaiter().GetResult()` blocks the calling thread. This can cause deadlocks in ASP.NET Core's thread pool under load. Should be properly `await`ed. |
+
+---
+
+## 7. Architecture Assessment
+
+### ✅ Strengths
+
+1. **Clean frontend/backend separation** — The architectural rule is respected. Zero OS calls from Flutter.
+2. **Interface-driven design** — 11 interfaces decouple implementations. Great for testability (evidenced by the test suite using fakes).
+3. **Platform abstraction** — Windows/Linux CPU and thermal providers behind `ICpuMetricsProvider` / `IThermalProvider` with compile-time `#if` guards.
+4. **Real-time architecture** — SignalR used effectively for 7+ different event types (scan progress, radar, nuke progress, CPU/RAM/thermal telemetry, drive alerts).
+5. **Robust deletion** — The Nuke Protocol has proper safeguards: dry run preview, `C:\Windows` protection, cancellation tokens, progress streaming.
+6. **Smart algorithms** — Min-heap for large file hunting, two-pass duplicate detection (size filter → hash), stale cache detection via `LastWriteTimeUtc`.
+7. **Comprehensive test coverage** — Tests span all three layers (controllers, engines, services) with proper fakes/mocks.
+8. **Thermal resilience** — 3-tier fallback (LibreHW → Dell OEM → WMI) plus last-good-payload caching.
+
+### ⚠️ Areas for Improvement
+
+1. **DI registration hygiene** — Multiple duplicate registrations create noise and confusion.
+2. **Structured logging** — Replace `Console.WriteLine` with `ILogger<T>`. The thematic log messages ("RADAR ONLINE", "ASSASSINATED PID") are fun but should use proper log levels.
+3. **Error handling consistency** — Mix of silent swallowing (`catch { }`), console logging, and proper exception propagation.
+4. **API contract mismatches** — Several frontend/backend communication bugs (wrong HTTP methods, wrong URLs, GET vs POST).
+5. **Configuration management** — The 63 MB `scanner_memory.json` is in the repo root and uses a relative path.
+6. **Security** — Open CORS policy, no authentication/authorization, no rate limiting on destructive endpoints.
+
+---
+
+## 8. File & Directory Statistics
+
+| Section | Files | Lines (est.) |
+|---|---|---|
+| Backend — Controllers | 6 | ~660 |
+| Backend — Engines | 4 | ~610 |
+| Backend — Services | 16 | ~2,100 |
+| Backend — Models/DTOs | 23 | ~350 |
+| Backend — Interfaces | 11 | ~120 |
+| Backend — Tests | 11 | ~1,400 |
+| Frontend — Screens | 7 | ~1,200 |
+| Frontend — Providers | 13 | ~800 |
+| Frontend — Widgets | 12 | ~1,100 |
+| Frontend — Services | 2 | ~420 |
+| Frontend — Models | 9 | ~350 |
+| Frontend — Utils | 4 | ~150 |
+| **Total** | **~118** | **~9,260** |
+
+---
+
+## 9. Prioritised Recommendations
+
+### Immediate (Pre-Beta Blockers)
+
+1. **Fix the `DuplicateFileDetector` string bug** (#2) — AppData exclusion is completely broken
+2. **Fix the `abortNuke()` URL** (#8) — Users cannot abort nuke operations
+3. **Fix the settings reset HTTP method** (#9) — Reset button is non-functional
+4. **Fix the RAM telemetry null check** (#3) — Will crash on null payloads
+5. **Update CI to .NET 10** (#4) — Builds are failing or testing wrong framework
+6. **Remove duplicate DI registrations** (#1) — Clean up before anyone else contributes
+7. **Fix the scan endpoint GET/POST mismatch** (#12) — Front-to-back communication is broken
+
+### Short-Term (Before v2.0)
+
+8. Replace `Console.WriteLine` with `ILogger<T>` across the backend
+9. Extract `FormatSize()` to a shared utility class
+10. Move `scanner_memory.json` to AppData with an absolute path
+11. Add `.gitignore` entry for `scanner_memory.json` (63 MB binary in repo root)
+12. Fix the `EnumerationOptions` not being passed to `GetFiles()` in `DiskScannerEngine`
+13. Remove the commented-out `InteractiveAnalyzer` class
+14. Strip `print()` debug spam from Flutter production code
+
+### Medium-Term (v2.1+)
+
+15. Add authentication/authorization to destructive endpoints
+16. Restrict CORS to known origins
+17. Add rate limiting to nuke/scan endpoints
+18. Implement structured logging with Serilog or similar
+19. Read actual CPU cache sizes from the system instead of hardcoding
+20. Fix `sync-over-async` in `DiskOperationsService.ScanDirectory`

--- a/backend/BackgroundWorkers/DriveMonitorService.cs
+++ b/backend/BackgroundWorkers/DriveMonitorService.cs
@@ -22,6 +22,9 @@ public class DriveMonitorService : BackgroundService
     private int _secondsSincelastSpaceCheck = 0;
 
     private const double AlertThresholdPercent = 90.0;
+    private readonly HashSet<string> _alertedDrives = new();
+    private readonly Dictionary<string, DateTime> _lastAlertUtc = new();
+    private static readonly TimeSpan AlertReArmInterval = TimeSpan.FromMinutes(30);
 
     public DriveMonitorService(
         IDriveDetectionService driveService,
@@ -55,24 +58,62 @@ public class DriveMonitorService : BackgroundService
                     _lastHardwareSignature = currentSignature;
                 }
 
-                // Checkinmg for space thresholds (every 60 seconds)
+                // Checking for space thresholds (every 60 seconds)
                 if (_secondsSincelastSpaceCheck >= 60)
                 {
                     foreach (var drive in drives)
                     {
-                        if (drive.UsedPercent >= AlertThresholdPercent)
-                        {
-                            _logger.LogWarning($"Disk Alert: {drive.Name} is critially full ({drive.UsedPercent}%).");
+                        var isOverThreshold = drive.UsedPercent >= AlertThresholdPercent;
+                        var alreadyAlerted = _alertedDrives.Contains(drive.Name);
 
-                            await _hubContext.Clients.All.SendAsync("DiskAlert", new
+                        if (isOverThreshold)
+                        {
+                            var dueForReminder =
+                                _lastAlertUtc.TryGetValue(drive.Name, out var last) &&
+                                (DateTime.UtcNow - last) >= AlertReArmInterval;
+
+                            // Fire only on the first crossing, or once the re-arm window has elapsed.
+                            if (!alreadyAlerted || dueForReminder)
+                            {
+                                _logger.LogWarning(
+                                    "Disk Alert: {DriveName} is critically full ({UsedPercent}%).",
+                                    drive.Name, drive.UsedPercent);
+
+                                await _hubContext.Clients.All.SendAsync("DiskAlert", new
+                                {
+                                    driveName = drive.Name,
+                                    label = drive.Label,
+                                    usedPercent = drive.UsedPercent,
+                                    freeFormatted = FormatSize(drive.FreeBytes)
+                                }, stoppingToken);
+
+                                _alertedDrives.Add(drive.Name);
+                                _lastAlertUtc[drive.Name] = DateTime.UtcNow;
+                            }
+                        }
+                        else if (alreadyAlerted)
+                        {
+                            // Drive recovered below the threshold — clear state and let the HUD dismiss it.
+                            _alertedDrives.Remove(drive.Name);
+                            _lastAlertUtc.Remove(drive.Name);
+
+                            await _hubContext.Clients.All.SendAsync("DiskAlertCleared", new
                             {
                                 driveName = drive.Name,
                                 label = drive.Label,
-                                usedPercent = drive.UsedPercent,
-                                freeFormatted = FormatSize(drive.FreeBytes)
+                                usedPercent = drive.UsedPercent
                             }, stoppingToken);
                         }
                     }
+
+                    // Prune state for drives that have been removed/unmounted.
+                    var presentNames = drives.Select(d => d.Name).ToHashSet();
+                    _alertedDrives.RemoveWhere(name => !presentNames.Contains(name));
+                    foreach (var stale in _lastAlertUtc.Keys.Where(k => !presentNames.Contains(k)).ToList())
+                    {
+                        _lastAlertUtc.Remove(stale);
+                    }
+
                     _secondsSincelastSpaceCheck = 0;
                 }
             }
@@ -88,10 +129,11 @@ public class DriveMonitorService : BackgroundService
 
     private string FormatSize(long bytes)
     {
-        string[] suffixes = { "B", "KB", "MB", "GB", "TB" };
+        string[] suffixes = { "B", "KB", "MB", "GB", "TB", "PB", "EB" };
         int counter = 0;
         decimal number = bytes;
-        while (Math.Round(number / 1024) >= 1)
+        // Stop at the largest known suffix so we can never index past the array.
+        while (Math.Round(number / 1024) >= 1 && counter < suffixes.Length - 1)
         {
             number /= 1024;
             counter++;

--- a/backend/BackgroundWorkers/DriveMonitorService.cs
+++ b/backend/BackgroundWorkers/DriveMonitorService.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using GSInteractiveDeviceAnalyzer.Models;
+using GSInteractiveDeviceAnalyzer.Services;
+using GSInteractiveDeviceAnalyzer.Interfaces;
+using GSInteractiveDeviceAnalyzer.Hubs;
+
+namespace GSInteractiveDeviceAnalyzer.BackgroundWorkers;
+
+public class DriveMonitorService : BackgroundService
+{
+    private readonly IDriveDetectionService _driveService;
+    private readonly IHubContext<SystemHub> _hubContext;
+    private readonly ILogger<DriveMonitorService> _logger;
+
+    private string _lastHardwareSignature = string.Empty;
+    private int _secondsSincelastSpaceCheck = 0;
+
+    private const double AlertThresholdPercent = 90.0;
+
+    public DriveMonitorService(
+        IDriveDetectionService driveService,
+        IHubContext<SystemHub> hubContext,
+        ILogger<DriveMonitorService>logger)
+    {
+        _driveService = driveService;
+        _hubContext = hubContext;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Drive Monitor Background Service is starting.");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                var drives = _driveService.GetReadyDrives();
+
+                // Checking for hardware changes (every 5 seconds)
+                var currentSignature = string.Join("|", drives.Select(d => $"{d.Name}-{d.Label}-{d.TotalBytes}"));
+
+                if (currentSignature != _lastHardwareSignature)
+                {
+                    _logger.LogInformation("Hardware change detected. Broadcasting DriveListUpdate.");
+
+                    await _hubContext.Clients.All.SendAsync("DriveListUpdate", new { drives = drives }, stoppingToken);
+
+                    _lastHardwareSignature = currentSignature;
+                }
+
+                // Checkinmg for space thresholds (every 60 seconds)
+                if (_secondsSincelastSpaceCheck >= 60)
+                {
+                    foreach (var drive in drives)
+                    {
+                        if (drive.UsedPercent >= AlertThresholdPercent)
+                        {
+                            _logger.LogWarning($"Disk Alert: {drive.Name} is critially full ({drive.UsedPercent}%).");
+
+                            await _hubContext.Clients.All.SendAsync("DiskAlert", new
+                            {
+                                driveName = drive.Name,
+                                label = drive.Label,
+                                usedPercent = drive.UsedPercent,
+                                freeFormatted = FormatSize(drive.FreeBytes)
+                            }, stoppingToken);
+                        }
+                    }
+                    _secondsSincelastSpaceCheck = 0;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "An error occurred in the Drive Monitor loop.");
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+            _secondsSincelastSpaceCheck += 5;
+        }
+    }
+
+    private string FormatSize(long bytes)
+    {
+        string[] suffixes = { "B", "KB", "MB", "GB", "TB" };
+        int counter = 0;
+        decimal number = bytes;
+        while (Math.Round(number / 1024) >= 1)
+        {
+            number /= 1024;
+            counter++;
+        }
+        return string.Format("{0:n1} {1}", number, suffixes[counter]);
+    }
+}

--- a/backend/Controllers/DrivesController.cs
+++ b/backend/Controllers/DrivesController.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
+using GSInteractiveDeviceAnalyzer.Models;
+using GSInteractiveDeviceAnalyzer.Services;
+using GSInteractiveDeviceAnalyzer.Interfaces;
+
+namespace GSInteractiveDeviceAnalyzer.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class DrivesController : ControllerBase
+{
+    private readonly IDriveDetectionService _driveService;
+
+    public DrivesController(IDriveDetectionService driveService)
+    {
+        _driveService = driveService;
+    }
+
+    [HttpGet]
+    public IActionResult GetAllDrives()
+    {
+        try
+        {
+            var drives = _driveService.GetReadyDrives();
+
+            return Ok(new ApiResponse<List<DriveMetric>>
+            {
+                Success = true,
+                Message = $"Successfully retrieved {drives.Count} ready drives.",
+                Data = drives
+            });
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, new ApiResponse<object>
+            {
+                Success = false,
+                Message = $"Failed to enumerate drives: {ex.Message}"
+            });
+        }
+    }
+}

--- a/backend/Controllers/StorageController.cs
+++ b/backend/Controllers/StorageController.cs
@@ -1,4 +1,4 @@
-﻿using GSInteractiveDeviceAnalyzer.Engine;
+using GSInteractiveDeviceAnalyzer.Engine;
 using GSInteractiveDeviceAnalyzer.Hubs;
 using GSInteractiveDeviceAnalyzer.Interfaces;
 using GSInteractiveDeviceAnalyzer.Models;
@@ -45,8 +45,6 @@ namespace GSInteractiveDeviceAnalyzer.Controllers
 
                         await Task.Delay(10);
                     }
-
-                    await hubContext.Clients.All.SendAsync("DirectoryStreamComplete", path);
                 }
                 catch (Exception ex)
                 {

--- a/backend/Controllers/StorageController.cs
+++ b/backend/Controllers/StorageController.cs
@@ -66,12 +66,39 @@ namespace GSInteractiveDeviceAnalyzer.Controllers
             });
         }
 
-        [HttpGet("scan")]
-        public async Task<IActionResult> ScanDirectory([FromQuery] string path)
+        [HttpPost("scan")]
+        public async Task<IActionResult> ScanDirectory(
+            [FromBody] ScanRequest request, 
+            [FromServices] IDriveDetectionService driveService)
         {
             try
             {
-                var result = _diskService.ScanDirectory(path);
+                string targetPath = string.IsNullOrWhiteSpace(request?.Root)
+                    ? (Path.GetPathRoot(Environment.SystemDirectory) ?? "C:\\")
+                    : request.Root;
+                
+                var normalizedRoot = Path.GetPathRoot(targetPath)?.ToUpperInvariant() ?? targetPath.ToUpperInvariant();
+
+                var readyDrives = driveService.GetReadyDrives();
+                if (!readyDrives.Any(d => d.Name.ToUpperInvariant() == normalizedRoot))
+                {
+                    return BadRequest(new ApiResponse<object>
+                    {
+                        Success = false,
+                        Message = $"Drive not ready or found: {normalizedRoot}"
+                    });
+                }
+
+                if (!System.IO.Directory.Exists(targetPath))
+                {
+                    return BadRequest(new ApiResponse<object>
+                    {
+                        Success = false,
+                        Message = "Scan failed: Invalid or missing target directory."
+                    });
+                }
+
+                var result = await Task.Run(() => _diskService.ScanDirectory(targetPath));
 
                 var response = new ApiResponse<IEnumerable<StorageNode>>
                 {
@@ -134,23 +161,52 @@ namespace GSInteractiveDeviceAnalyzer.Controllers
             });
         }
 
-        [HttpGet("duplicates")]
-        public async Task<IActionResult> ScanForDuplicates([FromQuery] string path, [FromServices] DiskScannerEngine engine)
+        [HttpPost("duplicates")]
+        public async Task<IActionResult> ScanForDuplicates(
+            [FromBody] ScanRequest request,
+            [FromServices] DiskScannerEngine engine,
+            [FromServices] IDriveDetectionService driveService)
         {
             try
             {
-                var cancelToken = engine.ScanToken();
-                var duplicateGroups = await _duplicateFileDetector.FindDuplicatesAsync(path);
+                string targetPath = string.IsNullOrWhiteSpace(request?.Root)
+                    ? (Path.GetPathRoot(Environment.SystemDirectory) ?? "C:\\")
+                    : request.Root;
+                
+                var normalizedRoot = Path.GetPathRoot(targetPath)?.ToUpperInvariant() ?? targetPath.ToUpperInvariant();
 
-                return Ok(new
+                var readyDrives = driveService.GetReadyDrives();
+                if (!readyDrives.Any(d => d.Name.ToUpperInvariant() == normalizedRoot))
                 {
-                    success = true,
-                    data = duplicateGroups
+                    return BadRequest(new ApiResponse<object>
+                    {
+                        Success = false,
+                        Message = $"Drive not ready or not found: {normalizedRoot}"
+                    });
+                }
+
+                if (!System.IO.Directory.Exists(targetPath))
+                {
+                    return BadRequest(new ApiResponse<object>
+                    {
+                        Success = false,
+                        Message = "Scan failed: Invalid or missing target directory."
+                    });
+                }
+
+                var cancelToken = engine.ScanToken();
+                var duplicateGroups = await _duplicateFileDetector.FindDuplicatesAsync(targetPath);
+
+                return Ok(new ApiResponse<IEnumerable<DuplicateGroup>>
+                {
+                    Success = true,
+                    Message = "Duplicates scanned successfully.",
+                    Data = duplicateGroups
                 });
             }
             catch (OperationCanceledException)
             {
-                return BadRequest(new ApiResponse<object>
+                return StatusCode(499, new ApiResponse<object>
                 {
                     Success = false,
                     Message = "Duplicate Scan Aborted by User."
@@ -161,22 +217,39 @@ namespace GSInteractiveDeviceAnalyzer.Controllers
                 return BadRequest(new ApiResponse<object>
                 {
                     Success = false,
-                    Message = ex.Message
+                    Message = $"Scan failed: {ex.Message}"
                 });
             }
-            { }
         }
 
         [HttpGet("scan-largefiles")]
         public async Task<IActionResult> GetLargeFiles(
-            [FromQuery] string root,
             [FromServices] ILargeFileHunterService hunter,
+            [FromServices] IDriveDetectionService driveService,
             CancellationToken cancellationToken,
+            [FromQuery] string? root = null,
             [FromQuery] int top = 20)
         {
             try
             {
-                if (string.IsNullOrWhiteSpace(root) || !System.IO.Directory.Exists(root))
+                if (string.IsNullOrWhiteSpace(root))
+                {
+                    root = Path.GetPathRoot(Environment.SystemDirectory) ?? "C:\\";
+                }
+
+                var normalizedRoot = Path.GetPathRoot(root)?.ToUpperInvariant() ?? root.ToUpperInvariant();
+
+                var readyDrives = driveService.GetReadyDrives();
+                if (!readyDrives.Any(d => d.Name.ToUpperInvariant() == normalizedRoot))
+                {
+                    return BadRequest(new ApiResponse<object>
+                    {
+                        Success = false,
+                        Message = $"Drive not ready or not found: {normalizedRoot}"
+                    });
+                }
+
+                if (!System.IO.Directory.Exists(root))
                 {
                     return BadRequest( new ApiResponse<object>
                     {
@@ -185,7 +258,7 @@ namespace GSInteractiveDeviceAnalyzer.Controllers
                     });
                 }
 
-                var result = await hunter.GetTopLargeFilesAsync(root, top);
+                var result = await hunter.GetTopLargeFilesAsync(root, top, cancellationToken);
 
                 var response = new ApiResponse<IEnumerable<LargeFile>>
                 {

--- a/backend/Engine/DiskScannerEngine.cs
+++ b/backend/Engine/DiskScannerEngine.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.Text.Json;
 using GSInteractiveDeviceAnalyzer.Hubs;
 using GSInteractiveDeviceAnalyzer.Interfaces;
@@ -21,7 +21,9 @@ public class DiskScannerEngine
     private readonly SemaphoreSlim _scanLock = new SemaphoreSlim(1, 1);
     private readonly object _fileWriteLock = new object();
     private int _deepScanThrottle = 0;
-    private readonly string _cacheFilePath = "scanner_memory.json";
+    private readonly string _cacheFilePath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "GSAnalyzer", "scanner_memory.json");
     private FileSystemWatcher? _liveRader;
     private readonly object _radarLock = new object();
     private DateTime _lastRadarAlert = DateTime.MinValue;
@@ -159,7 +161,7 @@ public class DiskScannerEngine
                 IgnoreInaccessible = true,
                 AttributesToSkip = 0
             };
-            var files = dir.GetFiles();
+            var files = dir.GetFiles("*", option);
             size += files.Sum(f => f.Length);
 
             var pulse = Interlocked.Increment(ref _deepScanThrottle);
@@ -253,6 +255,7 @@ public class DiskScannerEngine
             try
             {
                 string json = JsonSerializer.Serialize(DirectorySizeCache);
+                Directory.CreateDirectory(Path.GetDirectoryName(_cacheFilePath)!);
                 File.WriteAllText(_cacheFilePath, json);
                 Console.WriteLine($"MEMORY SAVED: {DirectorySizeCache.Count} folders saved to disk!");
             }

--- a/backend/GSInteractiveDeviceAnalyzer.Tests/Controller/ScanControllerMultiDriveTests.cs
+++ b/backend/GSInteractiveDeviceAnalyzer.Tests/Controller/ScanControllerMultiDriveTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+using GSInteractiveDeviceAnalyzer.Models;
+using GSInteractiveDeviceAnalyzer.Controllers;
+using GSInteractiveDeviceAnalyzer.Services;
+using GSInteractiveDeviceAnalyzer.Interfaces;
+using GSInteractiveDeviceAnalyzer.Tests.Fakes;
+
+namespace GSInteractiveDeviceAnalyzer.Tests.Controllers;
+
+public class ScanControllerMultiDriveTests
+{
+    private readonly StorageController _controller; 
+    private readonly IDriveDetectionService _fakeDriveService;
+    private readonly ILargeFileHunterService _fakeHunterService;
+
+    public ScanControllerMultiDriveTests()
+    {
+        _fakeDriveService = new FakeDriveDetectionService();
+        _fakeHunterService = new FakeLargeFileHunter();
+        
+        // Properly injects nulls for unused dependencies
+        _controller = new StorageController(null, null); 
+    }
+
+    [Fact]
+    public async Task GetLargeFiles_WithValidMountedDrive_ReturnsOk()
+    {
+        // Arrange
+        // Uses a directory we absolutely know exists on your physical motherboard
+        string requestedRoot = Environment.SystemDirectory; 
+
+        // Act
+        var result = await _controller.GetLargeFiles(
+            _fakeHunterService,
+            _fakeDriveService,
+            CancellationToken.None,
+            requestedRoot);
+
+        // Assert - Expecting total success
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<ApiResponse<IEnumerable<LargeFile>>>(okResult.Value);
+        Assert.True(response.Success);
+    }
+
+    [Fact]
+    public async Task GetLargeFiles_WithUnpluggedGhostDrive_ReturnsBadRequest()
+    {
+        // Arrange
+        string requestedRoot = "Z:\\"; // Z almost certainly doesn't exist
+
+        // Act
+        var result = await _controller.GetLargeFiles(
+            _fakeHunterService,
+            _fakeDriveService,
+            CancellationToken.None,
+            requestedRoot);
+
+        // Assert - Expecting the hardware gatekeeper to block it
+        var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
+        var response = Assert.IsType<ApiResponse<object>>(badRequestResult.Value);
+        
+        Assert.False(response.Success);
+        Assert.Contains("Drive not ready", response.Message);
+    }
+
+    [Fact]
+    public async Task GetLargeFiles_WithEmptyRoot_DefaultsToSystemDriveAndValidates()
+    {
+        // Arrange
+        string requestedRoot = ""; 
+
+        // Act
+        var result = await _controller.GetLargeFiles(
+            _fakeHunterService,
+            _fakeDriveService,
+            CancellationToken.None,
+            requestedRoot);
+
+        // Assert - Expecting total success because the controller will cleanly fall back to C:\
+        var okResult = Assert.IsType<OkObjectResult>(result);
+        var response = Assert.IsType<ApiResponse<IEnumerable<LargeFile>>>(okResult.Value);
+        Assert.True(response.Success);
+    }
+}

--- a/backend/GSInteractiveDeviceAnalyzer.Tests/Fakes/FakeDriveDetectionService.cs
+++ b/backend/GSInteractiveDeviceAnalyzer.Tests/Fakes/FakeDriveDetectionService.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using GSInteractiveDeviceAnalyzer.Interfaces;
+using GSInteractiveDeviceAnalyzer.Models;
+using GSInteractiveDeviceAnalyzer.Services;
+
+namespace GSInteractiveDeviceAnalyzer.Tests.Fakes;
+
+public class FakeDriveDetectionService : IDriveDetectionService
+{
+    public List<DriveMetric> GetReadyDrives()
+    {
+        string actualSystemRoot = Path.GetPathRoot(Environment.SystemDirectory) ?? "C:\\";
+        return new List<DriveMetric>
+        {
+            new DriveMetric { Name = actualSystemRoot, Label = "Main OS", IsReady = true }
+        };
+    }
+}

--- a/backend/GSInteractiveDeviceAnalyzer.Tests/Fakes/FakeLargeFileHunter.cs
+++ b/backend/GSInteractiveDeviceAnalyzer.Tests/Fakes/FakeLargeFileHunter.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GSInteractiveDeviceAnalyzer.Models;
+using GSInteractiveDeviceAnalyzer.Services;
+using GSInteractiveDeviceAnalyzer.Interfaces;
+
+namespace GSInteractiveDeviceAnalyzer.Tests.Fakes;
+
+public class FakeLargeFileHunter : ILargeFileHunterService
+{
+    public Task<List<LargeFile>> GetTopLargeFilesAsync(string rootPath, int topN, CancellationToken token = default)
+    {
+        return Task.FromResult(new List<LargeFile>());
+    }
+}

--- a/backend/Interfaces/IDriveDetectionService.cs
+++ b/backend/Interfaces/IDriveDetectionService.cs
@@ -1,0 +1,9 @@
+using GSInteractiveDeviceAnalyzer.Models;
+
+namespace GSInteractiveDeviceAnalyzer.Interfaces
+{
+    public interface IDriveDetectionService
+    {
+        List<DriveMetric> GetReadyDrives();
+    }
+}

--- a/backend/Models/DriveMetric.cs
+++ b/backend/Models/DriveMetric.cs
@@ -1,0 +1,14 @@
+namespace GSInteractiveDeviceAnalyzer.Models;
+
+public class DriveMetric
+{
+    public string Name { get; set; } = string.Empty;
+    public string Label { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty;
+    public long TotalBytes { get; set; }
+    public long FreeBytes { get; set; }
+    public long UsedBytes { get; set; }
+    public double UsedPercent { get; set; }
+    public string Format { get; set; } = string.Empty;
+    public bool IsReady { get; set; }
+}

--- a/backend/Models/ScanRequestDto.cs
+++ b/backend/Models/ScanRequestDto.cs
@@ -1,0 +1,7 @@
+namespace GSInteractiveDeviceAnalyzer.Models
+{
+    public class ScanRequest
+    {
+        public string Root { get; set; } = string.Empty;
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -10,8 +10,6 @@ using System.Runtime.InteropServices;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddSingleton<DiskScannerEngine>();
-
 builder.Services.AddCors(options =>
 {
     options.AddPolicy("AllowFlutterApp", policy =>
@@ -23,14 +21,18 @@ builder.Services.AddCors(options =>
 });
 
 builder.Services.AddControllers();
+
+// Engine singletons
 builder.Services.AddSingleton<DiskScannerEngine>();
 builder.Services.AddSingleton<RamMonitoringEngine>();
-builder.Services.AddSingleton<DuplicateFileDetector>();
-builder.Services.AddSingleton<LargeFileHunterService>();
+
+// Service singletons (interface → implementation)
 builder.Services.AddSingleton<ILargeFileHunterService, LargeFileHunterService>();
 builder.Services.AddSingleton<INukeProtocolService, NukeProtocolService>();
 builder.Services.AddSingleton<IDriveDetectionService, DriveDetectionService>();
 builder.Services.AddSingleton<ISettingService, SettingsServices>();
+
+// Platform-specific CPU provider
 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 {
     builder.Services.AddSingleton<ICpuMetricsProvider, WindowsCpuProvider>();
@@ -43,6 +45,8 @@ else
 {
     throw new PlatformNotSupportedException("OS not supported for CPU telemetry");
 }
+
+// Platform-specific thermal provider
 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 {
     builder.Services.AddSingleton<IThermalProvider, LibreThermalProvider>();
@@ -53,15 +57,18 @@ else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
 }
 else
 {
-    throw new PlatformNotSupportedException("OS not supported for CPU telemetry");
+    throw new PlatformNotSupportedException("OS not supported for thermal telemetry");
 }
+
+// Background services
 builder.Services.AddHostedService<CpuSamplerEngine>();
-builder.Services.AddSingleton<ILargeFileHunterService, LargeFileHunterService>();
-builder.Services.AddSingleton<INukeProtocolService, NukeProtocolService>();
 builder.Services.AddHostedService<ThermalMonitoringEngine>();
 builder.Services.AddHostedService<DriveMonitorService>();
+
+// Scoped services (per-request)
 builder.Services.AddScoped<IDiskOperationService, DiskOperationsService>();
 builder.Services.AddScoped<IDuplicateFileDetector, DuplicateFileDetector>();
+
 builder.Services.AddSignalR();
 var app = builder.Build();
 

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -1,4 +1,5 @@
 using GSInteractiveDeviceAnalyzer;
+using GSInteractiveDeviceAnalyzer.BackgroundWorkers;
 using GSInteractiveDeviceAnalyzer.Engine;
 using GSInteractiveDeviceAnalyzer.Hubs;
 using GSInteractiveDeviceAnalyzer.Interfaces;
@@ -28,6 +29,7 @@ builder.Services.AddSingleton<DuplicateFileDetector>();
 builder.Services.AddSingleton<LargeFileHunterService>();
 builder.Services.AddSingleton<ILargeFileHunterService, LargeFileHunterService>();
 builder.Services.AddSingleton<INukeProtocolService, NukeProtocolService>();
+builder.Services.AddSingleton<IDriveDetectionService, DriveDetectionService>();
 builder.Services.AddSingleton<ISettingService, SettingsServices>();
 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 {
@@ -57,6 +59,7 @@ builder.Services.AddHostedService<CpuSamplerEngine>();
 builder.Services.AddSingleton<ILargeFileHunterService, LargeFileHunterService>();
 builder.Services.AddSingleton<INukeProtocolService, NukeProtocolService>();
 builder.Services.AddHostedService<ThermalMonitoringEngine>();
+builder.Services.AddHostedService<DriveMonitorService>();
 builder.Services.AddScoped<IDiskOperationService, DiskOperationsService>();
 builder.Services.AddScoped<IDuplicateFileDetector, DuplicateFileDetector>();
 builder.Services.AddSignalR();

--- a/backend/Services/DriveDetectionService.cs
+++ b/backend/Services/DriveDetectionService.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using GSInteractiveDeviceAnalyzer.Models;
+using GSInteractiveDeviceAnalyzer.Interfaces;
+using System.Linq.Expressions;
+
+namespace GSInteractiveDeviceAnalyzer.Services;
+
+// public interface IDriveDetectionService
+// {
+//     List<DriveMetric> GetReadyDrives();
+// }
+
+public class DriveDetectionService : IDriveDetectionService
+{
+    public List<DriveMetric> GetReadyDrives()
+    {
+        var result = new List<DriveMetric>();
+        var drives = DriveInfo.GetDrives();
+
+        foreach (var drive in drives)
+        {
+            if (!drive.IsReady) continue;
+
+            try
+            {
+                long total = drive.TotalSize;
+                long free = drive.AvailableFreeSpace;
+                long used = total - free;
+
+                double percent = total > 0 ? Math.Round((double)used / total * 100, 1) : 0;
+
+                result.Add(new DriveMetric
+                {
+                    Name = drive.Name,
+                    Label = drive.VolumeLabel,
+                    Type = drive.DriveType.ToString(),
+                    TotalBytes = total,
+                    FreeBytes = free,
+                    UsedBytes = used,
+                    UsedPercent = percent,
+                    Format = drive.DriveFormat,
+                    IsReady = drive.IsReady
+                });
+            }
+            catch (IOException) { /* To skip unreadable drives */ }
+            catch (UnauthorizedAccessException) { /* To skip locked drives */ }
+        }
+
+        return result;
+    }
+}

--- a/backend/Services/DuplicateFileDetector.cs
+++ b/backend/Services/DuplicateFileDetector.cs
@@ -129,7 +129,8 @@ namespace GSInteractiveDeviceAnalyzer.Services
                 token.ThrowIfCancellationRequested();
 
                 string appDataSegment = $"{Path.DirectorySeparatorChar}AppData{Path.DirectorySeparatorChar}";
-                if (file.FullName.Contains("appDataSegment", StringComparison.OrdinalIgnoreCase))
+                if (!rootPath.Contains(appDataSegment, StringComparison.OrdinalIgnoreCase)
+                    && file.FullName.Contains(appDataSegment, StringComparison.OrdinalIgnoreCase))
                 {
                     continue;
                 }

--- a/frontend/gs_anlyzer_ui/lib/services/api_service.dart
+++ b/frontend/gs_anlyzer_ui/lib/services/api_service.dart
@@ -74,7 +74,7 @@ class ApiService {
   Future<void> abortNuke() async {
     try {
       print('SENDING NUKE ABORT SIGNAL....');
-      await http.post(Uri.parse('$nukeUrl/nuke'));
+      await http.post(Uri.parse('$nukeUrl/abort'));
     } catch (e) {
       print('Failed to send abort signal: $e');
     }
@@ -250,7 +250,7 @@ class ApiService {
 
   Future<Map<String, dynamic>?> resetSettings() async {
     try {
-      final response = await http.delete(Uri.parse('$settingsUrl/reset'));
+      final response = await http.post(Uri.parse('$settingsUrl/reset'));
       if (response.statusCode == 200) return jsonDecode(response.body)['data'];
     } catch (e) {
       print('[API] Reset Error: $e');

--- a/frontend/gs_anlyzer_ui/lib/services/api_service.dart
+++ b/frontend/gs_anlyzer_ui/lib/services/api_service.dart
@@ -12,18 +12,19 @@ class ApiService {
   static const String settingsUrl = 'http://localhost:5200/api/settings';
 
   Future<List<StorageNode>> scanDirectory(String path) async {
-    final uri = Uri.parse('$storageUrl/scan').replace(queryParameters: {
-      'path': path
-    });
-    print('MATRIX BRIDGE FIRING TO: $uri');
+    final uri = Uri.parse('$storageUrl/scan');
+    print('MATRIX BRIDGE FIRING TO: $uri (root: $path)');
 
+    final response = await http.post(
+      uri,
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({'Root': path}),
+    );
 
-    final response = await http.get(uri);
-
-    if(response.statusCode == 200) {
+    if (response.statusCode == 200) {
       final jsonBody = jsonDecode(response.body);
 
-      if(jsonBody['success'] == true) {
+      if (jsonBody['success'] == true) {
         print('FEDEX BOX OPENED! Data is: ${jsonBody['data']}');
         List<dynamic> data = jsonBody['data'];
         return data.map((json) => StorageNode.fromJson(json)).toList();
@@ -136,13 +137,14 @@ class ApiService {
   }
 
   Future<List<dynamic>> scanForDuplicates(String path) async {
-    final uri = Uri.parse('$storageUrl/duplicates').replace(queryParameters: {
-      'path': path
-    });
+    final uri = Uri.parse('$storageUrl/duplicates');
+    print('INITIATING DUPLICATE HUNTER ON: $uri (root: $path)');
 
-    print('INITIATING DUPLICATE HUNTER ON: $uri');
-
-    final response = await http.get(uri);
+    final response = await http.post(
+      uri,
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({'Root': path}),
+    );
 
     if (response.statusCode == 200) {
       final jsonBody = jsonDecode(response.body);
@@ -152,6 +154,9 @@ class ApiService {
       } else {
         throw Exception(jsonBody['message']);
       }
+    } else if (response.statusCode == 499) {
+      // Backend signalled the duplicate scan was cancelled by the user — not an error.
+      return <dynamic>[];
     } else {
       throw Exception('Bridge Failed with Status: ${response.statusCode} - ${response.body}');
     }

--- a/frontend/gs_anlyzer_ui/lib/services/telemetry_service.dart
+++ b/frontend/gs_anlyzer_ui/lib/services/telemetry_service.dart
@@ -100,7 +100,7 @@ import 'package:signalr_netcore/signalr_client.dart';
     }
 
     void _handleRamUpdate(List<Object?>? arguments) {
-      if (arguments == null && arguments!.isEmpty) return;
+      if (arguments == null || arguments.isEmpty) return;
       try {
         final rawData = arguments[0];
 


### PR DESCRIPTION
# Multi-drive review fixes: frontend contract sync, DiskAlert cooldown, FormatSize clamp

## Summary
Follow-up to #115 (multi-drive support). Addresses the two merge blockers and one
crash bug found in review:

1. **Sync the Flutter client to the new POST scan/duplicates contract** (blocker)
2. **Stop DiskAlert from re-firing every 60s** (blocker)
3. **Clamp `FormatSize` so PB-scale drives can't crash the monitor loop**

## Context
#115 changed `/api/storage/scan` and `/api/storage/duplicates` from `GET ?path=`
to `POST` with a `{ "Root": ... }` body, and wrapped responses in `ApiResponse<T>`.
That PR was backend-only, so `main` would have a broken frontend (the Dart client
still called `GET`). This PR lands the matching client changes plus two robustness
fixes in the new `DriveMonitorService`.

## Changes

### Frontend — `lib/services/api_service.dart`
- `scanDirectory` now `POST`s `{ "Root": path }` instead of `GET ?path=`.
- `scanForDuplicates` now `POST`s `{ "Root": path }` and treats **HTTP 499**
  (user-cancelled duplicate scan) as an empty result rather than an error.
- Response parsing is unchanged — `ApiResponse<T>` serializes to the same
  `success` / `message` / `data` keys the client already reads.

### Backend — `BackgroundWorkers/DriveMonitorService.cs`
- **DiskAlert is now edge-triggered.** Tracks alerted drives in state and fires
  once on threshold crossing instead of every 60s. A chronically-full drive
  re-reminds at most once per `AlertReArmInterval` (default 30 min).
- Emits a new `DiskAlertCleared` SignalR event when a drive drops back under the
  threshold; prunes state for unmounted drives so re-mounting re-alerts correctly.
- **`FormatSize` no longer throws on PB+ drives.** Added a
  `counter < suffixes.Length - 1` guard (the actual fix) and extended suffixes to
  `PB`/`EB`.
- Fixed inline typos on the touched lines (`critially` → `critically`,
  `// Checkinmg` → `// Checking`).

## Breaking change
The `scan` / `duplicates` endpoints require `POST` + JSON body as of #115. This PR
brings the only in-repo caller (the Flutter client) in line. Any external callers
must switch from `GET ?path=` to `POST { "Root": ... }`.

## Testing
- [ ] Browse directories and run a duplicate scan from the UI against the system drive
- [ ] Cancel an in-flight duplicate scan → UI clears results, no error toast (499 path)
- [ ] Fill a drive past 90% → exactly one `DiskAlert`; confirm it does not repeat every minute
- [ ] Free space back under 90% → `DiskAlertCleared` fires
- [ ] `dotnet test` (backend) and `flutter test` (frontend) pass

## Notes
- `DiskAlertCleared` is a new event; the HUD doesn't have to handle it yet
  (alerts simply won't auto-dismiss if ignored — same as today).
- Remaining #115 review items (test hardening, dead-code cleanup in
  `DriveDetectionService`, trailing newlines) are tracked separately and not in
  this PR.

Closes #115 review blockers.