### PR TITLE
Defence gridfeat(frontend): drive-selection flow for the Storage panel

### DIFF
--- a/backend/Controllers/NukeController.cs
+++ b/backend/Controllers/NukeController.cs
@@ -21,7 +21,7 @@ public class NukeController : ControllerBase
 
     [HttpPost("preview")]
     public async Task<IActionResult> GetNukePreview(
-        [FromBody] NukePreviewRequest request,
+        [FromBody] NukePreviewRequest request, [FromServices] IDriveDetectionService driveService,
         CancellationToken cancellationToken)
     {
         try
@@ -33,6 +33,20 @@ public class NukeController : ControllerBase
                     Success = false,
                     Message = "Preview failed: No target paths were specified."
                 });
+            }
+
+            var readyDrives = driveService.GetReadyDrives();
+            foreach (var path in request.Paths)
+            {
+                var normalizedRoot = Path.GetPathRoot(path)?.ToUpperInvariant() ?? path.ToUpperInvariant();
+                if (!readyDrives.Any(driveService => driveService.Name.ToUpperInvariant() == normalizedRoot))
+                {
+                    return BadRequest(new ApiResponse<object>
+                    {
+                        Success = false,
+                        Message = $"Drive not ready or not found: {normalizedRoot}"
+                    });
+                }
             }
 
             var previewData = await _nukeService.PreviewNukeAsync(request.Paths, cancellationToken);
@@ -65,12 +79,25 @@ public class NukeController : ControllerBase
     }
 
     [HttpDelete("execute")]
-    public async Task<IActionResult> NukeNode([FromBody] List<string> paths)
+    public async Task<IActionResult> NukeNode([FromBody] List<string> paths, [FromServices] IDriveDetectionService driveService)
     {
         try
         {
+            var readyDrives = driveService.GetReadyDrives();
+
             foreach (var path in paths)
             {
+                var normalizedRoot = Path.GetPathRoot(path)?.ToUpperInvariant() ?? path.ToUpperInvariant();
+                if (!readyDrives.Any(d => d.Name.ToUpperInvariant() == normalizedRoot))
+                {
+                    return BadRequest(new ApiResponse<object>
+                    {
+                        Success = false,
+                        Message = $"Drive not ready or not found: {normalizedRoot}"
+                    });
+                }
+
+
                 if (path.StartsWith("C:\\Windows", StringComparison.OrdinalIgnoreCase))
                     return BadRequest(new ApiResponse<object>
                         { Success = false, Message = "CRITICAL OS FILES PROTECTED." });

--- a/backend/Controllers/StorageController.cs
+++ b/backend/Controllers/StorageController.cs
@@ -22,8 +22,29 @@ namespace GSInteractiveDeviceAnalyzer.Controllers
         }
 
         [HttpPost("stream-sector")]
-        public IActionResult StreamDirectorySection([FromServices] IHubContext<SystemHub> hubContext, [FromServices] DiskScannerEngine engine, [FromQuery] string path)
+        public IActionResult StreamDirectorySection([FromServices] IHubContext<SystemHub> hubContext, [FromServices] DiskScannerEngine engine,[FromServices] IDriveDetectionService driveService, [FromQuery] string path)
         {
+            var normalizedRoot = Path.GetPathRoot(path)?.ToUpperInvariant() ?? path.ToUpperInvariant();
+
+            var readyDrives = driveService.GetReadyDrives();
+
+            if (!readyDrives.Any(d => d.Name.ToUpperInvariant() == normalizedRoot))
+            {
+                return BadRequest(new ApiResponse<object>
+                {
+                    Success = false,
+                    Message = $"Drive not ready or not found: {normalizedRoot}"
+                });
+            }
+
+            if (!Directory.Exists(path))
+            {
+                return BadRequest(new ApiResponse<object>
+                {
+                    Success = false,
+                    Message = "Invalid or missing target directory."
+                });
+            }
             var cancelToken = engine.ScanToken();
 
             _ = Task.Run(async () =>
@@ -120,10 +141,27 @@ namespace GSInteractiveDeviceAnalyzer.Controllers
         }
 
         [HttpGet("drive-stats")]
-        public IActionResult GetDriveStats([FromQuery] string driveLetter)
+        public IActionResult GetDriveStats([FromQuery] string driveLetter, [FromServices] IDriveDetectionService driveService)
         {
             try
             {
+                var normalizedRoot = driveLetter.ToUpperInvariant();
+                if (!normalizedRoot.EndsWith(":\\"))
+                {
+                    normalizedRoot = normalizedRoot.TrimEnd('\\', ':') + ":\\";
+                }
+
+                var readyDrives = driveService.GetReadyDrives();
+
+                if (!readyDrives.Any(d => d.Name.ToUpperInvariant() == normalizedRoot))
+                {
+                    return BadRequest(new ApiResponse<object>
+                    {
+                        Success = false,
+                        Message = $"Drive not reaady or not found: {normalizedRoot}"
+                    });
+                }
+
                 var stats = _diskService.GetDriveTelemetry(driveLetter);
 
                 var response = new ApiResponse<DriveTelemetryDto>
@@ -136,6 +174,7 @@ namespace GSInteractiveDeviceAnalyzer.Controllers
 
                 return Ok(response);
             }
+
             catch (Exception ex)
             {
                 return BadRequest(new ApiResponse<object>

--- a/frontend/gs_anlyzer_ui/lib/models/drive_info.dart
+++ b/frontend/gs_anlyzer_ui/lib/models/drive_info.dart
@@ -1,0 +1,47 @@
+import 'dart:core';
+
+class DriveInfo {
+  final String name;
+  final String label;
+  final String type;
+  final String format;
+  final int totalBytes;
+  final int freeBytes;
+  final int usedBytes;
+  final double percentageFree;
+  final double percentageUsed;
+
+
+  DriveInfo({
+    required this.name,
+    required this.label,
+    required this.type,
+    required this.format,
+    required this.totalBytes,
+    required this.freeBytes,
+    required this.usedBytes,
+    required this.percentageFree,
+    required this.percentageUsed,
+});
+
+  factory DriveInfo.fromJson(Map<String, dynamic> json) {
+    final int total = json['totalBytes'] ?? 0;
+    final int free = json['freeBytes'] ?? 0;
+    final int used = json['usedBytes'] ?? 0;
+
+    final double calcUsed = total == 0 ? 0.0 : (used / total) * 100;
+    final double calcFree = total == 0 ? 0.0 : (free / total) * 100;
+
+    return DriveInfo(
+      name: json['name'] ?? '',
+      label: json['label'] ?? 'Local Disk',
+      type: json['type'] ?? 'Fixed',
+      format: json['format'] ?? 'NTFS',
+      totalBytes: json['totalBytes'] ?? 0,
+      freeBytes: json['freeBytes'] ?? 0,
+      usedBytes: json['usedBytes'] ?? 0,
+      percentageFree: calcFree,
+      percentageUsed: calcUsed,
+    );
+  }
+}

--- a/frontend/gs_anlyzer_ui/lib/providers/drive_stats_provider.dart
+++ b/frontend/gs_anlyzer_ui/lib/providers/drive_stats_provider.dart
@@ -1,46 +1,48 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/legacy.dart';
-import 'package:gs_analyzer_ui/models/drive_stats.dart';
-import 'package:gs_analyzer_ui/providers/settings_provider.dart';
+import 'package:gs_analyzer_ui/models/drive_info.dart';
 import 'package:gs_analyzer_ui/services/api_service.dart';
 
-class DriveStatsState {
-  final DriveStats? stats;
-  final int diskThresholdPercent;
+final drivesProvider = NotifierProvider<DrivesNotifier, List<DriveInfo>>(() {
+  return DrivesNotifier();
+});
 
-  DriveStatsState({this.stats, this.diskThresholdPercent = 90});
-
-  bool get isCritical => stats != null && (stats!.usedBytes / stats!.totalBytes) >= (diskThresholdPercent / 100.0);
-}
-
-class DriveStatsNotifier extends StateNotifier<DriveStatsState> {
-  final Ref ref;
-  DriveStatsNotifier(this.ref) : super(DriveStatsState()) {
-    _fetchStats();
-    _listenToSettings();
+class DrivesNotifier extends Notifier<List<DriveInfo>> {
+  @override
+  List<DriveInfo> build() {
+    Future.microtask(() => refresh());
+    return [];
   }
-
-  void _listenToSettings() {
-    ref.listen(settingsProvider, (previous, next) {
-      final newThreshold = next.currentSettings?.alerts.diskThresholdPercent;
-      if (newThreshold != null && newThreshold != state.diskThresholdPercent) {
-        state = DriveStatsState(stats: state.stats, diskThresholdPercent: newThreshold);
+  Future<void> refresh() async {
+    final api = ApiService();
+    final initialData = await api.getDrives();
+    if (initialData != null) {
+      state = initialData.map((item) {
+        return DriveInfo.fromJson(Map<String, dynamic>.from(item as Map));
+      }).toList();
       }
-    }, fireImmediately: true);
-  }
-
-  Future<void> _fetchStats() async {
-    try {
-      final stats = await ApiService().getDriveTelemetry('C');
-      state = DriveStatsState(stats: stats, diskThresholdPercent: state.diskThresholdPercent);
-    } catch (e) {
-      print('Failed to fetch drive stats: $e');
     }
-  }
 
-  void refresh() => _fetchStats();
+    void updateFromTelemetry(List<dynamic> data) {
+    state = data.map((item) {
+      return DriveInfo.fromJson(Map<String, dynamic>.from(item as Map));
+    }).toList();
+  }
 }
 
-final driveStatsProvider = StateNotifierProvider<DriveStatsNotifier, DriveStatsState>((ref) {
-  return DriveStatsNotifier(ref);
+
+
+final selectedDriveNameProvider = StateProvider<String?>((ref) => null);
+
+final currentDriveProvider = Provider<DriveInfo?>((ref) {
+  final drives = ref.watch(drivesProvider);
+  if (drives.isEmpty) return null;
+
+  final selectedName = ref.watch(selectedDriveNameProvider);
+
+  if (selectedName == null) {
+    return drives.firstWhere((d) => d.type == 'fixed', orElse: () => drives.first);
+  }
+
+  return drives.firstWhere((d) => d.name == selectedName, orElse: () => drives.first);
 });

--- a/frontend/gs_anlyzer_ui/lib/providers/storage_view_provider.dart
+++ b/frontend/gs_anlyzer_ui/lib/providers/storage_view_provider.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
+
+enum StorageView { drivePicker, analyzer }
+
+final storageViewProvider =
+StateProvider<StorageView>((ref) => StorageView.drivePicker);

--- a/frontend/gs_anlyzer_ui/lib/providers/telemetry_provider.dart
+++ b/frontend/gs_anlyzer_ui/lib/providers/telemetry_provider.dart
@@ -88,8 +88,27 @@ class TelemetryNotifier extends StateNotifier<TelemetryState> {
         print('LIVE UPDATE: REFRESHING UI FOR $currentPath');
         ref.read(directoryProvider.notifier).scanDirectory(currentPath);
       }
-      ref.read(driveStatsProvider.notifier).refresh();
+      _telemetryService?.onDriveUpdate = (data) {
+        ref.read(drivesProvider.notifier).updateFromTelemetry(data);
+      };
     };
+    _telemetryService?.onSectorChanged = (changedFolder) {
+      final currentProgress = ref.read(nukeProgressProvider);
+      if (currentProgress > 0.0 && currentProgress < 100.0) {
+        return;
+      }
+      final currentPath = ref.read(directoryProvider).currentPath;
+      final normalizedCurrent = currentPath.replaceAll('\\\\', '/').toLowerCase();
+      final normalizedChanged = changedFolder.replaceAll('\\\\', '/').toLowerCase();
+
+      if(normalizedCurrent == normalizedChanged) {
+        print('LIVE UPDATE: REFRESHING UI FOR $currentPath');
+        ref.read(directoryProvider.notifier).scanDirectory(currentPath);
+      }
+
+      ref.read(drivesProvider.notifier).refresh();
+    };
+
     _telemetryService?.startListening();
   }
 

--- a/frontend/gs_anlyzer_ui/lib/screen/analyzer_dashboard.dart
+++ b/frontend/gs_anlyzer_ui/lib/screen/analyzer_dashboard.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:gs_analyzer_ui/providers/telemetry_provider.dart';
 import 'package:gs_analyzer_ui/services/api_service.dart';
 import 'package:gs_analyzer_ui/utils/hud_theme.dart';
 import 'package:gs_analyzer_ui/widgets/_directory_search_widget.dart';
@@ -9,198 +8,337 @@ import 'package:gs_analyzer_ui/widgets/go_up_row_widget.dart';
 import 'package:gs_analyzer_ui/widgets/telemetry_hud_widget.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gs_analyzer_ui/providers/directory_provider.dart';
+import '../providers/drive_stats_provider.dart';
+import '../providers/navigation_provider.dart';
 import '../utils/nuke_protocol.dart';
 import '../widgets/directory_table_header.dart';
 import '../widgets/large_file_scanner_panel.dart';
 import '../widgets/side_bar_widget.dart';
 import 'package:gs_analyzer_ui/providers/storage_mode_provider.dart';
 import 'package:gs_analyzer_ui/widgets/duplicate_scanner_pannel.dart';
+import 'package:gs_analyzer_ui/providers/storage_view_provider.dart';
 
 class AnalyzerDashboard extends ConsumerStatefulWidget {
   const AnalyzerDashboard({super.key});
-
   @override
   ConsumerState<AnalyzerDashboard> createState() => _AnalyzerDashboardState();
 }
 
 class _AnalyzerDashboardState extends ConsumerState<AnalyzerDashboard> {
-
   @override
   Widget build(BuildContext context) {
     final dirState = ref.watch(directoryProvider);
     final dirNotifier = ref.read(directoryProvider.notifier);
+    final activeDrive = ref.watch(currentDriveProvider);
     final currentMode = ref.watch(storageModeProvider);
-    ref.watch(telemetryProvider);
 
     return Scaffold(
-        backgroundColor: HudTheme.bgBase,
-        appBar: AppBar(
-            title: Row(
-              children: [
-                IconButton(
-                  icon: Icon(
-                    ref.watch(treeExpandedProvider) ? Icons.menu_open_outlined : Icons.menu_outlined,
-                    color: HudTheme.accentCyan,
-                  ),
-                  tooltip: 'Toggle Data Tree',
-                  onPressed: () {
-                    final notifier = ref.read(treeExpandedProvider.notifier);
-                    notifier.state = !notifier.state;
-                  },
-                ),
-                const SizedBox(width: 8),
-                Expanded(child: Text(dirState.currentPath,
-                  style: HudTheme.bodyText.copyWith(color: HudTheme.textMain, fontWeight: FontWeight.bold),
-                  overflow: TextOverflow.ellipsis,
-                )
-                )
-              ],
-            ),
-            backgroundColor: HudTheme.bgPanel,
-            elevation: 0,
-            actions: [
-              PopupMenuButton<StorageMode>(
-                icon: const Icon(Icons.build_circle_outlined, color: HudTheme.accentAmber,),
-                tooltip: 'Storage Tools',
-                color: HudTheme.bgPanel,
-                offset: const Offset(0, 50),
-                onSelected: (mode) {
-                  ref.read(storageModeProvider.notifier).state = mode;
-                },
-                itemBuilder: (context) => [
-                  PopupMenuItem(
-                    value: StorageMode.duplicateScanner,
-                    child: Text('DUPLICATE HUNTER', style: HudTheme.bodyText.copyWith(color: HudTheme.accentAmber, fontWeight: FontWeight.bold)),
-                  ),
-                  PopupMenuItem(
-                    value: StorageMode.largeFileScanner,
-                    child: Text('LARGE FILE SCANNER', style: HudTheme.bodyText.copyWith(color: HudTheme.accentAmber, fontWeight: FontWeight.bold)),
-                  ),
-                  PopupMenuItem(
-                    value: StorageMode.tempFileCleaner,
-                    child: Text('TEMP FILE CLEANER', style: HudTheme.bodyText.copyWith(color: HudTheme.accentAmber, fontWeight: FontWeight.bold)),
-                  ),
-                ],
-              ),
-              if (currentMode == StorageMode.diskAnalyzer) ...[
-                PopupMenuButton<dynamic>(
-                  icon: const Icon(Icons.sort_outlined),
-                  tooltip: 'Sort Option',
-                  color: HudTheme.bgPanel,
-                  onSelected: (value) {
-                    if (value is SortMethod) {
-                      ref.read(directoryProvider.notifier).setSortMethod(value);
-                    } else if (value is bool) {
-                      ref.read(directoryProvider.notifier).setAscending(value);
-                    }
-                  },
-                  itemBuilder: (context) =>
-                  [
-                    CheckedPopupMenuItem(
-                      value: SortMethod.name,
-                      checked: dirState.sortMethod == SortMethod.name,
-                      child: Text('Name', style: HudTheme.bodyText,),
-                    ),
-                    CheckedPopupMenuItem(
-                      value: SortMethod.size,
-                      checked: dirState.sortMethod == SortMethod.size,
-                      child: Text('Total Size', style: HudTheme.bodyText,),
-                    ),
-                    CheckedPopupMenuItem(
-                      value: SortMethod.date,
-                      checked: dirState.sortMethod == SortMethod.date,
-                      child: Text('DateModified', style: HudTheme.bodyText,),
-                    ),
-                    const PopupMenuDivider(),
-                    CheckedPopupMenuItem(
-                      value: true,
-                      checked: dirState.isAscending == true,
-                      child: Text('Ascending', style: HudTheme.bodyText,),
-                    ),
-                    CheckedPopupMenuItem(
-                      value: false,
-                      checked: dirState.isAscending == false,
-                      child: Text('Descending', style: HudTheme.bodyText,),
-                    ),
-                  ],
-                ),
-                TextButton(
-                  onPressed: () {
-                    ref.read(directoryProvider.notifier).toggleSelectionMode();
-                  },
-                  child: Text(
-                    dirState.isSelectionMode ? 'CANCEL SELECTION' : 'SELECT MULTIPLE',
-                    style: HudTheme.bodyText.copyWith(color: HudTheme.accentCyan, fontWeight: FontWeight.bold)
-                  ),
-                ),
-                if (dirState.isSelectionMode && dirState.selectedPath.isNotEmpty)
-                  IconButton(
-                    icon: const Icon(Icons.delete_forever_outlined, color: HudTheme.accentRed),
-                    tooltip:'Nuke Selected (${dirState.selectedPath.length})',
-                    onPressed: () => executeNukeProtocol(context, ref)
-                  ),
-                IconButton(
-                  icon: const Icon(Icons.refresh_outlined, color: HudTheme.accentCyan),
-                  tooltip: 'Refresh',
-                  onPressed: () => dirNotifier.scanDirectory(dirState.currentPath)
-                ),
-              ],
-            ],
-            bottom: currentMode == StorageMode.diskAnalyzer ? const PreferredSize(
-              preferredSize: const Size.fromHeight(60),
-              child: Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: const DirectorySearchWidget(),
-              )
-            ) : null,
-        ),
-        body: Row(
+      backgroundColor: HudTheme.bgBase,
+      appBar: AppBar(
+        title: Row(
           children: [
-            // LEFT PANEL: Persistent Tree
-            if (currentMode == StorageMode.diskAnalyzer) SideBarTreeWidget(
-              onNuke: (name, path) => executeNukeProtocol(context, ref, fileName: name, filePath: path),
+            IconButton(
+              icon: const Icon(Icons.arrow_back, color: HudTheme.accentCyan),
+              tooltip: 'Back to Drives',
+              onPressed: () =>
+              ref.read(storageViewProvider.notifier).state = StorageView.drivePicker,
             ),
-            // RIGHT PANEL: Directory Table
+            IconButton(
+              icon: Icon(
+                ref.watch(treeExpandedProvider) ? Icons.menu_open_outlined : Icons.menu_outlined,
+                color: HudTheme.accentCyan,
+              ),
+              tooltip: 'Toggle Data Tree',
+              onPressed: () {
+                final notifier = ref.read(treeExpandedProvider.notifier);
+                notifier.state = !notifier.state;
+              },
+            ),
+            const SizedBox(width: 8),
             Expanded(
-              child: Column(
-                children: [
-                  Expanded(
-                    child: currentMode == StorageMode.duplicateScanner ? const DuplicateScannerPanel() : currentMode == StorageMode.largeFileScanner ? const LargeFileScannerPanel() : currentMode == StorageMode.tempFileCleaner ? const Center(child: Text('TEMP FILE CLEANER OFFLINE', style: HudTheme.actionRed,)) : dirState.isLoading
-                        ? const TelemetryHudWidget()
-                        : dirState.errorMessage != null
-                        ? Center(child: Text('BRIDGE FAILURE: ${dirState.errorMessage}', style: HudTheme.actionRed))
-                        : Column(
-                      children: [
-                        DirectoryTableHeader(),
-                        if (dirState.currentPath != 'C:/' && dirState.searchQuery.isEmpty)
-                          GoUpRowWidget(),
-                        Expanded(
-                          child: dirState.displayNodes.isEmpty && dirState.searchQuery.isNotEmpty
-                              ? const Center(
-                            child: Text('NO DATA FOUND IN SECTOR', style: HudTheme.labelMuted),
-                          )
-                              : ListView.builder(
-                            itemCount: dirState.displayNodes.length,
-                            itemBuilder: (context, index) {
-                              return DirectoryNodeWidget(
-                                node: dirState.displayNodes[index],
-                                apiService: ApiService(),
-                                onNuke: (name, path) => executeNukeProtocol(context, ref, fileName: name, filePath: path),
-                                onNavigate: dirNotifier.scanDirectory,
-                                depth: 0,
-                              );
-                            },
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  const DriveTelemetryWidget(),
-                ],
+              child: Text(
+                dirState.currentPath,
+                style: HudTheme.bodyText.copyWith(
+                  color: HudTheme.textMain,
+                  fontWeight: FontWeight.bold,
+                ),
+                overflow: TextOverflow.ellipsis,
               ),
             ),
           ],
-        )
+        ),
+        backgroundColor: HudTheme.bgPanel,
+        elevation: 0,
+        actions: [
+          PopupMenuButton<StorageMode>(
+            icon: const Icon(
+              Icons.build_circle_outlined,
+              color: HudTheme.accentAmber,
+            ),
+            tooltip: 'Storage Tools',
+            color: HudTheme.bgPanel,
+            offset: const Offset(0, 50),
+            onSelected: (mode) {
+              ref.read(storageModeProvider.notifier).state = mode;
+            },
+            itemBuilder: (context) => [
+              PopupMenuItem(
+                value: StorageMode.duplicateScanner,
+                child: Text(
+                  'DUPLICATE HUNTER',
+                  style: HudTheme.bodyText.copyWith(
+                    color: HudTheme.accentAmber,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+              PopupMenuItem(
+                value: StorageMode.largeFileScanner,
+                child: Text(
+                  'LARGE FILE SCANNER',
+                  style: HudTheme.bodyText.copyWith(
+                    color: HudTheme.accentAmber,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+              PopupMenuItem(
+                value: StorageMode.tempFileCleaner,
+                child: Text(
+                  'TEMP FILE CLEANER',
+                  style: HudTheme.bodyText.copyWith(
+                    color: HudTheme.accentAmber,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          if (currentMode == StorageMode.diskAnalyzer) ...[
+            PopupMenuButton<dynamic>(
+              icon: const Icon(Icons.sort_outlined),
+              tooltip: 'Sort Option',
+              color: HudTheme.bgPanel,
+              onSelected: (value) {
+                if (value is SortMethod) {
+                  ref.read(directoryProvider.notifier).setSortMethod(value);
+                } else if (value is bool) {
+                  ref.read(directoryProvider.notifier).setAscending(value);
+                }
+              },
+              itemBuilder: (context) => [
+                CheckedPopupMenuItem(
+                  value: SortMethod.name,
+                  checked: dirState.sortMethod == SortMethod.name,
+                  child: Text('Name', style: HudTheme.bodyText),
+                ),
+                CheckedPopupMenuItem(
+                  value: SortMethod.size,
+                  checked: dirState.sortMethod == SortMethod.size,
+                  child: Text('Total Size', style: HudTheme.bodyText),
+                ),
+                CheckedPopupMenuItem(
+                  value: SortMethod.date,
+                  checked: dirState.sortMethod == SortMethod.date,
+                  child: Text('DateModified', style: HudTheme.bodyText),
+                ),
+                const PopupMenuDivider(),
+                CheckedPopupMenuItem(
+                  value: true,
+                  checked: dirState.isAscending == true,
+                  child: Text('Ascending', style: HudTheme.bodyText),
+                ),
+                CheckedPopupMenuItem(
+                  value: false,
+                  checked: dirState.isAscending == false,
+                  child: Text('Descending', style: HudTheme.bodyText),
+                ),
+              ],
+            ),
+            TextButton(
+              onPressed: () {
+                ref.read(directoryProvider.notifier).toggleSelectionMode();
+              },
+              child: Text(
+                dirState.isSelectionMode ? 'CANCEL SELECTION' : 'SELECT MULTIPLE',
+                style: HudTheme.bodyText.copyWith(
+                  color: HudTheme.accentCyan,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+            if (dirState.isSelectionMode && dirState.selectedPath.isNotEmpty)
+              IconButton(
+                icon: const Icon(
+                  Icons.delete_forever_outlined,
+                  color: HudTheme.accentRed,
+                ),
+                tooltip: 'Nuke Selected (${dirState.selectedPath.length})',
+                onPressed: () => executeNukeProtocol(context, ref),
+              ),
+            IconButton(
+              icon: const Icon(
+                Icons.refresh_outlined,
+                color: HudTheme.accentCyan,
+              ),
+              tooltip: 'Refresh',
+              onPressed: () => dirNotifier.scanDirectory(dirState.currentPath),
+            ),
+          ],
+        ],
+        bottom: currentMode == StorageMode.diskAnalyzer
+            ? const PreferredSize(
+                preferredSize: Size.fromHeight(60),
+                child: Padding(
+                  padding: EdgeInsets.all(8.0),
+                  child: DirectorySearchWidget(),
+                ),
+              )
+            : null,
+      ),
+      body: activeDrive == null
+          ? _buildAwaitingSelectionUI(ref)
+          : Row(
+              children: [
+                // LEFT PANEL: Persistent Tree
+                if (currentMode == StorageMode.diskAnalyzer)
+                  SideBarTreeWidget(
+                    onNuke: (name, path) => executeNukeProtocol(
+                      context,
+                      ref,
+                      fileName: name,
+                      filePath: path,
+                    ),
+                  ),
+                // RIGHT PANEL: Directory Table
+                Expanded(
+                  child: Column(
+                    children: [
+                      Expanded(
+                        child: _buildMainContent(
+                          context,
+                          currentMode,
+                          dirState,
+                          dirNotifier,
+                        ),
+                      ),
+                      const DriveTelemetryWidget(),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+    );
+  }
+
+  /// Picks the central panel based on the active [StorageMode] and the
+  /// directory state. Extracted out of the widget tree so the nested
+  /// conditionals stay readable.
+  Widget _buildMainContent(
+    BuildContext context,
+    StorageMode currentMode,
+    dynamic dirState,
+    dynamic dirNotifier,
+  ) {
+    if (currentMode == StorageMode.duplicateScanner) {
+      return const DuplicateScannerPanel();
+    }
+    if (currentMode == StorageMode.largeFileScanner) {
+      return const LargeFileScannerPanel();
+    }
+    if (currentMode == StorageMode.tempFileCleaner) {
+      return const Center(
+        child: Text('TEMP FILE CLEANER OFFLINE', style: HudTheme.actionRed),
+      );
+    }
+    // Default: disk analyzer table.
+    if (dirState.isLoading) {
+      return const TelemetryHudWidget();
+    }
+    if (dirState.errorMessage != null) {
+      return Center(
+        child: Text(
+          'BRIDGE FAILURE: ${dirState.errorMessage}',
+          style: HudTheme.actionRed,
+        ),
+      );
+    }
+    return Column(
+      children: [
+        DirectoryTableHeader(),
+        if (dirState.currentPath != 'C:/' && dirState.searchQuery.isEmpty) GoUpRowWidget(),
+        Expanded(
+          child: dirState.displayNodes.isEmpty && dirState.searchQuery.isNotEmpty
+              ? const Center(
+                  child: Text('NO DATA FOUND IN SECTOR', style: HudTheme.labelMuted),
+                )
+              : ListView.builder(
+                  itemCount: dirState.displayNodes.length,
+                  itemBuilder: (context, index) {
+                    return DirectoryNodeWidget(
+                      node: dirState.displayNodes[index],
+                      apiService: ApiService(),
+                      onNuke: (name, path) => executeNukeProtocol(
+                        context,
+                        ref,
+                        fileName: name,
+                        filePath: path,
+                      ),
+                      onNavigate: dirNotifier.scanDirectory,
+                      depth: 0,
+                    );
+                  },
+                ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildAwaitingSelectionUI(WidgetRef ref) {
+    return Center(
+      child: Container(
+        padding: const EdgeInsets.all(40),
+        decoration: HudTheme.hudPanelDecoration,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.storage, size: 64, color: Colors.white24),
+            const SizedBox(height: 24),
+            Text(
+              'SYSTEM STANDBY',
+              style: HudTheme.headerCyan.copyWith(
+                color: HudTheme.accentCyan,
+                fontSize: 24,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Awaiting target matrix assignment for Directory Indexing.',
+              style: HudTheme.bodyText.copyWith(color: HudTheme.textDim),
+            ),
+            const SizedBox(height: 32),
+            OutlinedButton.icon(
+              icon: const Icon(Icons.touch_app, color: HudTheme.accentCyan),
+              label: const Text(
+                'ASSIGN TARGET DRIVE',
+                style: TextStyle(letterSpacing: 2),
+              ),
+              style: OutlinedButton.styleFrom(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 24,
+                  vertical: 16,
+                ),
+                side: BorderSide(color: HudTheme.accentCyan),
+                foregroundColor: HudTheme.accentCyan,
+              ),
+              onPressed: () {
+                // Flips the sidebar to the Storage Screen (Index 1)
+                ref.read(navigationProvider.notifier).state = AppRoute.storage;
+              },
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/frontend/gs_anlyzer_ui/lib/screen/master_layout.dart
+++ b/frontend/gs_anlyzer_ui/lib/screen/master_layout.dart
@@ -7,6 +7,8 @@ import 'package:gs_analyzer_ui/screen/settings_screen.dart';
 import 'package:gs_analyzer_ui/screen/thermal_module_screen.dart';
 import 'package:gs_analyzer_ui/utils/hud_theme.dart';
 import 'package:gs_analyzer_ui/widgets/global_sidebar_widget.dart';
+import 'package:gs_analyzer_ui/screen/storage_screen.dart';
+import 'package:gs_analyzer_ui/providers/storage_view_provider.dart';
 
 import 'cpu_metrics_screen.dart';
 
@@ -16,6 +18,12 @@ class MasterLayout extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final currentRoute = ref.watch(navigationProvider);
+
+    ref.listen<AppRoute>(navigationProvider, (prev, next) {
+      if (next == AppRoute.storage && prev != AppRoute.storage) {
+        ref.read(storageViewProvider.notifier).state = StorageView.drivePicker;
+      }
+    });
 
     return Scaffold(
       backgroundColor: HudTheme.bgBase,
@@ -32,7 +40,7 @@ class MasterLayout extends ConsumerWidget {
   Widget _buildActiveScreen(AppRoute route) {
     switch (route) {
       case AppRoute.storage:
-        return const AnalyzerDashboard();
+        return const StorageRouter();
 
       case AppRoute.memory:
         return const RamScannerScreen();
@@ -52,5 +60,17 @@ class MasterLayout extends ConsumerWidget {
       case AppRoute.dashboard:
         return const Center(child: Text('MAIN DASHBOARD OFFLINE', style: HudTheme.headerCyan));
     }
+  }
+}
+
+class StorageRouter extends ConsumerWidget {
+  const StorageRouter({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final view = ref.watch(storageViewProvider);
+    return view == StorageView.analyzer
+        ? const AnalyzerDashboard()
+        : const StorageScreen();
   }
 }

--- a/frontend/gs_anlyzer_ui/lib/screen/storage_screen.dart
+++ b/frontend/gs_anlyzer_ui/lib/screen/storage_screen.dart
@@ -1,0 +1,319 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/drive_info.dart';
+import '../providers/drive_stats_provider.dart';
+import '../providers/settings_provider.dart';
+import '../utils/hud_theme.dart';
+import '../utils/hud_label.dart';
+import 'package:gs_analyzer_ui/providers/directory_provider.dart';
+import 'package:gs_analyzer_ui/providers/storage_view_provider.dart';
+import 'package:gs_analyzer_ui/providers/storage_mode_provider.dart';
+
+class StorageScreen extends ConsumerWidget {
+  const StorageScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final currentDrive = ref.watch(currentDriveProvider);
+
+    final drives = ref.watch(drivesProvider);
+
+    Widget buildBody() {
+      if (drives.isEmpty) {
+        return Center(child: CircularProgressIndicator(color: HudTheme.accentCyan));
+      }
+
+      if (currentDrive == null) {
+        return const SizedBox.shrink();
+      }
+
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _DriveSelectorBar(drives: drives, selectedDrive: currentDrive),
+          const Divider(color: Colors.white10, height: 1),
+
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: _DriveDetailCard(drive: currentDrive),
+          ),
+
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              child: ListView(
+                children: [
+                  _ScanLaunchTile(
+                    title: 'DIRECTORY SCANNER',
+                    subtitle: 'Index every sector on ${currentDrive.name}',
+                    icon: Icons.account_tree_outlined,
+                    onLaunch: () => _enterAnalyzer(ref, currentDrive, StorageMode.diskAnalyzer),
+                  ),
+                  _ScanLaunchTile(
+                    title: 'DUPLICATE HUNTER',
+                    subtitle: 'Scan for duplicate files on ${currentDrive.name}',
+                    icon: Icons.copy_all_outlined,
+                    onLaunch: () => _enterAnalyzer(ref, currentDrive, StorageMode.duplicateScanner),
+                  ),
+                ],
+              ),
+            ),
+          )
+        ],
+      );
+    }
+
+    return Scaffold(
+      backgroundColor: HudTheme.bgPanel,
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        title: Text('STORAGE MATRICES', style: HudTheme.headerCyan),
+      ),
+      body: buildBody(),
+    );
+  }
+
+  void _enterAnalyzer(WidgetRef ref, DriveInfo drive, StorageMode mode) {
+
+    ref.read(selectedDriveNameProvider.notifier).state = drive.name;
+
+    ref.read(storageModeProvider.notifier).state = mode;
+
+    if (mode == StorageMode.diskAnalyzer) {
+      ref.read(directoryProvider.notifier).scanDirectory(drive.name);
+    }
+
+    ref.read(storageViewProvider.notifier).state = StorageView.analyzer;
+  }
+}
+
+class _ScanLaunchTile extends StatelessWidget {
+  final String title;
+  final String subtitle;
+  final IconData icon;
+  final VoidCallback onLaunch;
+
+  const _ScanLaunchTile({
+    required this.title,
+    required this.subtitle,
+    required this.icon,
+    required this.onLaunch,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: onLaunch,
+          borderRadius: BorderRadius.circular(8),
+          child: Container(
+            padding: const EdgeInsets.all(16),
+            decoration: HudTheme.hudPanelDecoration,
+            child: Row(
+              children: [
+                Icon(icon, color: HudTheme.accentCyan),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(title,
+                          style: HudTheme.headerCyan
+                              .copyWith(color: HudTheme.accentCyan)),
+                      const SizedBox(height: 4),
+                      Text(subtitle,
+                          style: HudTheme.bodyText
+                              .copyWith(color: HudTheme.textDim)),
+                    ],
+                  ),
+                ),
+                const Icon(Icons.chevron_right, color: HudTheme.textDim),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DriveSelectorBar extends ConsumerWidget {
+  final List<DriveInfo> drives;
+  final DriveInfo selectedDrive;
+
+  const _DriveSelectorBar({required this.drives, required this.selectedDrive});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: drives.map((drive) {
+          final isSelected = drive.name == selectedDrive.name;
+          return GestureDetector(
+            onTap: () => ref.read(selectedDriveNameProvider.notifier).state = drive.name,
+            child: _DriveTab(drive: drive, isActive: isSelected),
+          );
+        }).toList(),
+      ),
+    );
+  }
+}
+
+class _DriveTab extends ConsumerWidget {
+  final DriveInfo drive;
+  final bool isActive;
+
+  const _DriveTab({required this.drive, required this.isActive});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    IconData getIcon() {
+      if (drive.type.toLowerCase() == 'removable') return Icons.usb;
+      if (drive.type.toLowerCase() == 'network') return Icons.cloud;
+      return Icons.storage;
+    }
+
+    // Connect threshold to user settings!
+    final alertSettings = ref.watch(settingsProvider).currentSettings?.alerts;
+    final redThreshold = alertSettings?.diskThresholdPercent ?? 90;
+
+    Color getStatusColor() {
+      if (drive.percentageUsed >= redThreshold) return Colors.redAccent;
+      if (drive.percentageUsed >= redThreshold - 10) return Colors.amber;
+      return HudTheme.accentCyan; // Green or Cyan for healthy
+    }
+
+    return Container(
+      width: 160,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: isActive ? Colors.white.withOpacity(0.05) : Colors.transparent,
+        border: Border(
+          bottom: BorderSide(
+            color: isActive ? HudTheme.accentCyan : Colors.transparent,
+            width: 3,
+          ),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(getIcon(), color: isActive ? HudTheme.accentCyan : HudTheme.textDim, size: 16),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  '${drive.label} (${drive.name})',
+                  style: HudTheme.bodyText.copyWith(
+                    color: isActive ? HudTheme.accentCyan : HudTheme.textDim,
+                    fontWeight: isActive ? FontWeight.bold : FontWeight.normal,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          LinearProgressIndicator(
+            value: drive.percentageUsed / 100,
+            backgroundColor: Colors.white10,
+            color: getStatusColor(),
+            minHeight: 2,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DriveDetailCard extends ConsumerWidget {
+  final DriveInfo drive;
+
+  const _DriveDetailCard({required this.drive});
+
+  String _formatGB(int bytes) => (bytes / (1024 * 1024 * 1024)).toStringAsFixed(1);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final alertSettings = ref.watch(settingsProvider).currentSettings?.alerts;
+    final redThreshold = alertSettings?.diskThresholdPercent ?? 90;
+
+    final Color statusColor = drive.percentageUsed >= redThreshold
+        ? Colors.redAccent
+        : (drive.percentageUsed >= redThreshold - 10 ? Colors.amber : HudTheme.accentCyan);
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: HudTheme.hudPanelDecoration,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text('DRIVE: ${drive.label} (${drive.name})',
+                  style: HudTheme.headerCyan.copyWith(color: HudTheme.accentCyan)),
+              if (drive.percentageUsed >= redThreshold)
+                Text('● CRITICAL SPACE', style: HudTheme.bodyText.copyWith(color: Colors.redAccent, fontWeight: FontWeight.bold)),
+            ],
+          ),
+          const Divider(color: Colors.white10, height: 24, thickness: 1),
+
+          Row(
+            children: [
+              _buildMetaTag('TYPE', drive.type.toUpperCase()),
+              const SizedBox(width: 24),
+              _buildMetaTag('FORMAT', drive.format.toUpperCase()),
+              const SizedBox(width: 24),
+              _buildMetaTag('MOUNT', drive.name.toUpperCase()),
+            ],
+          ),
+          const SizedBox(height: 16),
+
+          Row(
+            children: [
+              Expanded(
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(4),
+                  child: LinearProgressIndicator(
+                    value: drive.percentageUsed / 100,
+                    backgroundColor: Colors.white10,
+                    color: statusColor,
+                    minHeight: 16,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 16),
+              Text('${drive.percentageUsed.toStringAsFixed(1)}%', style: HudTheme.bodyText),
+            ],
+          ),
+          const SizedBox(height: 12),
+
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text('USED: ${_formatGB(drive.usedBytes)} GB', style: HudTheme.bodyText.copyWith(color: statusColor)),
+              Text('FREE: ${_formatGB(drive.freeBytes)} GB', style: HudTheme.bodyText),
+              Text('TOTAL: ${_formatGB(drive.totalBytes)} GB', style: HudTheme.bodyText.copyWith(color: HudTheme.textDim)),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMetaTag(String label, String value) {
+    return Row(
+      children: [
+        Text('$label: ', style: HudTheme.bodyText.copyWith(color: HudTheme.textDim)),
+        Text(value, style: HudTheme.bodyText.copyWith(fontWeight: FontWeight.bold)),
+      ],
+    );
+  }
+}

--- a/frontend/gs_anlyzer_ui/lib/services/api_service.dart
+++ b/frontend/gs_anlyzer_ui/lib/services/api_service.dart
@@ -10,6 +10,7 @@ class ApiService {
   static const String nukeUrl = 'http://localhost:5200/api/nuke';
   static const String thermalUrl = 'http://localhost:5200/api/thermal';
   static const String settingsUrl = 'http://localhost:5200/api/settings';
+  static const String driveUrl = 'http://localhost:5200/api/drives';
 
   Future<List<StorageNode>> scanDirectory(String path) async {
     final uri = Uri.parse('$storageUrl/scan');
@@ -259,6 +260,22 @@ class ApiService {
       if (response.statusCode == 200) return jsonDecode(response.body)['data'];
     } catch (e) {
       print('[API] Reset Error: $e');
+    }
+    return null;
+  }
+
+  Future<List<dynamic>?> getDrives() async {
+    try {
+      final response = await http.get(Uri.parse(driveUrl));
+
+      if (response.statusCode == 200) {
+        final decoded = jsonDecode(response.body);
+
+        if (decoded is List) return decoded;
+        if (decoded['data'] != null) return decoded['data'];
+      }
+    } catch (e) {
+      print("[Api] Drives Fetch Error: $e");
     }
     return null;
   }

--- a/frontend/gs_anlyzer_ui/lib/services/telemetry_service.dart
+++ b/frontend/gs_anlyzer_ui/lib/services/telemetry_service.dart
@@ -10,6 +10,7 @@ import 'package:signalr_netcore/signalr_client.dart';
     Function(String path, List<dynamic> chunk)? onDirectoryChunk;
     Function(String path)? onDirectoryStreamComplete;
     Function(Map<String, dynamic>)? onCpuUpdate;
+    Function(List<dynamic>)? onDriveUpdate;
 
     TelemetryService({required this.onProgressUpdate}) {
       _initRadio();
@@ -28,10 +29,15 @@ import 'package:signalr_netcore/signalr_client.dart';
       _hubConnection.on('NukeProgress', _handleNukeProgress);
       _hubConnection.on('NukeAborted', _handleNukeAborted);
       _hubConnection.on('RamTelemetryUpdate', _handleRamUpdate);
-      _hubConnection.on('DirectoryChunk', _hadleDirectoryChunk);
+      _hubConnection.on('DirectoryChunk', _handleDirectoryChunk);
       _hubConnection.on(
           'DirectoryStreamComplete', _handleDirectoryStreamComplete);
       _hubConnection.on('ReceiveCpuTelemetry', _handleCpuUpdate);
+      _hubConnection.on('DriveListUpdate', _handleDriveUpdate);
+
+      _hubConnection.start()?.catchError((err) {
+        print('TELEMETRY RADIO ERROR: $err');
+      });
     }
 
     Future<void> startListening() async {
@@ -124,7 +130,7 @@ import 'package:signalr_netcore/signalr_client.dart';
       }
     }
 
-    void _hadleDirectoryChunk(List<Object?>? arguments) {
+    void _handleDirectoryChunk(List<Object?>? arguments) {
       if (arguments != null && arguments.isNotEmpty) {
         final data = arguments[0] as Map<String, dynamic>;
         if (onDirectoryChunk != null) {
@@ -156,5 +162,22 @@ import 'package:signalr_netcore/signalr_client.dart';
       } catch (e) {
         print('CPU TELEMETRY CRASH: $e');
       }
+    }
+
+    void _handleDriveUpdate(List<Object?>? arguments) {
+        if (arguments != null && arguments.isNotEmpty) return;
+        try {
+          final rawData = arguments?[0];
+
+          if (rawData is List) {
+            if (onDriveUpdate != null) {
+              onDriveUpdate!(rawData);
+            }
+          } else {
+            print('UNKNOWN DRIVE PAYLOAD TYPE: ${rawData.runtimeType}');
+          }
+        } catch (e) {
+          print('DRIVE TELEMETRY CRASH: $e');
+        }
     }
   }

--- a/frontend/gs_anlyzer_ui/lib/utils/nuke_protocol.dart
+++ b/frontend/gs_anlyzer_ui/lib/utils/nuke_protocol.dart
@@ -63,7 +63,7 @@ Future<void> executeNukeProtocol(BuildContext context, WidgetRef ref, {String? f
     }
 
     ref.invalidate(rootTreeProvider);
-    ref.read(driveStatsProvider.notifier).refresh();
+    ref.read(drivesProvider.notifier).refresh();
 
     snackbarKey.currentState?.showSnackBar(SnackBar(
       behavior: SnackBarBehavior.floating,

--- a/frontend/gs_anlyzer_ui/lib/widgets/drive_telemetry_widget.dart
+++ b/frontend/gs_anlyzer_ui/lib/widgets/drive_telemetry_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gs_analyzer_ui/providers/drive_stats_provider.dart';
+import 'package:gs_analyzer_ui/providers/settings_provider.dart';
 import 'package:gs_analyzer_ui/utils/hud_label.dart';
 import 'dart:math';
 
@@ -21,8 +22,10 @@ class DriveTelemetryWidget extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final driveState = ref.watch(driveStatsProvider);
-    final stats = driveState.stats;
+    final stats = ref.watch(currentDriveProvider);
+
+    final alertSettings = ref.watch(settingsProvider).currentSettings?.alerts;
+    final redThreshold = alertSettings?.diskThresholdPercent ?? 90;
 
     if (stats == null) {
       return const SizedBox(
@@ -31,8 +34,8 @@ class DriveTelemetryWidget extends ConsumerWidget {
       );
     }
 
-    final double usageFraction = stats.usedBytes / stats.totalBytes;
-    final isCritical = driveState.isCritical;
+    final double usageFraction = stats.percentageUsed / 100.0;
+    final bool isCritical = stats.percentageFree >= redThreshold;
 
     return Container(
       padding: const EdgeInsets.all(20),
@@ -46,10 +49,10 @@ class DriveTelemetryWidget extends ConsumerWidget {
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              HudLabel('CAPACITY (C:)'),
+              HudLabel('CAPACITY (${stats.name})'),
               if (isCritical)
                 const Text('LOW SPACE ALERT', style: HudTheme.actionRed),
-              Text('${stats.percentageFree}% FREE', style: isCritical ? HudTheme.actionRed : HudTheme.statGreen,
+              Text('${stats.percentageFree.toStringAsFixed(1)}% FREE', style: isCritical ? HudTheme.actionRed : HudTheme.statGreen,
               ),
             ],
           ),


### PR DESCRIPTION
## Summary
Wires the new `StorageScreen` (drive picker) to the `AnalyzerDashboard`
(directory views) so the Storage panel follows a clear two-step flow:
**pick a drive → view its contents.**

Previously `AppRoute.storage` mapped straight to `AnalyzerDashboard`, so the
`StorageScreen` was never rendered and the dashboard's "Assign Target Drive"
button looped back to itself.

## Changes
- **New** `providers/storage_view_provider.dart` — `StorageView { drivePicker, analyzer }`
  sub-view flag (the existing `currentDriveProvider` auto-defaults to the first
  fixed drive, so it can't signal "no drive chosen yet").
- `screen/master_layout.dart` — `AppRoute.storage` now renders a `StorageRouter`
  that swaps between picker and dashboard; resets to the picker when the panel
  is (re)entered from another route. `AppRoute.dashboard` left untouched.
- `screen/storage_screen.dart` — drive tabs now *preview* (detail card); the
  DIRECTORY SCANNER / DUPLICATE HUNTER modules lock in the drive, set the
  storage mode, start the scan, and switch to the dashboard.
- `screen/analyzer_dashboard.dart` — added a "Back to Drives" button; fixed the
  duplicate `body:` / missing `currentMode` build errors; extracted the central
  panel into `_buildMainContent`.

## Flow
Sidebar → Storage → pick drive (preview) → DIRECTORY SCANNER → directory views → Back to Drives

## Test 
- [x] `dart analyze` clean
- [x] Storage panel opens on the drive picker
- [x] Selecting a different tab updates the detail card without navigating
- [x] DIRECTORY SCANNER scans the selected drive root and opens the table
- [x] DUPLICATE HUNTER opens the dashboard in duplicate mode
- [x] "Back to Drives" returns to the picker
- [x] Re-entering Storage from another panel shows the picker