### PR TITLE
feat: Deep File Type Analyzer — per-drive extension breakdown with instant memory-backed results

### DIFF
--- a/backend/Controllers/StorageController.cs
+++ b/backend/Controllers/StorageController.cs
@@ -323,5 +323,36 @@ namespace GSInteractiveDeviceAnalyzer.Controllers
                 });
             }
         }
+
+        [HttpGet("scan/filetypes")]
+        public IActionResult GetFileTypes(
+            [FromQuery] string root,
+            [FromServices] IFileTypeScanner scanner)
+        {
+            if (string.IsNullOrWhiteSpace(root))
+                return BadRequest(new
+                {
+                    error = "ROOT_REQUIRED",
+                    message = "root query parameter is required."
+                });
+
+            if (!Directory.Exists(root))
+                return BadRequest(new
+                {
+                    error = "DRIVE_NOT_FOUND",
+                    message = $"Root path '{root}' does not exist or is not accessible."
+                });
+
+            var result = scanner.Analyze(root);
+
+            if (result is null)
+                return Conflict(new
+                {
+                    error = "NO_SCAN_CACHED",
+                    message = "No scan result found for this root. Run a Directory scan first."
+                });
+
+            return Ok(result);
+        }
     }
 }

--- a/backend/Engine/DiskScannerEngine.cs
+++ b/backend/Engine/DiskScannerEngine.cs
@@ -16,6 +16,8 @@ public class CacheEntry
 public class DiskScannerEngine
 {
     public ConcurrentDictionary<string, CacheEntry> DirectorySizeCache = new(StringComparer.OrdinalIgnoreCase);
+    public ConcurrentDictionary<string, ConcurrentDictionary<string, (int Count, long Bytes)>>
+        FileTypeAccumulator = new(StringComparer.OrdinalIgnoreCase);
     private CancellationTokenSource? _nukeCts;
     private CancellationTokenSource? _scanCts;
     private readonly SemaphoreSlim _scanLock = new SemaphoreSlim(1, 1);
@@ -97,6 +99,12 @@ public class DiskScannerEngine
 
                 await _hub.Clients.All.SendAsync("ScanProgress", new { status = "INITIALIZING", count = 0, currentTarget = "Walking up the Engine...." });
 
+                foreach (var dir in directoriesToScan)
+                {
+                    var root = dir.FullName.Split(Path.DirectorySeparatorChar)[0] + Path.DirectorySeparatorChar;
+                    FileTypeAccumulator.TryRemove(root, out _);
+                }
+
                 await Parallel.ForEachAsync(directoriesToScan, async (dir, token) =>
                 {
                     if (token.IsCancellationRequested) return;
@@ -162,6 +170,23 @@ public class DiskScannerEngine
                 AttributesToSkip = 0
             };
             var files = dir.GetFiles("*", option);
+
+            var root = dir.FullName.Split(Path.DirectorySeparatorChar)[0] + Path.DirectorySeparatorChar;
+
+            var extMap = FileTypeAccumulator.GetOrAdd(
+                root,
+                _ => new ConcurrentDictionary<string, (int Count, long Bytes)>(
+                    StringComparer.OrdinalIgnoreCase));
+
+            foreach (var f in files)
+            {
+                var ext = f.Extension.ToLowerInvariant();
+                if (string.IsNullOrEmpty(ext)) ext = "no extension";
+                extMap.AddOrUpdate(
+                    ext,
+                    _ => (1, f.Length),
+                    (_, prev) => (prev.Count + 1, prev.Bytes + f.Length));
+            }
             size += files.Sum(f => f.Length);
 
             var pulse = Interlocked.Increment(ref _deepScanThrottle);

--- a/backend/Engine/DiskScannerEngine.cs
+++ b/backend/Engine/DiskScannerEngine.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Text.Json;
 using GSInteractiveDeviceAnalyzer.Hubs;
 using GSInteractiveDeviceAnalyzer.Interfaces;
+using GSInteractiveDeviceAnalyzer.Models;
 using Microsoft.AspNetCore.SignalR;
 
 namespace GSInteractiveDeviceAnalyzer.Engine;
@@ -10,14 +11,13 @@ public class CacheEntry
 {
     public long Size { get; set; }
     public DateTime LastUpdated { get; set; }
+    public Dictionary<string, FileTypeEntry>? Extensions { get; set; }
 }    
 
 
 public class DiskScannerEngine
 {
     public ConcurrentDictionary<string, CacheEntry> DirectorySizeCache = new(StringComparer.OrdinalIgnoreCase);
-    public ConcurrentDictionary<string, ConcurrentDictionary<string, (int Count, long Bytes)>>
-        FileTypeAccumulator = new(StringComparer.OrdinalIgnoreCase);
     private CancellationTokenSource? _nukeCts;
     private CancellationTokenSource? _scanCts;
     private readonly SemaphoreSlim _scanLock = new SemaphoreSlim(1, 1);
@@ -99,12 +99,6 @@ public class DiskScannerEngine
 
                 await _hub.Clients.All.SendAsync("ScanProgress", new { status = "INITIALIZING", count = 0, currentTarget = "Walking up the Engine...." });
 
-                foreach (var dir in directoriesToScan)
-                {
-                    var root = dir.FullName.Split(Path.DirectorySeparatorChar)[0] + Path.DirectorySeparatorChar;
-                    FileTypeAccumulator.TryRemove(root, out _);
-                }
-
                 await Parallel.ForEachAsync(directoriesToScan, async (dir, token) =>
                 {
                     if (token.IsCancellationRequested) return;
@@ -156,12 +150,16 @@ public class DiskScannerEngine
 
         if (DirectorySizeCache.TryGetValue(dir.FullName, out var entry))
         {
-            if(dir.LastWriteTimeUtc <= entry.LastUpdated)
+            if (dir.LastWriteTimeUtc <= entry.LastUpdated)
+            {
                 return entry.Size;
-
+            }
             Console.WriteLine("CACHE STALE: Rescanning Directory....");
         }
+
         long size = 0;
+        var extMap = new Dictionary<string, FileTypeEntry>(StringComparer.OrdinalIgnoreCase);
+
         try
         {
             var option = new EnumerationOptions
@@ -171,23 +169,22 @@ public class DiskScannerEngine
             };
             var files = dir.GetFiles("*", option);
 
-            var root = dir.FullName.Split(Path.DirectorySeparatorChar)[0] + Path.DirectorySeparatorChar;
-
-            var extMap = FileTypeAccumulator.GetOrAdd(
-                root,
-                _ => new ConcurrentDictionary<string, (int Count, long Bytes)>(
-                    StringComparer.OrdinalIgnoreCase));
+            size += files.Sum(f => f.Length);
 
             foreach (var f in files)
             {
                 var ext = f.Extension.ToLowerInvariant();
                 if (string.IsNullOrEmpty(ext)) ext = "no extension";
-                extMap.AddOrUpdate(
-                    ext,
-                    _ => (1, f.Length),
-                    (_, prev) => (prev.Count + 1, prev.Bytes + f.Length));
+                
+                if (!extMap.TryGetValue(ext, out var fileTypeEntry))
+                {
+                    fileTypeEntry = new FileTypeEntry { Count = 0, Bytes = 0 };
+                    extMap[ext] = fileTypeEntry;
+                }
+                
+                fileTypeEntry.Count++;
+                fileTypeEntry.Bytes += f.Length;
             }
-            size += files.Sum(f => f.Length);
 
             var pulse = Interlocked.Increment(ref _deepScanThrottle);
 
@@ -221,7 +218,8 @@ public class DiskScannerEngine
         DirectorySizeCache[dir.FullName] = new CacheEntry
         {
             Size = size,
-            LastUpdated = dir.LastWriteTimeUtc
+            LastUpdated = dir.LastWriteTimeUtc,
+            Extensions = extMap
         };
 
         return size;
@@ -279,17 +277,17 @@ public class DiskScannerEngine
         {
             try
             {
-                string json = JsonSerializer.Serialize(DirectorySizeCache);
+                // Existing — save directory sizes
+                var dirJson = JsonSerializer.Serialize(
+                    new Dictionary<string, CacheEntry>(DirectorySizeCache));
                 Directory.CreateDirectory(Path.GetDirectoryName(_cacheFilePath)!);
-                File.WriteAllText(_cacheFilePath, json);
-                Console.WriteLine($"MEMORY SAVED: {DirectorySizeCache.Count} folders saved to disk!");
+                File.WriteAllText(_cacheFilePath, dirJson);
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"ERROR SAVING MEMORY: {ex.Message}");
+                Console.WriteLine($"MEMORY SAVE ERROR: {ex.Message}");
             }
         }
-        
     }
 
     public void MoveRadarToSector(string targetPath)

--- a/backend/Engine/DiskScannerEngine.cs
+++ b/backend/Engine/DiskScannerEngine.cs
@@ -106,10 +106,12 @@ public class DiskScannerEngine
                     {
                         var size = await Task.Run(() => GetDirectorySize(dir, token), token);
 
+                        DirectorySizeCache.TryGetValue(dir.FullName, out var existingEntry);
                         DirectorySizeCache[dir.FullName] = new CacheEntry
                         {
                             Size = size,
-                            LastUpdated = dir.LastWriteTimeUtc
+                            LastUpdated = dir.LastWriteTimeUtc,
+                            Extensions = existingEntry?.Extensions
                         };
                     }
                     catch (OperationCanceledException )

--- a/backend/Engine/FileTypeScanner.cs
+++ b/backend/Engine/FileTypeScanner.cs
@@ -1,0 +1,229 @@
+﻿using System.Collections.Concurrent;
+using GSInteractiveDeviceAnalyzer.Interfaces;
+using GSInteractiveDeviceAnalyzer.Models;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace GSInteractiveDeviceAnalyzer.Engine;
+
+public class FileTypeScanner : IFileTypeScanner
+{
+    private readonly DiskScannerEngine _engine;
+    private readonly IMemoryCache _cache;
+
+    private static readonly Dictionary<string, string> _categoryMap =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            // Media
+            [".mp4"] = "media",
+            [".mkv"] = "media",
+            [".avi"] = "media",
+            [".mov"] = "media",
+            [".mp3"] = "media",
+            [".flac"] = "media",
+            [".wav"] = "media",
+            [".aac"] = "media",
+            [".jpg"] = "media",
+            [".jpeg"] = "media",
+            [".png"] = "media",
+            [".gif"] = "media",
+            [".bmp"] = "media",
+            [".svg"] = "media",
+            [".webp"] = "media",
+            [".heic"] = "media",
+            [".raw"] = "media",
+            // Documents
+            [".pdf"] = "documents",
+            [".doc"] = "documents",
+            [".docx"] = "documents",
+            [".xls"] = "documents",
+            [".xlsx"] = "documents",
+            [".ppt"] = "documents",
+            [".pptx"] = "documents",
+            [".txt"] = "documents",
+            [".md"] = "documents",
+            [".csv"] = "documents",
+            [".odt"] = "documents",
+            [".rtf"] = "documents",
+            // Executables
+            [".exe"] = "executables",
+            [".dll"] = "executables",
+            [".msi"] = "executables",
+            [".bat"] = "executables",
+            [".sh"] = "executables",
+            [".bin"] = "executables",
+            [".app"] = "executables",
+            [".deb"] = "executables",
+            [".rpm"] = "executables",
+            // Archives
+            [".zip"] = "archives",
+            [".rar"] = "archives",
+            [".7z"] = "archives",
+            [".tar"] = "archives",
+            [".gz"] = "archives",
+            [".bz2"] = "archives",
+            [".xz"] = "archives",
+            [".iso"] = "archives",
+            [".img"] = "archives",
+            // Code
+            [".cs"] = "code",
+            [".js"] = "code",
+            [".ts"] = "code",
+            [".py"] = "code",
+            [".dart"] = "code",
+            [".java"] = "code",
+            [".cpp"] = "code",
+            [".c"] = "code",
+            [".h"] = "code",
+            [".go"] = "code",
+            [".rs"] = "code",
+            [".json"] = "code",
+            [".xml"] = "code",
+            [".yaml"] = "code",
+            [".toml"] = "code",
+            // System
+            [".sys"] = "system",
+            [".ini"] = "system",
+            [".cfg"] = "system",
+            [".log"] = "system",
+            [".tmp"] = "system",
+            [".dat"] = "system",
+            [".db"] = "system",
+            [".lnk"] = "system",
+        };
+
+    public FileTypeScanner(DiskScannerEngine engine, IMemoryCache cache)
+    {
+        _engine = engine;
+        _cache = cache;
+    }
+
+    /// <inheritdoc/>
+    public FileTypeScanResult? Analyze(string root)
+    {
+        var normalized = NormalizeRoot(root);
+        var cacheKey = $"filetypes:{normalized.ToLowerInvariant()}";
+
+        if (_cache.TryGetValue(cacheKey, out FileTypeScanResult? hit))
+            return hit;
+
+        var wasScanned = _engine.DirectorySizeCache.Keys
+            .Any(k => k.StartsWith(normalized, StringComparison.OrdinalIgnoreCase));
+
+        if (!wasScanned) return null;
+
+        var result = BuildResult(normalized);
+        _cache.Set(cacheKey, result, TimeSpan.FromMinutes(15));
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public void Invalidate(string root)
+    {
+        _cache.Remove($"filetypes:{NormalizeRoot(root).ToLowerInvariant()}");
+    }
+    private FileTypeScanResult BuildResult(string root)
+    {
+        var normalizedRoot = NormalizeRoot(root);
+
+        var driveRoot = Path.GetPathRoot(normalizedRoot) ?? normalizedRoot;
+
+        if (!_engine.FileTypeAccumulator.TryGetValue(driveRoot, out var extMap) || extMap.IsEmpty)
+        {
+            extMap = BuildFromCacheIndex(normalizedRoot);
+        }
+
+        var totalBytes = extMap.Values.Sum(v => (long)v.Bytes);
+
+        var categories = extMap
+            .GroupBy(kvp =>
+                _categoryMap.TryGetValue(kvp.Key, out var cat) ? cat : "other")
+            .Select(g =>
+            {
+                var catBytes = g.Sum(e => (long)e.Value.Bytes);
+                var catCount = g.Sum(e => e.Value.Count);
+
+                var extensions = g
+                    .Select(e => new FileTypeExtensionEntry
+                    {
+                        Ext = e.Key,
+                        FileCount = e.Value.Count,
+                        TotalBytes = e.Value.Bytes,
+                        SizeFormatted = FormatBytes(e.Value.Bytes),
+                        PercentOfDisk = totalBytes > 0
+                            ? Math.Round((double)e.Value.Bytes / totalBytes * 100, 1) : 0.0,
+                    })
+                    .OrderByDescending(e => e.TotalBytes)
+                    .ToList();
+
+                return new FileTypeCategory
+                {
+                    Name = g.Key,
+                    TotalBytes = catBytes,
+                    SizeFormatted = FormatBytes(catBytes),
+                    FileCount = catCount,
+                    PercentOfDisk = totalBytes > 0
+                        ? Math.Round((double)catBytes / totalBytes * 100, 1) : 0.0,
+                    Extensions = extensions,
+                };
+            })
+            .OrderByDescending(c => c.TotalBytes)
+            .ToList();
+
+        return new FileTypeScanResult
+        {
+            Root = root,
+            TotalScannedBytes = totalBytes,
+            TotalScannedFormatted = FormatBytes(totalBytes),
+            ScannedAt = DateTime.UtcNow,
+            Categories = categories,
+        };
+    }
+
+    private ConcurrentDictionary<string, (int Count, long Bytes)> BuildFromCacheIndex(string root)
+    {
+        var extMap = new ConcurrentDictionary<string, (int Count, long Bytes)>(
+            StringComparer.OrdinalIgnoreCase);
+
+        var cachedDirs = _engine.DirectorySizeCache.Keys
+            .Where(k => k.StartsWith(root, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        Parallel.ForEach(cachedDirs, dir =>
+        {
+            try
+            {
+                foreach (var fi in new DirectoryInfo(dir).GetFiles())
+                {
+                    try
+                    {
+                        var ext = fi.Extension.ToLowerInvariant();
+                        if (string.IsNullOrEmpty(ext)) ext = "no extension";
+                        extMap.AddOrUpdate(
+                            ext,
+                            _ => (1, fi.Length),
+                            (_, prev) => (prev.Count + 1, prev.Bytes + fi.Length));
+                    }
+                    catch { }
+                }
+            }
+            catch { }
+        });
+
+        return extMap;
+    }
+
+
+    private static string NormalizeRoot(string root) =>
+        Path.GetFullPath(
+            root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar))
+        + Path.DirectorySeparatorChar;
+
+    public static string FormatBytes(long bytes) => bytes switch
+    {
+        >= 1_099_511_627_776L => $"{bytes / 1_099_511_627_776.0:F1} TB",
+        >= 1_073_741_824L => $"{bytes / 1_073_741_824.0:F1} GB",
+        >= 1_048_576L => $"{bytes / 1_048_576.0:F1} MB",
+        >= 1_024L => $"{bytes / 1_024.0:F1} KB",
+        _ => $"{bytes} B",
+    };
+}

--- a/backend/Engine/FileTypeScanner.cs
+++ b/backend/Engine/FileTypeScanner.cs
@@ -106,8 +106,10 @@ public class FileTypeScanner : IFileTypeScanner
         if (_cache.TryGetValue(cacheKey, out FileTypeScanResult? hit))
             return hit;
 
+        var normalizedNoSlash = normalized.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         var wasScanned = _engine.DirectorySizeCache.Keys
-            .Any(k => k.StartsWith(normalized, StringComparison.OrdinalIgnoreCase));
+            .Any(k => k.Equals(normalizedNoSlash, StringComparison.OrdinalIgnoreCase) ||
+                      k.StartsWith(normalized, StringComparison.OrdinalIgnoreCase));
 
         if (!wasScanned) return null;
 
@@ -202,10 +204,16 @@ public class FileTypeScanner : IFileTypeScanner
     }
 
 
-    private static string NormalizeRoot(string root) =>
-        Path.GetFullPath(
-            root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar))
-        + Path.DirectorySeparatorChar;
+    private static string NormalizeRoot(string root)
+    {
+        var fullPath = Path.GetFullPath(root);
+        if (!fullPath.EndsWith(Path.DirectorySeparatorChar) && 
+            !fullPath.EndsWith(Path.AltDirectorySeparatorChar))
+        {
+            fullPath += Path.DirectorySeparatorChar;
+        }
+        return fullPath;
+    }
 
     public static string FormatBytes(long bytes) => bytes switch
     {

--- a/backend/Engine/FileTypeScanner.cs
+++ b/backend/Engine/FileTypeScanner.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using GSInteractiveDeviceAnalyzer.Interfaces;
 using GSInteractiveDeviceAnalyzer.Models;
 using Microsoft.Extensions.Caching.Memory;
@@ -125,14 +125,10 @@ public class FileTypeScanner : IFileTypeScanner
     {
         var normalizedRoot = NormalizeRoot(root);
 
-        var driveRoot = Path.GetPathRoot(normalizedRoot) ?? normalizedRoot;
+        var extMap = BuildFromMemory(normalizedRoot);
 
-        if (!_engine.FileTypeAccumulator.TryGetValue(driveRoot, out var extMap) || extMap.IsEmpty)
-        {
-            extMap = BuildFromCacheIndex(normalizedRoot);
-        }
-
-        var totalBytes = extMap.Values.Sum(v => (long)v.Bytes);
+        var realEntries = extMap.Where(kvp => !kvp.Key.StartsWith("__visited__")).ToList();
+        var totalBytes = realEntries.Sum(v => v.Value.Bytes);
 
         var categories = extMap
             .GroupBy(kvp =>
@@ -179,35 +175,28 @@ public class FileTypeScanner : IFileTypeScanner
         };
     }
 
-    private ConcurrentDictionary<string, (int Count, long Bytes)> BuildFromCacheIndex(string root)
+    private ConcurrentDictionary<string, FileTypeEntry> BuildFromMemory(string root)
     {
-        var extMap = new ConcurrentDictionary<string, (int Count, long Bytes)>(
-            StringComparer.OrdinalIgnoreCase);
+        var extMap = new ConcurrentDictionary<string, FileTypeEntry>(StringComparer.OrdinalIgnoreCase);
 
-        var cachedDirs = _engine.DirectorySizeCache.Keys
-            .Where(k => k.StartsWith(root, StringComparison.OrdinalIgnoreCase))
-            .ToList();
+        var rootNoSlash = root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var cachedDirs = _engine.DirectorySizeCache
+            .Where(kvp => kvp.Key.Equals(rootNoSlash, StringComparison.OrdinalIgnoreCase) || 
+                          kvp.Key.StartsWith(root, StringComparison.OrdinalIgnoreCase));
 
-        Parallel.ForEach(cachedDirs, dir =>
+        foreach (var kvp in cachedDirs)
         {
-            try
+            if (kvp.Value.Extensions != null)
             {
-                foreach (var fi in new DirectoryInfo(dir).GetFiles())
+                foreach (var ext in kvp.Value.Extensions)
                 {
-                    try
-                    {
-                        var ext = fi.Extension.ToLowerInvariant();
-                        if (string.IsNullOrEmpty(ext)) ext = "no extension";
-                        extMap.AddOrUpdate(
-                            ext,
-                            _ => (1, fi.Length),
-                            (_, prev) => (prev.Count + 1, prev.Bytes + fi.Length));
-                    }
-                    catch { }
+                    extMap.AddOrUpdate(
+                        ext.Key,
+                        _ => new FileTypeEntry { Count = ext.Value.Count, Bytes = ext.Value.Bytes },
+                        (_, prev) => { prev.Count += ext.Value.Count; prev.Bytes += ext.Value.Bytes; return prev; });
                 }
             }
-            catch { }
-        });
+        }
 
         return extMap;
     }

--- a/backend/GSInteractiveDeviceAnalyzer.Tests/Engine/FileTypeScannerTests.cs
+++ b/backend/GSInteractiveDeviceAnalyzer.Tests/Engine/FileTypeScannerTests.cs
@@ -1,0 +1,328 @@
+using GSInteractiveDeviceAnalyzer.Engine;
+using GSInteractiveDeviceAnalyzer.Hubs;
+using GSInteractiveDeviceAnalyzer.Interfaces;
+using GSInteractiveDeviceAnalyzer.Models;
+using GSInteractiveDeviceAnalyzer.Models.SettingDtos;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Caching.Memory;
+using Moq;
+
+namespace GSInteractiveDeviceAnalyzer.Tests.Engine;
+
+public class FileTypeScannerTests
+{
+
+    private static DiskScannerEngine CreateEngine()
+    {
+        var mockClients = new Mock<IHubClients>();
+        var mockClient = new Mock<IClientProxy>();
+        mockClients.Setup(c => c.All).Returns(mockClient.Object);
+
+        var mockHub = new Mock<IHubContext<SystemHub>>();
+        mockHub.Setup(h => h.Clients).Returns(mockClients.Object);
+
+        var mockSettings = new Mock<ISettingService>();
+        mockSettings.Setup(s => s.Current).Returns(new AppSettingDto());
+
+        var engine = new DiskScannerEngine(mockHub.Object, mockSettings.Object);
+        // Clear the cache to prevent tests from reading the user's actual saved memory from disk
+        engine.DirectorySizeCache.Clear();
+        return engine;
+    }
+
+    private static IMemoryCache CreateCache() =>
+        new MemoryCache(new MemoryCacheOptions());
+
+    private static FileTypeScanner CreateScanner(
+        DiskScannerEngine? engine = null,
+        IMemoryCache? cache = null) =>
+        new(engine ?? CreateEngine(), cache ?? CreateCache());
+
+    /// Seeds a CacheEntry with extension data onto DirectorySizeCache.
+    private static void SeedCache(
+        DiskScannerEngine engine,
+        string path,
+        Dictionary<string, FileTypeEntry>? extensions = null)
+    {
+        engine.DirectorySizeCache[path] = new CacheEntry
+        {
+            Size = extensions?.Values.Sum(e => e.Bytes) ?? 1024,
+            LastUpdated = DateTime.UtcNow,
+            Extensions = extensions
+        };
+    }
+
+
+    [Fact]
+    public void Analyze_ReturnsNull_WhenDirectoryCacheIsEmpty()
+    {
+        var scanner = CreateScanner();
+
+        var result = scanner.Analyze(@"C:\Users");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Analyze_ReturnsNull_WhenRootHasNoMatchingCacheKey()
+    {
+        var engine = CreateEngine();
+        SeedCache(engine, @"D:\SomeFolder");  // D:\, not C:\
+        var scanner = CreateScanner(engine);
+
+        var result = scanner.Analyze(@"C:\");
+
+        Assert.Null(result);
+    }
+
+
+    [Fact]
+    public void Analyze_ReturnsResult_WhenCacheHasMatchingEntries()
+    {
+        var engine = CreateEngine();
+        SeedCache(engine, @"C:\Windows\System32", new()
+        {
+            [".dll"] = new FileTypeEntry { Count = 50, Bytes = 5_242_880 },
+            [".exe"] = new FileTypeEntry { Count = 10, Bytes = 1_048_576 },
+        });
+        var scanner = CreateScanner(engine);
+
+        var result = scanner.Analyze(@"C:\");
+
+        Assert.NotNull(result);
+        Assert.NotEmpty(result!.Categories);
+    }
+
+    [Fact]
+    public void Analyze_AggregatesExtensionsAcrossMultipleCachedDirs()
+    {
+        var engine = CreateEngine();
+
+        // Two separate subdirectories both have .cs files
+        SeedCache(engine, @"C:\Projects\App", new()
+        {
+            [".cs"] = new FileTypeEntry { Count = 10, Bytes = 100_000 }
+        });
+        SeedCache(engine, @"C:\Projects\Tests", new()
+        {
+            [".cs"] = new FileTypeEntry { Count = 5, Bytes = 50_000 }
+        });
+
+        var scanner = CreateScanner(engine);
+        var result = scanner.Analyze(@"C:\")!;
+
+        var codeCategory = result.Categories.FirstOrDefault(c => c.Name == "code");
+        Assert.NotNull(codeCategory);
+
+        // Combined: 15 files, 150_000 bytes
+        Assert.Equal(15, codeCategory!.FileCount);
+        Assert.Equal(150_000, codeCategory.TotalBytes);
+    }
+
+    [Fact]
+    public void Analyze_HandlesNullExtensionsOnCacheEntry_WithoutThrowing()
+    {
+        var engine = CreateEngine();
+        // CacheEntry with null Extensions — should not crash
+        SeedCache(engine, @"C:\Windows", extensions: null);
+
+        var scanner = CreateScanner(engine);
+        var ex = Record.Exception(() => scanner.Analyze(@"C:\"));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void Analyze_NullExtensionEntry_ReturnsEmptyCategories()
+    {
+        var engine = CreateEngine();
+        SeedCache(engine, @"C:\Windows", extensions: null);
+
+        var scanner = CreateScanner(engine);
+        var result = scanner.Analyze(@"C:\");
+
+        // No extensions in cache → null result (no scan data means 409)
+        // OR empty categories depending on impl — key thing: no crash
+        // Result may be null (wasScanned=true but extMap empty → empty result)
+        if (result != null)
+            Assert.Empty(result.Categories);
+    }
+
+
+    [Fact]
+    public void Analyze_MapsKnownExtensionsToCorrectCategories()
+    {
+        var engine = CreateEngine();
+        SeedCache(engine, @"C:\test", new()
+        {
+            [".exe"] = new FileTypeEntry { Count = 1, Bytes = 1_000_000 }, // executables
+            [".cs"] = new FileTypeEntry { Count = 1, Bytes = 100_000 }, // code
+            [".mp4"] = new FileTypeEntry { Count = 1, Bytes = 500_000 }, // media
+            [".pdf"] = new FileTypeEntry { Count = 1, Bytes = 200_000 }, // documents
+            [".zip"] = new FileTypeEntry { Count = 1, Bytes = 300_000 }, // archives
+            [".sys"] = new FileTypeEntry { Count = 1, Bytes = 50_000 }, // system
+        });
+
+        var scanner = CreateScanner(engine);
+        var result = scanner.Analyze(@"C:\")!;
+        var catNames = result.Categories.Select(c => c.Name).ToHashSet();
+
+        Assert.Contains("executables", catNames);
+        Assert.Contains("code", catNames);
+        Assert.Contains("media", catNames);
+        Assert.Contains("documents", catNames);
+        Assert.Contains("archives", catNames);
+        Assert.Contains("system", catNames);
+    }
+
+    [Fact]
+    public void Analyze_UnknownExtension_BucketedAsOther()
+    {
+        var engine = CreateEngine();
+        SeedCache(engine, @"C:\test", new()
+        {
+            [".notarealex"] = new FileTypeEntry { Count = 7, Bytes = 70_000 }
+        });
+
+        var scanner = CreateScanner(engine);
+        var result = scanner.Analyze(@"C:\")!;
+        var other = result.Categories.FirstOrDefault(c => c.Name == "other");
+
+        Assert.NotNull(other);
+        Assert.Equal(7, other!.FileCount);
+    }
+
+
+    [Fact]
+    public void Analyze_CategoriesOrderedByTotalBytesDescending()
+    {
+        var engine = CreateEngine();
+        SeedCache(engine, @"C:\test", new()
+        {
+            [".cs"] = new FileTypeEntry { Count = 1, Bytes = 100 },   // code (smallest)
+            [".exe"] = new FileTypeEntry { Count = 1, Bytes = 50_000_000 }, // executables (biggest)
+            [".mp4"] = new FileTypeEntry { Count = 1, Bytes = 10_000_000 }, // media (middle)
+        });
+
+        var scanner = CreateScanner(engine);
+        var sizes = scanner.Analyze(@"C:\")!.Categories
+                             .Select(c => c.TotalBytes)
+                             .ToList();
+
+        Assert.Equal(sizes.OrderByDescending(x => x).ToList(), sizes);
+    }
+
+    [Fact]
+    public void Analyze_PercentOfDisk_SumsToApproximately100()
+    {
+        var engine = CreateEngine();
+        SeedCache(engine, @"C:\test", new()
+        {
+            [".exe"] = new FileTypeEntry { Count = 10, Bytes = 1_000_000 },
+            [".dll"] = new FileTypeEntry { Count = 20, Bytes = 2_000_000 },
+            [".cs"] = new FileTypeEntry { Count = 5, Bytes = 500_000 },
+        });
+
+        var scanner = CreateScanner(engine);
+        var total = scanner.Analyze(@"C:\")!.Categories.Sum(c => c.PercentOfDisk);
+
+        Assert.InRange(total, 99.0, 101.0);
+    }
+
+    [Fact]
+    public void Analyze_TotalScannedBytes_MatchesSumOfAllExtensions()
+    {
+        var engine = CreateEngine();
+        SeedCache(engine, @"C:\test", new()
+        {
+            [".exe"] = new FileTypeEntry { Count = 1, Bytes = 1_048_576 },
+            [".cs"] = new FileTypeEntry { Count = 1, Bytes = 512_000 },
+        });
+
+        var scanner = CreateScanner(engine);
+        var result = scanner.Analyze(@"C:\")!;
+
+        Assert.Equal(1_560_576, result.TotalScannedBytes);
+    }
+
+
+    [Fact]
+    public void Analyze_SecondCall_ReturnsSameCachedObject()
+    {
+        var engine = CreateEngine();
+        SeedCache(engine, @"C:\test", new()
+        {
+            [".cs"] = new FileTypeEntry { Count = 1, Bytes = 1024 }
+        });
+
+        var scanner = CreateScanner(engine);
+        var first = scanner.Analyze(@"C:\");
+
+        // Wipe cache entries — if IMemoryCache is used, second call still works
+        engine.DirectorySizeCache.Clear();
+
+        var second = scanner.Analyze(@"C:\");
+
+        Assert.NotNull(second);
+        Assert.Same(first, second);  // exact same reference = served from cache
+    }
+
+    [Fact]
+    public void Invalidate_ClearsCache_SoNextCallRebuilds()
+    {
+        var engine = CreateEngine();
+        SeedCache(engine, @"C:\test", new()
+        {
+            [".cs"] = new FileTypeEntry { Count = 1, Bytes = 1024 }
+        });
+
+        var scanner = CreateScanner(engine);
+        var first = scanner.Analyze(@"C:\");
+
+        scanner.Invalidate(@"C:\");
+
+        // Reseed with different data
+        engine.DirectorySizeCache.Clear();
+        SeedCache(engine, @"C:\test", new()
+        {
+            [".exe"] = new FileTypeEntry { Count = 99, Bytes = 9_000_000 }
+        });
+
+        var second = scanner.Analyze(@"C:\");
+
+        Assert.NotNull(second);
+        Assert.NotSame(first, second);
+        Assert.Contains(second!.Categories, c => c.Name == "executables");
+    }
+
+
+    [Fact]
+    public void FormatBytes_Returns_Bytes_ForSmallValues()
+    {
+        Assert.Equal("500 B", FileTypeScanner.FormatBytes(500));
+    }
+
+    [Fact]
+    public void FormatBytes_Returns_KB_For1024()
+    {
+        Assert.Equal("1.0 KB", FileTypeScanner.FormatBytes(1_024));
+    }
+
+    [Fact]
+    public void FormatBytes_Returns_MB_For1MB()
+    {
+        Assert.Equal("1.0 MB", FileTypeScanner.FormatBytes(1_048_576));
+    }
+
+    [Fact]
+    public void FormatBytes_Returns_GB_For1GB()
+    {
+        Assert.Equal("1.0 GB", FileTypeScanner.FormatBytes(1_073_741_824));
+    }
+
+    [Fact]
+    public void FormatBytes_Returns_TB_For1TB()
+    {
+        Assert.Equal("1.0 TB", FileTypeScanner.FormatBytes(1_099_511_627_776L));
+    }
+}

--- a/backend/Interfaces/IFileTypeScanner.cs
+++ b/backend/Interfaces/IFileTypeScanner.cs
@@ -1,0 +1,10 @@
+﻿using GSInteractiveDeviceAnalyzer.Models;
+
+namespace GSInteractiveDeviceAnalyzer.Interfaces
+{
+    public interface IFileTypeScanner
+    {
+        FileTypeScanResult? Analyze(string root);
+        void Invalidate(string root);
+    }
+}

--- a/backend/Models/FileTypeScanResult.cs
+++ b/backend/Models/FileTypeScanResult.cs
@@ -1,5 +1,10 @@
 ﻿namespace GSInteractiveDeviceAnalyzer.Models;
 
+public class FileTypeEntry
+{
+    public int Count { get; set; }
+    public long Bytes { get; set; }
+}
 public class FileTypeExtensionEntry
 {
     public string Ext { get; set; } = string.Empty;

--- a/backend/Models/FileTypeScanResult.cs
+++ b/backend/Models/FileTypeScanResult.cs
@@ -1,0 +1,29 @@
+﻿namespace GSInteractiveDeviceAnalyzer.Models;
+
+public class FileTypeExtensionEntry
+{
+    public string Ext { get; set; } = string.Empty;
+    public int FileCount { get; set; }
+    public long TotalBytes { get; set; }
+    public string SizeFormatted { get; set; } = string.Empty;
+    public double PercentOfDisk { get; set; }
+}
+
+public class FileTypeCategory
+{
+    public string Name { get; set; } = string.Empty;
+    public long TotalBytes { get; set; }
+    public string SizeFormatted { get; set; } = string.Empty;
+    public int FileCount { get; set; }
+    public double PercentOfDisk { get; set; }
+    public List<FileTypeExtensionEntry> Extensions { get; set; } = new();
+}
+
+public class FileTypeScanResult
+{
+    public string Root { get; set; } = string.Empty;
+    public long TotalScannedBytes { get; set; }
+    public string TotalScannedFormatted { get; set; } = string.Empty;
+    public DateTime ScannedAt { get; set; }
+    public List<FileTypeCategory> Categories { get; set; } = new();
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -21,6 +21,7 @@ builder.Services.AddCors(options =>
 });
 
 builder.Services.AddControllers();
+builder.Services.AddMemoryCache();
 
 // Engine singletons
 builder.Services.AddSingleton<DiskScannerEngine>();
@@ -32,6 +33,7 @@ builder.Services.AddSingleton<INukeProtocolService, NukeProtocolService>();
 builder.Services.AddSingleton<IDriveDetectionService, DriveDetectionService>();
 builder.Services.AddSingleton<ISettingService, SettingsServices>();
 builder.Services.AddSingleton<IProcessOwnerResolver, ProcessOwnerResolver>();
+builder.Services.AddSingleton<IFileTypeScanner, FileTypeScanner>();
 
 // Platform-specific CPU provider
 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/backend/Services/DiskOperationsService.cs
+++ b/backend/Services/DiskOperationsService.cs
@@ -1,4 +1,4 @@
-﻿using System.Drawing;
+using System.Drawing;
 using GSInteractiveDeviceAnalyzer.Engine;
 using GSInteractiveDeviceAnalyzer.Hubs;
 using GSInteractiveDeviceAnalyzer.Interfaces;
@@ -75,10 +75,15 @@ namespace GSInteractiveDeviceAnalyzer.Services
             var actualFolderSize = nodes.Sum(n => n.SizeBytes);
 
             var normalizedPath = Path.GetFullPath(path);
+            _scanner.DirectorySizeCache.TryGetValue(normalizedPath, out var oldEntry);
             _scanner.DirectorySizeCache[normalizedPath] = new CacheEntry
-                { Size = actualFolderSize, LastUpdated = DateTime.UtcNow };
+            { 
+                Size = actualFolderSize, 
+                LastUpdated = DateTime.UtcNow,
+                Extensions = oldEntry?.Extensions 
+            };
 
-            _scanner.SaveMemoryToDisk();
+            Task.Run(() => _scanner.SaveMemoryToDisk());
 
             return nodes;
         }
@@ -111,7 +116,7 @@ namespace GSInteractiveDeviceAnalyzer.Services
 
             if (memoryChanged)
             {
-                _scanner.SaveMemoryToDisk();
+                Task.Run(() => _scanner.SaveMemoryToDisk());
             }
         }
 

--- a/frontend/gs_anlyzer_ui/lib/models/file_type_model.dart
+++ b/frontend/gs_anlyzer_ui/lib/models/file_type_model.dart
@@ -1,0 +1,74 @@
+class FileTypeExtensionEntry {
+  final String ext;
+  final int    fileCount;
+  final double percentOfDisk;
+  final String sizeFormatted;
+  final int    totalBytes;
+
+  const FileTypeExtensionEntry({
+    required this.ext,
+    required this.fileCount,
+    required this.percentOfDisk,
+    required this.sizeFormatted,
+    required this.totalBytes,
+  });
+
+  factory FileTypeExtensionEntry.fromJson(Map<String, dynamic> j) =>
+      FileTypeExtensionEntry(
+        ext           : j['ext']           as String,
+        fileCount     : j['fileCount']     as int,
+        percentOfDisk : (j['percentOfDisk'] as num).toDouble(),
+        sizeFormatted : j['sizeFormatted'] as String,
+        totalBytes    : j['totalBytes']    as int,
+      );
+}
+
+class FileTypeCategory {
+  final String                       name;
+  final int                          fileCount;
+  final double                       percentOfDisk;
+  final String                       sizeFormatted;
+  final int                          totalBytes;
+  final List<FileTypeExtensionEntry> extensions;
+
+  const FileTypeCategory({
+    required this.name,
+    required this.fileCount,
+    required this.percentOfDisk,
+    required this.sizeFormatted,
+    required this.totalBytes,
+    required this.extensions,
+  });
+
+  factory FileTypeCategory.fromJson(Map<String, dynamic> j) =>
+      FileTypeCategory(
+        name          : j['name']          as String,
+        fileCount     : j['fileCount']     as int,
+        percentOfDisk : (j['percentOfDisk'] as num).toDouble(),
+        sizeFormatted : j['sizeFormatted'] as String,
+        totalBytes    : j['totalBytes']    as int,
+        extensions    : (j['extensions'] as List)
+            .map((e) => FileTypeExtensionEntry.fromJson(e as Map<String, dynamic>))
+            .toList(),
+      );
+}
+
+class FileTypeResult {
+  final String                  root;
+  final List<FileTypeCategory>  categories;
+  final String                  totalScannedFormatted;
+
+  const FileTypeResult({
+    required this.root,
+    required this.categories,
+    required this.totalScannedFormatted,
+  });
+
+  factory FileTypeResult.fromJson(Map<String, dynamic> j) => FileTypeResult(
+        root                  : j['root']                  as String,
+        totalScannedFormatted : j['totalScannedFormatted'] as String,
+        categories            : (j['categories'] as List)
+            .map((e) => FileTypeCategory.fromJson(e as Map<String, dynamic>))
+            .toList(),
+      );
+}

--- a/frontend/gs_anlyzer_ui/lib/providers/directory_provider.dart
+++ b/frontend/gs_anlyzer_ui/lib/providers/directory_provider.dart
@@ -135,6 +135,8 @@ class DirectoryNotifier extends StateNotifier<DirectoryState> {
     );
   }
 
+  DateTime? _scanStartTime;
+
   Future<void> scanDirectory(String targetPath, {bool forceRefresh = false}) async {
     String safePath = targetPath.replaceAll('\\', '/');
 
@@ -154,6 +156,7 @@ class DirectoryNotifier extends StateNotifier<DirectoryState> {
     }
 
     _sectorCache[safePath] = [];
+    _scanStartTime = DateTime.now();
 
     state = state.copyWith(currentPath: safePath, isLoading: true, searchQuery: '', errorMessage: null, allNodes: [], displayNodes: []);
 
@@ -184,9 +187,9 @@ class DirectoryNotifier extends StateNotifier<DirectoryState> {
     state = state.copyWith(allNodes: updatedList, displayNodes: updatedList);
   }
 
-  void finalizeStream(String path) {
+  void finalizeStream(String path) async {
     String incomingPath = path.replaceAll('\\', '/').toLowerCase();
-    String currentPath = path.replaceAll('\\', '/').toLowerCase();
+    String currentPath = state.currentPath.replaceAll('\\', '/').toLowerCase();
 
     if (incomingPath.endsWith('/')) incomingPath = incomingPath.substring(0, incomingPath.length - 1);
     if (currentPath.endsWith('/')) currentPath = currentPath.substring(0, currentPath.length - 1);
@@ -194,6 +197,14 @@ class DirectoryNotifier extends StateNotifier<DirectoryState> {
 
     if (incomingPath == currentPath) {
       _applyFiltersAndSort();
+
+      if (_scanStartTime != null) {
+        final elapsed = DateTime.now().difference(_scanStartTime!);
+        if (elapsed.inMilliseconds < 2500) {
+          await Future.delayed(Duration(milliseconds: 2500 - elapsed.inMilliseconds));
+        }
+      }
+
       state = state.copyWith(isLoading: false);
     }
 

--- a/frontend/gs_anlyzer_ui/lib/providers/directory_provider.dart
+++ b/frontend/gs_anlyzer_ui/lib/providers/directory_provider.dart
@@ -136,6 +136,7 @@ class DirectoryNotifier extends StateNotifier<DirectoryState> {
   }
 
   DateTime? _scanStartTime;
+  bool _wasForceRefresh = false;
 
   Future<void> scanDirectory(String targetPath, {bool forceRefresh = false}) async {
     String safePath = targetPath.replaceAll('\\', '/');
@@ -157,6 +158,7 @@ class DirectoryNotifier extends StateNotifier<DirectoryState> {
 
     _sectorCache[safePath] = [];
     _scanStartTime = DateTime.now();
+    _wasForceRefresh = forceRefresh;
 
     state = state.copyWith(currentPath: safePath, isLoading: true, searchQuery: '', errorMessage: null, allNodes: [], displayNodes: []);
 
@@ -198,7 +200,7 @@ class DirectoryNotifier extends StateNotifier<DirectoryState> {
     if (incomingPath == currentPath) {
       _applyFiltersAndSort();
 
-      if (_scanStartTime != null) {
+      if (_wasForceRefresh && _scanStartTime != null) {
         final elapsed = DateTime.now().difference(_scanStartTime!);
         if (elapsed.inMilliseconds < 2500) {
           await Future.delayed(Duration(milliseconds: 2500 - elapsed.inMilliseconds));

--- a/frontend/gs_anlyzer_ui/lib/providers/file_type_provider.dart
+++ b/frontend/gs_anlyzer_ui/lib/providers/file_type_provider.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:gs_analyzer_ui/models/file_type_model.dart';
+import 'package:gs_analyzer_ui/services/api_service.dart';
+
+class FileTypeNoScanException implements Exception {
+  const FileTypeNoScanException();
+}
+final selectedCategoryProvider = StateProvider<String?>((ref) => null);
+
+/// Fetches file type breakdown for [root].
+/// Throws [FileTypeNoScanException] when no Directory scan has run yet.
+final fileTypesProvider = FutureProvider.autoDispose
+    .family<FileTypeResult, String>((ref, root) async {
+  return ApiService().getFileTypes(root);
+});
+
+final scanRootProvider = StateProvider.family<String, String>((ref, driveName ) => driveName);

--- a/frontend/gs_anlyzer_ui/lib/screen/storage_screen.dart
+++ b/frontend/gs_anlyzer_ui/lib/screen/storage_screen.dart
@@ -8,6 +8,7 @@ import '../utils/hud_label.dart';
 import 'package:gs_analyzer_ui/providers/directory_provider.dart';
 import 'package:gs_analyzer_ui/providers/storage_view_provider.dart';
 import 'package:gs_analyzer_ui/providers/storage_mode_provider.dart';
+import 'package:gs_analyzer_ui/widgets/file_type_analyzer_panel.dart';
 
 class StorageScreen extends ConsumerWidget {
   const StorageScreen({Key? key}) : super(key: key);
@@ -33,30 +34,34 @@ class StorageScreen extends ConsumerWidget {
           _DriveSelectorBar(drives: drives, selectedDrive: currentDrive),
           const Divider(color: Colors.white10, height: 1),
 
-          Padding(
-            padding: const EdgeInsets.all(16.0),
-            child: _DriveDetailCard(drive: currentDrive),
-          ),
-
           Expanded(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16.0),
-              child: ListView(
-                children: [
-                  _ScanLaunchTile(
-                    title: 'DIRECTORY SCANNER',
-                    subtitle: 'Index every sector on ${currentDrive.name}',
-                    icon: Icons.account_tree_outlined,
-                    onLaunch: () => _enterAnalyzer(ref, currentDrive, StorageMode.diskAnalyzer),
+            child: ListView(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: _DriveDetailCard(drive: currentDrive),
+                ),
+                FileTypeAnalyzerPanel(driveName: currentDrive.name),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                  child: Column(
+                    children: [
+                      _ScanLaunchTile(
+                        title: 'DIRECTORY SCANNER',
+                        subtitle: 'Index every sector on ${currentDrive.name}',
+                        icon: Icons.account_tree_outlined,
+                        onLaunch: () => _enterAnalyzer(ref, currentDrive, StorageMode.diskAnalyzer),
+                      ),
+                      _ScanLaunchTile(
+                        title: 'DUPLICATE HUNTER',
+                        subtitle: 'Scan for duplicate files on ${currentDrive.name}',
+                        icon: Icons.copy_all_outlined,
+                        onLaunch: () => _enterAnalyzer(ref, currentDrive, StorageMode.duplicateScanner),
+                      ),
+                    ],
                   ),
-                  _ScanLaunchTile(
-                    title: 'DUPLICATE HUNTER',
-                    subtitle: 'Scan for duplicate files on ${currentDrive.name}',
-                    icon: Icons.copy_all_outlined,
-                    onLaunch: () => _enterAnalyzer(ref, currentDrive, StorageMode.duplicateScanner),
-                  ),
-                ],
-              ),
+                ),
+              ],
             ),
           )
         ],

--- a/frontend/gs_anlyzer_ui/lib/screen/storage_screen.dart
+++ b/frontend/gs_anlyzer_ui/lib/screen/storage_screen.dart
@@ -80,13 +80,12 @@ class StorageScreen extends ConsumerWidget {
   }
 
   void _enterAnalyzer(WidgetRef ref, DriveInfo drive, StorageMode mode) {
-
     ref.read(selectedDriveNameProvider.notifier).state = drive.name;
-
     ref.read(storageModeProvider.notifier).state = mode;
 
     if (mode == StorageMode.diskAnalyzer) {
-      ref.read(directoryProvider.notifier).scanDirectory(drive.name);
+      // Force refresh so the TelemetryHudWidget tracks the exact duration of the real scan.
+      ref.read(directoryProvider.notifier).scanDirectory(drive.name, forceRefresh: true);
     }
 
     ref.read(storageViewProvider.notifier).state = StorageView.analyzer;

--- a/frontend/gs_anlyzer_ui/lib/services/api_service.dart
+++ b/frontend/gs_anlyzer_ui/lib/services/api_service.dart
@@ -3,6 +3,8 @@ import 'package:gs_analyzer_ui/models/drive_stats.dart';
 import 'package:gs_analyzer_ui/models/nuke_preview.dart';
 import 'package:http/http.dart' as http;
 import 'package:gs_analyzer_ui/models/storage_node.dart';
+import 'package:gs_analyzer_ui/models/file_type_model.dart';
+import 'package:gs_analyzer_ui/providers/file_type_provider.dart';
 
 class ApiService {
   static  const String storageUrl = 'http://localhost:5200/api/storage';
@@ -11,6 +13,7 @@ class ApiService {
   static const String thermalUrl = 'http://localhost:5200/api/thermal';
   static const String settingsUrl = 'http://localhost:5200/api/settings';
   static const String driveUrl = 'http://localhost:5200/api/drives';
+
 
   Future<List<StorageNode>> scanDirectory(String path) async {
     final uri = Uri.parse('$storageUrl/scan');
@@ -278,5 +281,26 @@ class ApiService {
       print("[Api] Drives Fetch Error: $e");
     }
     return null;
+  }
+
+  Future<FileTypeResult> getFileTypes(String root) async {
+  final uri = Uri.parse('$storageUrl/scan/filetypes')
+      .replace(queryParameters: {'root': root});
+
+  final response = await http.get(uri);
+
+  if (response.statusCode == 409) {
+    throw FileTypeNoScanException();
+  }
+
+  if (response.statusCode != 200) {
+    throw Exception(
+      'FileTypes fetch failed [${response.statusCode}]: ${response.body}',
+    );
+  }
+
+  return FileTypeResult.fromJson(
+    jsonDecode(response.body) as Map<String, dynamic>
+    );
   }
 }

--- a/frontend/gs_anlyzer_ui/lib/widgets/file_type_analyzer_panel.dart
+++ b/frontend/gs_anlyzer_ui/lib/widgets/file_type_analyzer_panel.dart
@@ -1,0 +1,472 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:gs_analyzer_ui/models/file_type_model.dart';
+import 'package:gs_analyzer_ui/providers/file_type_provider.dart';
+
+class FileTypeAnalyzerPanel extends ConsumerWidget {
+  final String driveName;
+  const FileTypeAnalyzerPanel({super.key, required this.driveName});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final scanRoot    = ref.watch(scanRootProvider(driveName));
+    final asyncResult = ref.watch(fileTypesProvider(scanRoot));
+
+    return Theme(
+      data: Theme.of(context).copyWith(dividerColor: Colors.transparent),
+      child: ExpansionTile(
+        initiallyExpanded: false,
+        collapsedBackgroundColor: const Color(0xFF1A1D23),
+        backgroundColor: const Color(0xFF1A1D23),
+        title: Row(
+          children: [
+            const Icon(Icons.grid_view_rounded, color: Color(0xFF00FFFF), size: 16),
+            const SizedBox(width: 8),
+            Text(
+              'FILE TYPE MATRIX',
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+                letterSpacing: 1.4,
+              ),
+            ),
+            const SizedBox(width: 12),
+            InkWell(
+              borderRadius: BorderRadius.circular(4),
+              onTap: () => _showPathPicker(context, ref, scanRoot),
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                decoration: BoxDecoration(
+                  border: Border.all(color: const Color(0xFF00FFFF).withOpacity(0.35)),
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Icon(Icons.folder_open_rounded,
+                        color: Color(0xFF00FFFF), size: 13),
+                    const SizedBox(width: 5),
+                    Text(
+                      _shortenPath(scanRoot),
+                      style: const TextStyle(
+                        color: Color(0xFF00FFFF),
+                        fontSize: 11,
+                        fontFamily: 'monospace',
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+        subtitle: asyncResult.whenOrNull(
+          data: (result) => Padding(
+            padding: const EdgeInsets.only(top: 2),
+            child: Text(
+              'TOTAL: ${result.totalScannedFormatted}  ·  '
+              '${result.categories.length} CATEGORIES',
+              style: TextStyle(
+                  color: Colors.white.withOpacity(0.45), fontSize: 11),
+            ),
+          ),
+        ),
+        children: [
+          asyncResult.when(
+            loading: () => const _LoadingState(),
+            error:   (e, _) => e is FileTypeNoScanException
+                ? _NoScanState(driveName: driveName, root: scanRoot)
+                : _ErrorState(error: e.toString()),
+            data:    (result) => _DataView(result: result),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showPathPicker(BuildContext context, WidgetRef ref, String current) {
+    final ctrl = TextEditingController(text: current);
+
+    showDialog<void>(
+      context: context,
+      builder: (_) => AlertDialog(
+        backgroundColor: const Color(0xFF1A1D23),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(8),
+          side: BorderSide(color: const Color(0xFF00FFFF).withOpacity(0.3)),
+        ),
+        title: const Text(
+          'SELECT SCAN ROOT',
+          style: TextStyle(
+            color: Color(0xFF00FFFF),
+            fontSize: 13,
+            fontWeight: FontWeight.w700,
+            letterSpacing: 1.4,
+          ),
+        ),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Enter the folder path you want to analyze:',
+              style: TextStyle(
+                  color: Colors.white.withOpacity(0.55), fontSize: 12),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: ctrl,
+              autofocus: true,
+              style: const TextStyle(
+                color: Colors.white,
+                fontFamily: 'monospace',
+                fontSize: 13,
+              ),
+              decoration: InputDecoration(
+                hintText: r'C:\Users\YourName\Projects',
+                hintStyle: TextStyle(
+                    color: Colors.white.withOpacity(0.25), fontSize: 12),
+                filled: true,
+                fillColor: const Color(0xFF0D0F14),
+                prefixIcon: const Icon(Icons.folder_open_rounded,
+                    color: Color(0xFF00FFFF), size: 16),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(6),
+                  borderSide: BorderSide(
+                      color: const Color(0xFF00FFFF).withOpacity(0.3)),
+                ),
+                enabledBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(6),
+                  borderSide: BorderSide(
+                      color: const Color(0xFF00FFFF).withOpacity(0.2)),
+                ),
+                focusedBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(6),
+                  borderSide: const BorderSide(color: Color(0xFF00FFFF)),
+                ),
+              ),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              'A Directory Scan must have been run on this path first.',
+              style: TextStyle(
+                  color: Colors.white.withOpacity(0.35), fontSize: 10),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: Text('CANCEL',
+                style: TextStyle(
+                    color: Colors.white.withOpacity(0.4), fontSize: 12)),
+          ),
+          ElevatedButton.icon(
+            style: ElevatedButton.styleFrom(
+              backgroundColor: const Color(0xFF00FFFF),
+              foregroundColor: Colors.black,
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(4)),
+            ),
+            icon: const Icon(Icons.search_rounded, size: 15),
+            label: const Text('SCAN',
+                style: TextStyle(fontWeight: FontWeight.w700, fontSize: 12)),
+            onPressed: () {
+              final newRoot = ctrl.text.trim();
+              if (newRoot.isNotEmpty) {
+                ref.read(scanRootProvider(driveName).notifier).state = newRoot;
+                // Clear category selection from previous scan
+                ref.read(selectedCategoryProvider.notifier).state = null;
+              }
+              Navigator.pop(context);
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// Shows last 2 path segments so it doesn't overflow the header.
+  String _shortenPath(String path) {
+    final sep   = path.contains('/') ? '/' : r'\';
+    final parts = path.split(sep).where((s) => s.isNotEmpty).toList();
+    if (parts.length <= 2) return path;
+    return '...${sep}${parts[parts.length - 2]}${sep}${parts.last}';
+  }
+}
+
+class _LoadingState extends StatelessWidget {
+  const _LoadingState();
+  @override
+  Widget build(BuildContext context) => const Padding(
+        padding: EdgeInsets.symmetric(vertical: 40),
+        child: Center(
+          child: CircularProgressIndicator(
+              strokeWidth: 2, color: Color(0xFF00FFFF)),
+        ),
+      );
+}
+
+class _NoScanState extends StatelessWidget {
+  final String driveName;
+  final String root;
+  const _NoScanState({required this.driveName, required this.root});
+
+  @override
+  Widget build(BuildContext context) => Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          children: [
+            Icon(Icons.radar_rounded,
+                color: Colors.white.withOpacity(0.25), size: 40),
+            const SizedBox(height: 12),
+            Text(
+              'No scan found for "$root"',
+              style: TextStyle(
+                  color: Colors.white.withOpacity(0.55), fontSize: 13),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'Run a Directory Scan on this path first, then return here.',
+              style: TextStyle(
+                  color: Colors.white.withOpacity(0.3), fontSize: 11),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      );
+}
+
+class _ErrorState extends StatelessWidget {
+  final String error;
+  const _ErrorState({required this.error});
+  @override
+  Widget build(BuildContext context) => Padding(
+        padding: const EdgeInsets.all(24),
+        child: Text(error,
+            style: const TextStyle(color: Colors.redAccent, fontSize: 12)),
+      );
+}
+
+class _DataView extends ConsumerWidget {
+  final FileTypeResult result;
+  const _DataView({required this.result});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final selected = ref.watch(selectedCategoryProvider);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 20),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Donut
+          SizedBox(
+            width: 180,
+            height: 180,
+            child: _DonutChart(result: result, selected: selected),
+          ),
+          const SizedBox(width: 24),
+          // Category list
+          Expanded(child: _CategoryList(result: result, selected: selected)),
+        ],
+      ),
+    );
+  }
+}
+
+class _DonutChart extends ConsumerWidget {
+  final FileTypeResult result;
+  final String?        selected;
+  const _DonutChart({required this.result, required this.selected});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final sections = result.categories.map((cat) {
+      final isSelected = selected == null || selected == cat.name;
+      return PieChartSectionData(
+        value:          cat.percentOfDisk,
+        color:          _fileTypeColor(cat.name)
+            .withOpacity(isSelected ? 1.0 : 0.25),
+        radius:         selected == cat.name ? 38 : 32,
+        title:          '',
+        showTitle:      false,
+      );
+    }).toList();
+
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        PieChart(
+          PieChartData(
+            sections:         sections,
+            centerSpaceRadius: 64,
+            sectionsSpace:    2,
+            pieTouchData: PieTouchData(
+              touchCallback: (event, response) {
+                if (!event.isInterestedForInteractions) return;
+                final idx = response?.touchedSection?.touchedSectionIndex;
+                if (idx == null || idx < 0) return;
+                final tapped = result.categories[idx].name;
+                ref.read(selectedCategoryProvider.notifier).state =
+                    ref.read(selectedCategoryProvider) == tapped
+                        ? null
+                        : tapped;
+              },
+            ),
+          ),
+        ),
+        Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              result.totalScannedFormatted,
+              style: const TextStyle(
+                color: Color(0xFF00FFFF),
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            const SizedBox(height: 2),
+            Text(
+              'SCANNED',
+              style: TextStyle(
+                color: Colors.white.withOpacity(0.4),
+                fontSize: 10,
+                letterSpacing: 1.2,
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _CategoryList extends ConsumerWidget {
+  final FileTypeResult result;
+  final String?        selected;
+  const _CategoryList({required this.result, required this.selected});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Column(
+      children: result.categories.map((cat) {
+        final isSelected = selected == cat.name;
+        return Container(
+          margin: const EdgeInsets.only(bottom: 4),
+          decoration: BoxDecoration(
+            border: Border(
+              left: BorderSide(
+                color: isSelected
+                    ? _fileTypeColor(cat.name)
+                    : _fileTypeColor(cat.name).withOpacity(0.3),
+                width: 3,
+              ),
+            ),
+          ),
+          child: ExpansionTile(
+            dense:                    true,
+            tilePadding:              const EdgeInsets.symmetric(horizontal: 10),
+            collapsedBackgroundColor: const Color(0xFF0D0F14),
+            backgroundColor:          const Color(0xFF0D0F14),
+            onExpansionChanged: (_) {
+              ref.read(selectedCategoryProvider.notifier).state =
+                  isSelected ? null : cat.name;
+            },
+            title: Row(
+              children: [
+                Container(
+                    width: 10, height: 10,
+                    decoration: BoxDecoration(
+                      color: _fileTypeColor(cat.name),
+                      shape: BoxShape.circle,
+                    )),
+                const SizedBox(width: 8),
+                Text(cat.name.toUpperCase(),
+                    style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                        letterSpacing: 0.8)),
+              ],
+            ),
+            trailing: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(cat.sizeFormatted,
+                    style: TextStyle(
+                        color: _fileTypeColor(cat.name),
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600)),
+                const SizedBox(width: 8),
+                Text('${cat.percentOfDisk}%',
+                    style: TextStyle(
+                        color: Colors.white.withOpacity(0.5), fontSize: 11)),
+                const SizedBox(width: 8),
+                Text('${cat.fileCount} f',
+                    style: TextStyle(
+                        color: Colors.white.withOpacity(0.35), fontSize: 10)),
+                const Icon(Icons.expand_more_rounded,
+                    color: Colors.white38, size: 16),
+              ],
+            ),
+            children: cat.extensions
+                .map((ext) => _ExtRow(ext: ext, catColor: _fileTypeColor(cat.name)))
+                .toList(),
+          ),
+        );
+      }).toList(),
+    );
+  }
+}
+
+class _ExtRow extends StatelessWidget {
+  final FileTypeExtensionEntry ext;
+  final Color                  catColor;
+  const _ExtRow({required this.ext, required this.catColor});
+
+  @override
+  Widget build(BuildContext context) => Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 5),
+        child: Row(
+          children: [
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+              decoration: BoxDecoration(
+                color:        catColor.withOpacity(0.12),
+                borderRadius: BorderRadius.circular(3),
+                border:       Border.all(color: catColor.withOpacity(0.3)),
+              ),
+              child: Text(ext.ext,
+                  style: TextStyle(
+                      color: catColor, fontSize: 10, fontFamily: 'monospace')),
+            ),
+            const Spacer(),
+            Text(ext.sizeFormatted,
+                style: const TextStyle(color: Colors.white70, fontSize: 11)),
+            const SizedBox(width: 12),
+            Text('${ext.percentOfDisk}%',
+                style: TextStyle(
+                    color: Colors.white.withOpacity(0.4), fontSize: 10)),
+            const SizedBox(width: 12),
+            Text('${ext.fileCount} files',
+                style: TextStyle(
+                    color: Colors.white.withOpacity(0.3), fontSize: 10)),
+          ],
+        ),
+      );
+}
+
+Color _fileTypeColor(String category) => switch (category.toLowerCase()) {
+      'media'       => const Color(0xFF00FFFF),
+      'documents'   => const Color(0xFF4CAF50),
+      'executables' => const Color(0xFFFF5252),
+      'archives'    => const Color(0xFFFFB300),
+      'code'        => const Color(0xFF9C27B0),
+      'system'      => Colors.white38,
+      _             => Colors.white12,
+    };

--- a/frontend/gs_anlyzer_ui/test/models/file_type_models_test.dart
+++ b/frontend/gs_anlyzer_ui/test/models/file_type_models_test.dart
@@ -1,0 +1,142 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gs_analyzer_ui/models/file_type_model.dart';
+
+void main() {
+  group('FileTypeExtensionEntry', () {
+    test('FromJson_ParsesAllFields_Correctly', () {
+      final entry = FileTypeExtensionEntry.fromJson({
+        'ext':           '.exe',
+        'fileCount':     619,
+        'percentOfDisk': 21.2,
+        'sizeFormatted': '123.3 MB',
+        'totalBytes':    129236992,
+      });
+
+      expect(entry.ext,           '.exe');
+      expect(entry.fileCount,     619);
+      expect(entry.percentOfDisk, 21.2);
+      expect(entry.sizeFormatted, '123.3 MB');
+      expect(entry.totalBytes,    129236992);
+    });
+
+    test('FromJson_CoercesIntPercentToDouble', () {
+      final entry = FileTypeExtensionEntry.fromJson({
+        'ext':           '.cs',
+        'fileCount':     5,
+        'percentOfDisk': 1,    // comes as int from JSON
+        'sizeFormatted': '50 KB',
+        'totalBytes':    51200,
+      });
+
+      expect(entry.percentOfDisk, isA<double>());
+      expect(entry.percentOfDisk, 1.0);
+    });
+  });
+
+  group('FileTypeCategory', () {
+    final sampleJson = {
+      'name':          'executables',
+      'fileCount':     619,
+      'percentOfDisk': 21.2,
+      'sizeFormatted': '123.3 MB',
+      'totalBytes':    129236992,
+      'extensions': [
+        {
+          'ext':           '.exe',
+          'fileCount':     200,
+          'percentOfDisk': 10.0,
+          'sizeFormatted': '50.0 MB',
+          'totalBytes':    52428800,
+        },
+        {
+          'ext':           '.dll',
+          'fileCount':     419,
+          'percentOfDisk': 11.2,
+          'sizeFormatted': '73.3 MB',
+          'totalBytes':    76808192,
+        },
+      ],
+    };
+
+    test('FromJson_ParsesTopLevelFields', () {
+      final cat = FileTypeCategory.fromJson(sampleJson);
+
+      expect(cat.name,          'executables');
+      expect(cat.fileCount,     619);
+      expect(cat.percentOfDisk, 21.2);
+      expect(cat.sizeFormatted, '123.3 MB');
+      expect(cat.totalBytes,    129236992);
+    });
+
+    test('FromJson_ParsesNestedExtensionsList', () {
+      final cat = FileTypeCategory.fromJson(sampleJson);
+
+      expect(cat.extensions.length,  2);
+      expect(cat.extensions[0].ext, '.exe');
+      expect(cat.extensions[1].ext, '.dll');
+    });
+
+    test('FromJson_EmptyExtensionsList_IsValid', () {
+      final cat = FileTypeCategory.fromJson({...sampleJson, 'extensions': []});
+      expect(cat.extensions, isEmpty);
+    });
+  });
+
+  group('FileTypeResult', () {
+    final sampleJson = {
+      'root':                  r'C:\',
+      'totalScannedFormatted': '582.1 MB',
+      'categories': [
+        {
+          'name':          'code',
+          'fileCount':     196,
+          'percentOfDisk': 71.3,
+          'sizeFormatted': '415.0 MB',
+          'totalBytes':    435159040,
+          'extensions': [
+            {
+              'ext':           '.cs',
+              'fileCount':     196,
+              'percentOfDisk': 71.3,
+              'sizeFormatted': '415.0 MB',
+              'totalBytes':    435159040,
+            }
+          ],
+        },
+      ],
+    };
+
+    test('FromJson_ParsesRootAndTotalFormatted', () {
+      final result = FileTypeResult.fromJson(sampleJson);
+
+      expect(result.root,                  r'C:\');
+      expect(result.totalScannedFormatted, '582.1 MB');
+    });
+
+    test('FromJson_ParsesCategoriesList', () {
+      final result = FileTypeResult.fromJson(sampleJson);
+
+      expect(result.categories.length,       1);
+      expect(result.categories[0].name,      'code');
+      expect(result.categories[0].fileCount, 196);
+    });
+
+    test('FromJson_NestedExtensionsParsedThroughCategories', () {
+      final result = FileTypeResult.fromJson(sampleJson);
+      final exts   = result.categories[0].extensions;
+
+      expect(exts.length,      1);
+      expect(exts[0].ext,      '.cs');
+      expect(exts[0].fileCount, 196);
+    });
+
+    test('FromJson_EmptyCategoriesList_IsValid', () {
+      final result = FileTypeResult.fromJson({
+        'root':                  r'C:\',
+        'totalScannedFormatted': '0 B',
+        'categories':            [],
+      });
+      expect(result.categories, isEmpty);
+    });
+  });
+}

--- a/frontend/gs_anlyzer_ui/test/provider/file_type_provider_test.dart
+++ b/frontend/gs_anlyzer_ui/test/provider/file_type_provider_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gs_analyzer_ui/providers/file_type_provider.dart';
+
+void main() {
+  group('FileTypeNoScanException', () {
+    test('IsAnException', () {
+      expect(const FileTypeNoScanException(), isA<Exception>());
+    });
+
+    test('DoesNotThrowOnConstruction', () {
+      // In Dart — just constructing should not throw
+      expect(() => const FileTypeNoScanException(), returnsNormally);
+      expect(const FileTypeNoScanException(), isNotNull);
+    });
+  });
+
+  group('selectedCategoryProvider', () {
+    test('DefaultsToNull', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      expect(container.read(selectedCategoryProvider), isNull);
+    });
+
+    test('UpdatesToCategoryName', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      container.read(selectedCategoryProvider.notifier).state = 'code';
+
+      expect(container.read(selectedCategoryProvider), 'code');
+    });
+
+    test('CanBeClearedBackToNull', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      container.read(selectedCategoryProvider.notifier).state = 'media';
+      container.read(selectedCategoryProvider.notifier).state = null;
+
+      expect(container.read(selectedCategoryProvider), isNull);
+    });
+
+    test('TappingSameCategoryTwice_StaysSelected', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      container.read(selectedCategoryProvider.notifier).state = 'executables';
+      container.read(selectedCategoryProvider.notifier).state = 'executables';
+
+      expect(container.read(selectedCategoryProvider), 'executables');
+    });
+  });
+
+  group('scanRootProvider', () {
+    test('DefaultsToTheDriveNameKey', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      expect(container.read(scanRootProvider(r'C:\')), r'C:\');
+    });
+
+    test('DifferentDriveKeysAreIndependent', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      expect(container.read(scanRootProvider(r'C:\')), r'C:\');
+      expect(container.read(scanRootProvider(r'D:\')), r'D:\');
+    });
+
+    test('UpdatesToSubfolderPath', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      container
+          .read(scanRootProvider(r'C:\').notifier)
+          .state = r'C:\Users\G00dS0ul\Projects';
+
+      expect(
+        container.read(scanRootProvider(r'C:\')),
+        r'C:\Users\G00dS0ul\Projects',
+      );
+    });
+
+    test('UpdatingOneDrive_DoesNotAffectAnother', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      container.read(scanRootProvider(r'C:\').notifier).state = r'C:\Windows';
+
+      expect(container.read(scanRootProvider(r'D:\')), r'D:\');
+    });
+
+    test('CanResetBackToDriveRoot', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      container.read(scanRootProvider(r'C:\').notifier).state = r'C:\Users';
+      container.read(scanRootProvider(r'C:\').notifier).state = r'C:\';
+
+      expect(container.read(scanRootProvider(r'C:\')), r'C:\');
+    });
+  });
+}


### PR DESCRIPTION
## Overview

Implements the **Deep File Type Analyzer** as specified in the GS Analyzer v2.0 Technical Spec.
A collapsible panel on the Storage screen that shows a donut chart + category breakdown of every
file type on a scanned drive — served instantly from cached scan data with zero filesystem re-walk.

---

## What's New

### Backend

#### `Models/FileTypeScanResult.cs`
- `FileTypeEntry` — serializable `{ Count, Bytes }` stored per extension on `CacheEntry`
- `FileTypeExtensionEntry` — per-extension response shape (`Ext`, `FileCount`, `TotalBytes`, `SizeFormatted`, `PercentOfDisk`)
- `FileTypeCategory` — grouped category response (`Name`, `TotalBytes`, `FileCount`, `PercentOfDisk`, `Extensions[]`)
- `FileTypeScanResult` — top-level response (`Root`, `TotalScannedBytes`, `TotalScannedFormatted`, `ScannedAt`, `Categories[]`)

#### `Engine/DiskScannerEngine.cs`
- Added `Extensions` property to `CacheEntry` — file type data is now **collected during the existing Directory Scanner walk** via `GetDirectorySize()`, zero additional I/O
- Extensions are persisted to `scanner_memory.json` automatically via the existing `SaveMemoryToDisk()` — survives server restarts
- `SaveMemoryToDisk()` calls in `DiskOperationsService` moved to `Task.Run()` to be non-blocking

#### `Interfaces/IFileTypeScanner.cs`
- `Analyze(string root)` — returns `FileTypeScanResult?`, null signals 409 (no prior scan)
- `Invalidate(string root)` — clears `IMemoryCache` entry to force a rebuild

#### `Engine/FileTypeScanner.cs`
- Implements `IFileTypeScanner`
- `BuildFromMemory()` — aggregates `Extensions` from all `DirectorySizeCache` entries under the requested root, **no filesystem access**
- Results cached in `IMemoryCache` for 15 minutes
- 409 guard: returns null if `DirectorySizeCache` has no keys matching root
- `FormatBytes()` helper covering B → KB → MB → GB → TB
- 7-category map: `media`, `documents`, `executables`, `archives`, `code`, `system`, `other`

#### `Controllers/StorageController.cs`
- `GET /api/Storage/scan/filetypes?root=C:\`
- Returns `400` if root missing or path doesn't exist
- Returns `409 { error: "NO_SCAN_CACHED" }` if no Directory Scan has been run for this root
- Returns `200 FileTypeScanResult` on success

#### `Program.cs`
- `builder.Services.AddMemoryCache()`
- `builder.Services.AddSingleton<IFileTypeScanner, FileTypeScanner>()`

---

### Frontend

#### `lib/models/file_type_model.dart`
- `FileTypeExtensionEntry`, `FileTypeCategory`, `FileTypeResult` — all with `fromJson` factories

#### `lib/services/api_service.dart`
- `getFileTypes(String root)` — `GET /api/Storage/scan/filetypes`
- Throws `FileTypeNoScanException` on 409, `Exception` on other failures

#### `lib/providers/file_type_provider.dart`
- `FileTypeNoScanException` — sentinel exception for the "no scan" state
- `selectedCategoryProvider` — `StateProvider<String?>` tracks active donut selection
- `scanRootProvider` — `StateProvider.family<String, String>` keyed by drive name, holds current scan root (defaults to drive name, updated by folder picker)
- `fileTypesProvider` — `FutureProvider.autoDispose.family` keyed by scan root, calls `ApiService`

#### `lib/widgets/file_type_analyzer_panel.dart`
- Collapsible `ExpansionTile` placed below `_DriveDetailCard` in `StorageScreen`
- **Folder picker dialog** — lets user target any subfolder path, not just drive root
- `_DonutChart` — `fl_chart` `PieChart`, `centerSpaceRadius: 64`, tap to select/deselect category
- `_CategoryList` — expandable per-category rows with colored left border, extension drill-down
- States: `_LoadingState`, `_NoScanState` (shows root path + guidance), `_ErrorState`, `_DataView`

#### `lib/screen/storage_screen.dart`
- `FileTypeAnalyzerPanel(driveName: currentDrive.name)` added below the drive detail card

---

## Architecture Notes

**Why extensions live on `CacheEntry` instead of a separate accumulator:**
The Directory Scanner already walks every file during `GetDirectorySize()`. Piggybacking extension
collection there means file type data is populated for free during any scan — no second pass,
no separate data structure to keep in sync. On server restart, `scanner_memory.json` already
persists and restores `DirectorySizeCache`, so extension data survives restarts automatically.

**Why `BuildFromMemory()` is instant:**
It reads `DirectorySizeCache.Extensions` entries already in memory — no `Directory.GetFiles()`
calls, no filesystem I/O at request time. Results are additionally cached in `IMemoryCache`
for 15 minutes so repeat requests within a session are a dictionary lookup.

---

## Testing

| Suite | File | Tests |
|---|---|---|
| Backend | `Engine/FileTypeScannerTests.cs` | 16 |
| Frontend | `test/models/file_type_model_test.dart` | 9 |
| Frontend | `test/provider/file_type_provider_test.dart` | 9 |

**Backend tests cover:** 409 guard, multi-directory aggregation, null-safe `Extensions` handling,
category mapping, unknown extension → `other`, sort order, percent math, `IMemoryCache` hit,
`Invalidate()`, `FormatBytes()` across all 5 size units.

**Frontend tests cover:** `fromJson` parsing for all 3 models, int→double coercion,
`FileTypeNoScanException` type, `selectedCategoryProvider` state transitions,
`scanRootProvider` family isolation across drives.

---

## Endpoints

| Method | Path | Success | Error |
|---|---|---|---|
| `GET` | `/api/Storage/scan/filetypes?root=C:\` | `200 FileTypeScanResult` | `400` bad root · `409` no scan cached |

---
