### PR TITLE
feat: Recoverable delete (recycle bin) with multi-entry undo stack

### DIFF
--- a/backend/Controllers/NukeController.cs
+++ b/backend/Controllers/NukeController.cs
@@ -111,7 +111,17 @@ public class NukeController : ControllerBase
                     return BadRequest(new ApiResponse<object>
                         { Success = false, Message = "CRITICAL OS FILES PROTECTED." });
             }
-            var result = await _nukeService.ObliterateNodeAsync(request.Paths, request.UseRecycleBin);
+
+            if (string.IsNullOrWhiteSpace(request.PlanToken))
+            {
+                return BadRequest(new ApiResponse<object>
+                {
+                    Success = false,
+                    Message = "Execution requires a valid Dry-Run planToken."
+                });
+            }
+
+            var result = await _nukeService.ObliterateNodeAsync(request.Paths, request.PlanToken, request.UseRecycleBin);
 
             var response = new ApiResponse<NukeResultDto>
             {
@@ -130,12 +140,12 @@ public class NukeController : ControllerBase
                 Message = ex.Message
             });
         }
-        catch (UnauthorizedAccessException)
+        catch (UnauthorizedAccessException ex)
         {
             return StatusCode(403, new ApiResponse<object>
             {
                 Success = false,
-                Message = "ACCESS DENIED: OS level restricted"
+                Message = string.IsNullOrEmpty(ex.Message) || ex.Message == "Attempted to perform an unauthorized operation." ? "ACCESS DENIED: OS level restricted" : ex.Message
             });
         }
         catch (Exception ex)

--- a/backend/Controllers/NukeController.cs
+++ b/backend/Controllers/NukeController.cs
@@ -79,13 +79,22 @@ public class NukeController : ControllerBase
     }
 
     [HttpDelete("execute")]
-    public async Task<IActionResult> NukeNode([FromBody] List<string> paths, [FromServices] IDriveDetectionService driveService)
+    public async Task<IActionResult> NukeNode([FromBody] NukeExecuteRequest request, [FromServices] IDriveDetectionService driveService)
     {
         try
         {
+            if (request == null || request.Paths == null || request.Paths.Count == 0)
+            {
+                return BadRequest(new ApiResponse<object>
+                {
+                    Success = false,
+                    Message = "Nuke failed: No target paths were specified."
+                });
+            }
+
             var readyDrives = driveService.GetReadyDrives();
 
-            foreach (var path in paths)
+            foreach (var path in request.Paths)
             {
                 var normalizedRoot = Path.GetPathRoot(path)?.ToUpperInvariant() ?? path.ToUpperInvariant();
                 if (!readyDrives.Any(d => d.Name.ToUpperInvariant() == normalizedRoot))
@@ -102,7 +111,7 @@ public class NukeController : ControllerBase
                     return BadRequest(new ApiResponse<object>
                         { Success = false, Message = "CRITICAL OS FILES PROTECTED." });
             }
-            var result = await _nukeService.ObliterateNodeAsync(paths);
+            var result = await _nukeService.ObliterateNodeAsync(request.Paths, request.UseRecycleBin);
 
             var response = new ApiResponse<NukeResultDto>
             {
@@ -148,6 +157,91 @@ public class NukeController : ControllerBase
         {
             Success = true,
             Message = "Abort Signal received. Brakes applied."
+        });
+    }
+
+    // ──────────────────────────────────────────────
+    //  Undo Endpoints
+    // ──────────────────────────────────────────────
+
+    [HttpGet("undo/peek")]
+    public IActionResult PeekUndo()
+    {
+        var operation = _nukeService.PeekUndo();
+
+        if (operation is null)
+        {
+            return NotFound(new ApiResponse<object>
+            {
+                Success = false,
+                Message = "No undoable operations in the stack."
+            });
+        }
+
+        return Ok(new ApiResponse<NukeOperation>
+        {
+            Success = true,
+            Message = "Most recent undoable operation.",
+            Data = operation
+        });
+    }
+
+    [HttpGet("undo/history")]
+    public IActionResult GetUndoHistory()
+    {
+        var history = _nukeService.GetUndoHistory();
+
+        return Ok(new ApiResponse<IEnumerable<NukeOperation>>
+        {
+            Success = true,
+            Message = "Undo history retrieved.",
+            Data = history
+        });
+    }
+
+    [HttpPost("undo")]
+    public IActionResult UndoLastNuke()
+    {
+        var peeked = _nukeService.PeekUndo();
+
+        if (peeked is null)
+        {
+            return NotFound(new ApiResponse<object>
+            {
+                Success = false,
+                Message = "No undoable operations in the stack."
+            });
+        }
+
+        if (!peeked.UsedRecycleBin)
+        {
+            return Conflict(new ApiResponse<object>
+            {
+                Success = false,
+                Message = "Cannot undo: files were permanently deleted.",
+                Data = new { error = "PERMANENT_DELETE" }
+            });
+        }
+
+        var result = _nukeService.UndoLastNuke();
+
+        return Ok(new ApiResponse<NukeResultDto>
+        {
+            Success = true,
+            Message = "Undo completed — files restored to original locations.",
+            Data = result
+        });
+    }
+
+    [HttpDelete("undo")]
+    public IActionResult ClearUndoStack()
+    {
+        _nukeService.ClearUndoStack();
+
+        return Ok(new ApiResponse<object>
+        {
+            Success = true,
+            Message = "Undo stack cleared."
         });
     }
 }

--- a/backend/Controllers/NukeController.cs
+++ b/backend/Controllers/NukeController.cs
@@ -114,11 +114,7 @@ public class NukeController : ControllerBase
 
             if (string.IsNullOrWhiteSpace(request.PlanToken))
             {
-                return BadRequest(new ApiResponse<object>
-                {
-                    Success = false,
-                    Message = "Execution requires a valid Dry-Run planToken."
-                });
+                throw new UnauthorizedAccessException("Execution requires a valid Dry-Run planToken.");
             }
 
             var result = await _nukeService.ObliterateNodeAsync(request.Paths, request.PlanToken, request.UseRecycleBin);
@@ -209,12 +205,12 @@ public class NukeController : ControllerBase
         });
     }
 
-    [HttpPost("undo")]
-    public IActionResult UndoLastNuke()
+    [HttpPost("undo/{operationId?}")]
+    public IActionResult UndoNuke(string? operationId = null)
     {
-        var peeked = _nukeService.PeekUndo();
+        var result = _nukeService.UndoNuke(operationId);
 
-        if (peeked is null)
+        if (result is null)
         {
             return NotFound(new ApiResponse<object>
             {
@@ -222,18 +218,6 @@ public class NukeController : ControllerBase
                 Message = "No undoable operations in the stack."
             });
         }
-
-        if (!peeked.UsedRecycleBin)
-        {
-            return Conflict(new ApiResponse<object>
-            {
-                Success = false,
-                Message = "Cannot undo: files were permanently deleted.",
-                Data = new { error = "PERMANENT_DELETE" }
-            });
-        }
-
-        var result = _nukeService.UndoLastNuke();
 
         return Ok(new ApiResponse<NukeResultDto>
         {

--- a/backend/Engine/DiskScannerEngine.cs
+++ b/backend/Engine/DiskScannerEngine.cs
@@ -434,4 +434,45 @@ public class DiskScannerEngine : IDiskScannerEngine
             Console.WriteLine($"Error deleting item: {ex.Message}");
         }
     }
+
+    public void InvalidatePaths(IEnumerable<string> paths)
+    {
+        var nukedSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var parentsToRemove = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var subtreePrefixes = new List<string>();
+
+        foreach (var path in paths)
+        {
+            var normalizedPath = Path.GetFullPath(path);
+            nukedSet.Add(normalizedPath);
+
+            subtreePrefixes.Add(
+                normalizedPath.EndsWith(Path.DirectorySeparatorChar.ToString())
+                    ? normalizedPath
+                    : normalizedPath + Path.DirectorySeparatorChar);
+
+            var parent = Path.GetDirectoryName(normalizedPath);
+            while (!string.IsNullOrEmpty(parent))
+            {
+                parentsToRemove.Add(parent);
+                parent = Path.GetDirectoryName(parent);
+            }
+        }
+
+        if (nukedSet.Count == 0) return;
+
+        var keysToRemove = DirectorySizeCache.Keys
+            .Where(k =>
+                nukedSet.Contains(k) ||
+                parentsToRemove.Contains(k) ||
+                subtreePrefixes.Any(prefix => k.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)))
+            .ToList();
+
+        foreach (var key in keysToRemove)
+        {
+            DirectorySizeCache.TryRemove(key, out _);
+        }
+
+        SaveMemoryToDisk();
+    }
 }

--- a/backend/GSInteractiveDeviceAnalyzer.Tests/Controller/NukeControllerTest.cs
+++ b/backend/GSInteractiveDeviceAnalyzer.Tests/Controller/NukeControllerTest.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using GSInteractiveDeviceAnalyzer.Controllers;
+using GSInteractiveDeviceAnalyzer.Interfaces;
+using GSInteractiveDeviceAnalyzer.Models;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace GSInteractiveDeviceAnalyzer.Tests.Controllers;
+
+public class NukeControllerTests
+{
+    private readonly Mock<INukeProtocolService> _service = new();
+    private readonly Mock<IDriveDetectionService> _drives = new();
+    private readonly NukeController _controller;
+
+    public NukeControllerTests()
+    {
+        _controller = new NukeController(_service.Object);
+        DriveReady("C:\\"); // default: C:\ is ready
+    }
+
+    private void DriveReady(params string[] roots) =>
+        _drives.Setup(d => d.GetReadyDrives())
+               .Returns(roots.Select(r => new DriveMetric { Name = r }).ToList());
+
+    private static int Status(IActionResult r) => ((ObjectResult)r).StatusCode ?? 200;
+    private static dynamic Body(IActionResult r) => ((ObjectResult)r).Value!;
+
+    private static NukeOperation Op(bool recoverable) =>
+        new("op-1", DateTime.UtcNow, new() { "C:\\a" }, new() { "C:\\a" }, recoverable, 1);
+
+    [Fact]
+    public async Task Execute_NoPaths_Returns400()
+    {
+        var r = await _controller.NukeNode(new NukeExecuteRequest { Paths = new(), PlanToken = "t" }, _drives.Object);
+        Assert.Equal(400, Status(r));
+        Assert.False((bool)Body(r).Success);
+    }
+
+    [Fact]
+    public async Task Execute_DriveNotReady_Returns400()
+    {
+        DriveReady("D:\\");
+        var r = await _controller.NukeNode(
+            new NukeExecuteRequest { Paths = new() { "C:\\temp\\x" }, PlanToken = "t" }, _drives.Object);
+        Assert.Equal(400, Status(r));
+        Assert.Contains("Drive not ready", (string)Body(r).Message);
+    }
+
+    [Fact]
+    public async Task Execute_ProtectedWindowsPath_Returns400()
+    {
+        var r = await _controller.NukeNode(
+            new NukeExecuteRequest { Paths = new() { "C:\\Windows\\System32" }, PlanToken = "t" }, _drives.Object);
+        Assert.Equal(400, Status(r));
+        Assert.Contains("PROTECTED", (string)Body(r).Message);
+    }
+
+    [Fact]
+    public async Task Execute_EmptyPlanToken_Returns403_AndNeverCallsService()
+    {
+        var r = await _controller.NukeNode(
+            new NukeExecuteRequest { Paths = new() { "C:\\temp\\x" }, PlanToken = "   " }, _drives.Object);
+        Assert.Equal(403, Status(r));
+        Assert.Contains("planToken", (string)Body(r).Message);
+        _service.Verify(s => s.ObliterateNodeAsync(It.IsAny<List<string>>(), It.IsAny<string>(), It.IsAny<bool>()),
+                        Times.Never);
+    }
+
+    [Fact]
+    public async Task Execute_Valid_Returns200_WithResult()
+    {
+        var dto = new NukeResultDto
+        {
+            DeletedFiles = 3,
+            StagedBytes = 100,
+            RecycleBinUsed = true,
+            Recoverable = true,
+            OperationId = "op-1"
+        };
+        _service.Setup(s => s.ObliterateNodeAsync(It.IsAny<List<string>>(), "tok", true)).ReturnsAsync(dto);
+
+        var r = await _controller.NukeNode(
+            new NukeExecuteRequest { Paths = new() { "C:\\temp\\x" }, PlanToken = "tok", UseRecycleBin = true },
+            _drives.Object);
+
+        Assert.Equal(200, Status(r));
+        Assert.True((bool)Body(r).Success);
+        Assert.Equal("op-1", (string)Body(r).Data.OperationId);
+    }
+
+    [Fact]
+    public async Task Execute_InvalidOrReusedToken_Returns403()
+    {
+        _service.Setup(s => s.ObliterateNodeAsync(It.IsAny<List<string>>(), It.IsAny<string>(), It.IsAny<bool>()))
+                .ThrowsAsync(new UnauthorizedAccessException("Path 'C:\\temp\\x' was not part of the previewed plan."));
+
+        var r = await _controller.NukeNode(
+            new NukeExecuteRequest { Paths = new() { "C:\\temp\\x" }, PlanToken = "stale" }, _drives.Object);
+
+        Assert.Equal(403, Status(r));
+        Assert.Contains("previewed plan", (string)Body(r).Message);
+    }
+
+    [Fact]
+    public async Task Execute_MissingFile_Returns404()
+    {
+        _service.Setup(s => s.ObliterateNodeAsync(It.IsAny<List<string>>(), It.IsAny<string>(), It.IsAny<bool>()))
+                .ThrowsAsync(new FileNotFoundException("gone"));
+
+        var r = await _controller.NukeNode(
+            new NukeExecuteRequest { Paths = new() { "C:\\temp\\x" }, PlanToken = "tok" }, _drives.Object);
+
+        Assert.Equal(404, Status(r));
+    }
+
+    [Fact]
+    public void Peek_None_Returns404()
+    {
+        _service.Setup(s => s.PeekUndo()).Returns((NukeOperation?)null);
+        Assert.Equal(404, Status(_controller.PeekUndo()));
+    }
+
+    [Fact]
+    public void Peek_Found_Returns200()
+    {
+        _service.Setup(s => s.PeekUndo()).Returns(Op(recoverable: true));
+        var r = _controller.PeekUndo();
+        Assert.Equal(200, Status(r));
+        Assert.Equal("op-1", (string)Body(r).Data.OperationId);
+    }
+
+    [Fact]
+    public void Undo_NothingToUndo_Returns404()
+    {
+        _service.Setup(s => s.UndoNuke(null)).Returns((NukeResultDto?)null);
+        Assert.Equal(404, Status(_controller.UndoNuke()));
+        _service.Verify(s => s.UndoNuke(null), Times.Once);
+    }
+
+    [Fact]
+    public void Undo_Recoverable_Returns200()
+    {
+        _service.Setup(s => s.UndoNuke(null))
+                .Returns(new NukeResultDto { DeletedFiles = 1, Recoverable = true, OperationId = "op-1" });
+
+        var r = _controller.UndoNuke();
+        Assert.Equal(200, Status(r));
+        Assert.True((bool)Body(r).Success);
+    }
+
+    [Fact]
+    public void History_Returns200_WithList()
+    {
+        _service.Setup(s => s.GetUndoHistory()).Returns(new List<NukeOperation> { Op(true) });
+        Assert.Equal(200, Status(_controller.GetUndoHistory()));
+    }
+
+    [Fact]
+    public void Clear_Returns200_AndClearsStack()
+    {
+        var r = _controller.ClearUndoStack();
+        Assert.Equal(200, Status(r));
+        _service.Verify(s => s.ClearUndoStack(), Times.Once);
+    }
+
+    [Fact]
+    public void Abort_Returns200_AndSignalsService()
+    {
+        var r = _controller.AbortNuke();
+        Assert.Equal(200, Status(r));
+        _service.Verify(s => s.TriggerNukeAbort(), Times.Once);
+    }
+}

--- a/backend/GSInteractiveDeviceAnalyzer.Tests/Controller/StorageControllerAgeHeatmapTest.cs
+++ b/backend/GSInteractiveDeviceAnalyzer.Tests/Controller/StorageControllerAgeHeatmapTest.cs
@@ -17,11 +17,6 @@ namespace GSInteractiveDeviceAnalyzer.Tests.Controllers
             return new StorageController(diskService.Object, duplicateDetector.Object);
         }
 
-        /// <summary>
-        /// GetAgeHeatmap checks Directory.Exists before it calls Analyze.
-        /// We need a real directory that exists on disk so the controller
-        /// doesn't short-circuit with 400. Use the temp folder.
-        /// </summary>
         private static string ExistingRoot => Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar);
 
         [Fact]

--- a/backend/GSInteractiveDeviceAnalyzer.Tests/Services/NukeProtocolServiceTests.cs
+++ b/backend/GSInteractiveDeviceAnalyzer.Tests/Services/NukeProtocolServiceTests.cs
@@ -1,148 +1,250 @@
-using GSInteractiveDeviceAnalyzer.Engine;
-using GSInteractiveDeviceAnalyzer.Hubs;
-using GSInteractiveDeviceAnalyzer.Interfaces;
-using GSInteractiveDeviceAnalyzer.Models;
-using GSInteractiveDeviceAnalyzer.Services;
-using Microsoft.AspNetCore.SignalR;
-using Moq;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using GSInteractiveDeviceAnalyzer.Models.SettingDtos;
+using GSInteractiveDeviceAnalyzer.Hubs;
+using GSInteractiveDeviceAnalyzer.Interfaces;
+using GSInteractiveDeviceAnalyzer.Services;
+using Microsoft.AspNetCore.SignalR;
+using Moq;
 using Xunit;
 
-namespace GSInteractiveDeviceAnalyzer.Tests;
+namespace GSInteractiveDeviceAnalyzer.Tests.Services;
 
 public class NukeProtocolServiceTests : IDisposable
 {
-    private readonly string _sandboxRoot;
-    private readonly NukeProtocolService _service;
-    private readonly Mock<DiskScannerEngine> _mockScanner;
-    private readonly Mock<IHubContext<SystemHub>> _mockHub;
+    private readonly string _workDir;
+    private readonly string _stagingBase;
+    private readonly Mock<IDiskScannerEngine> _scanner = new();
 
     public NukeProtocolServiceTests()
     {
-        _sandboxRoot = Path.Combine(Path.GetTempPath(), $"NukeTest_{Guid.NewGuid()}");
-        Directory.CreateDirectory(_sandboxRoot);
+        _workDir = Path.Combine(Path.GetTempPath(), "gsnuke_work_" + Guid.NewGuid().ToString("N"));
+        _stagingBase = Path.Combine(Path.GetTempPath(), "gsnuke_stage_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_workDir);
+        Directory.CreateDirectory(_stagingBase);
 
-        _mockHub = new Mock<IHubContext<SystemHub>>();
-
-        // 1. Create the Settings Mock
-        var mockSettings = new Mock<ISettingService>();
-
-        // 2. 🚀 CRITICAL: Mock the 'Current' property so the base constructor doesn't throw a NullReferenceException if it reads from it!
-        mockSettings.Setup(s => s.Current).Returns(AppSettingDto.GetFactoryDefaults());
-
-        // 3. 🚀 CRITICAL: Pass exactly 2 arguments to match the real constructor, avoiding the runtime MissingMethodException!
-        _mockScanner = new Mock<DiskScannerEngine>(_mockHub.Object, mockSettings.Object);
-
-        _service = new NukeProtocolService(_mockScanner.Object, _mockHub.Object);
+        _scanner.Setup(s => s.NukeToken()).Returns(CancellationToken.None);
+        _scanner.Setup(s => s.InvalidatePaths(It.IsAny<IEnumerable<string>>()));
     }
 
     public void Dispose()
     {
-        if (Directory.Exists(_sandboxRoot))
+        foreach (var d in new[] { _workDir, _stagingBase })
+            try { if (Directory.Exists(d)) Directory.Delete(d, true); } catch { /* ignore */ }
+    }
+
+    private NukeProtocolService CreateService()
+    {
+        var hub = new Mock<IHubContext<SystemHub>>();
+        var clients = new Mock<IHubClients>();
+        var proxy = new Mock<IClientProxy>();
+        clients.Setup(c => c.All).Returns(proxy.Object);
+        hub.Setup(h => h.Clients).Returns(clients.Object);
+        proxy.Setup(p => p.SendCoreAsync(It.IsAny<string>(), It.IsAny<object?[]>(), It.IsAny<CancellationToken>()))
+             .Returns(Task.CompletedTask);
+
+        return new NukeProtocolService(_scanner.Object, hub.Object, runStartupCleanup: false)
         {
-            Directory.Delete(_sandboxRoot, true);
-        }
+            StagingBaseResolver = _ => _stagingBase
+        };
+    }
+
+    private string NewFile(string content = "hello world")
+    {
+        var path = Path.Combine(_workDir, $"f_{Guid.NewGuid():N}.txt");
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    private static async Task<string> TokenFor(NukeProtocolService svc, params string[] paths)
+        => (await svc.PreviewNukeAsync(new List<string>(paths))).PlanToken;
+
+    [Fact]
+    public async Task Obliterate_EmptyToken_Throws()
+    {
+        var svc = CreateService();
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(
+            () => svc.ObliterateNodeAsync(new() { NewFile() }, "", useRecycleBin: false));
     }
 
     [Fact]
-    public async Task Preview_IsStrictlyReadOnly_DoesNotDeleteFiles()
+    public async Task Obliterate_UnknownToken_Throws()
     {
-        // Arrange
-        var testFile = Path.Combine(_sandboxRoot, "keep_me.txt");
-        await File.WriteAllTextAsync(testFile, "This data must survive.");
-        var paths = new List <string> { _sandboxRoot };
-
-        // Act
-        var result = await _service.PreviewNukeAsync(paths, CancellationToken.None);
-
-        // Assert
-        Assert.True(File.Exists(testFile), "The preview endpoint accidentally deleted a file!");
-        Assert.Equal(1, result.TotalFiles);
+        var svc = CreateService();
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(
+            () => svc.ObliterateNodeAsync(new() { NewFile() }, "not-a-real-token", useRecycleBin: false));
     }
 
     [Fact]
-    public async Task Preview_CorrectlySumsSizesrecursively_ForNestedDirectories()
+    public async Task Obliterate_PathNotInPlan_Throws_AndDoesNotDelete()
     {
-        // Arrange
-        var subFolder = Path.Combine(_sandboxRoot, "SubFolder");
-        var subsubFolder = Path.Combine(subFolder, "SubSubFolder");
-        Directory.CreateDirectory(subsubFolder);
+        var svc = CreateService();
+        var planned = NewFile();
+        var notPlanned = NewFile();
+        var token = await TokenFor(svc, planned); // token bound to `planned` only
 
-        var file1 = Path.Combine(subFolder, "file1.dat");
-        var file2 = Path.Combine(subsubFolder, "file2.dat");
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(
+            () => svc.ObliterateNodeAsync(new() { planned, notPlanned }, token, useRecycleBin: false));
 
-        await File.WriteAllBytesAsync(file1, new byte[10]);
-        await File.WriteAllBytesAsync(file2, new byte[20]);
-
-        var paths = new List<string> { _sandboxRoot };
-
-        // Act
-        var result = await _service.PreviewNukeAsync(paths, CancellationToken.None);
-
-        // Assert
-        Assert.Equal(2, result.TotalFiles);
-        Assert.Equal(30, result.TotalBytes);
+        Assert.True(File.Exists(planned)); // nothing deleted — validation runs first
+        Assert.True(File.Exists(notPlanned));
     }
 
     [Fact]
-    public async Task Preview_InaccesibleFiles_AreExcludedWithoutCrashing()
+    public async Task Obliterate_TokenIsSingleUse()
     {
-        // Arrange
-        var accessibleFile = Path.Combine(_sandboxRoot, "open.txt");
-        await File.WriteAllBytesAsync(accessibleFile, new byte[50]);
+        var svc = CreateService();
+        var file = NewFile();
+        var token = await TokenFor(svc, file);
 
-        var fakeRoute = Path.Combine(_sandboxRoot, "NonExistentSecureFolder");
+        await svc.ObliterateNodeAsync(new() { file }, token, useRecycleBin: true); // consumes token
 
-        var paths = new List<string> { _sandboxRoot, fakeRoute };
-
-        // Act
-        var result = await _service.PreviewNukeAsync(paths, CancellationToken.None);
-
-        // Assert: this should skip the fake file and count the open one only
-        Assert.Equal(1, result.TotalFiles);
-        Assert.Equal(50, result.TotalBytes);
-        
+        var file2 = NewFile();
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(
+            () => svc.ObliterateNodeAsync(new() { file2 }, token, useRecycleBin: true));
     }
 
-    [Theory]
-    [InlineData(0, "0.0 B")]
-    [InlineData(1024, "1.0 KB")]
-    [InlineData(5242880, "5.0 MB")]
-    public async Task Preview_TotalFormatted_MatchesTotalBytesInHumanReadableForm(long byteSize, string expectedFormat)
+    [Fact]
+    public async Task RecycleBin_Stages_SetsStagedBytes_AndIsRecoverable()
     {
-        // Arrange
-        if (byteSize > 0)
+        var svc = CreateService();
+        var file = NewFile("123456"); // 6 bytes
+        var token = await TokenFor(svc, file);
+
+        var result = await svc.ObliterateNodeAsync(new() { file }, token, useRecycleBin: true);
+
+        Assert.False(File.Exists(file));
+        Assert.True(result.RecycleBinUsed);
+        Assert.True(result.Recoverable);
+        Assert.Equal(1, result.DeletedFiles);
+        Assert.Equal(6, result.StagedBytes);
+        Assert.Equal(0, result.FreedBytes);
+        Assert.NotNull(svc.PeekUndo()); // recoverable op is peekable
+        Assert.Single(svc.GetUndoHistory());
+    }
+
+    [Fact]
+    public async Task Permanent_Deletes_SetsFreedBytes_NotRecoverable_NotPeekable()
+    {
+        var svc = CreateService();
+        var file = NewFile("123456");
+        var token = await TokenFor(svc, file);
+
+        var result = await svc.ObliterateNodeAsync(new() { file }, token, useRecycleBin: false);
+
+        Assert.False(File.Exists(file));
+        Assert.False(result.Recoverable);
+        Assert.Equal(6, result.FreedBytes);
+        Assert.Equal(0, result.StagedBytes);
+        Assert.Null(svc.PeekUndo()); // permanent op is filtered out of peek
+        Assert.Single(svc.GetUndoHistory()); // still recorded in history
+    }
+
+    [Fact]
+    public async Task GhostPath_IsSkipped()
+    {
+        var svc = CreateService();
+        var ghost = Path.Combine(_workDir, "does_not_exist.txt");
+        var token = await TokenFor(svc, ghost);
+
+        var result = await svc.ObliterateNodeAsync(new() { ghost }, token, useRecycleBin: false);
+
+        Assert.Equal(1, result.SkippedFiles);
+        Assert.Equal(0, result.DeletedFiles);
+    }
+
+    [Fact]
+    public async Task Undo_RestoresFile_ToOriginalPath()
+    {
+        var svc = CreateService();
+        var file = NewFile("payload");
+        var token = await TokenFor(svc, file);
+        await svc.ObliterateNodeAsync(new() { file }, token, useRecycleBin: true);
+
+        var undo = svc.UndoNuke();
+
+        Assert.NotNull(undo);
+        Assert.Equal(1, undo!.DeletedFiles); // reused field = restored count
+        Assert.Equal(0, undo.SkippedFiles);
+        Assert.True(File.Exists(file));
+        Assert.Equal("payload", File.ReadAllText(file));
+        Assert.Null(svc.PeekUndo()); // op consumed
+    }
+
+    [Fact]
+    public async Task Undo_SkipsPermanentOnTop_RestoresRecoverableBeneath()
+    {
+        var svc = CreateService();
+        var recoverable = NewFile("keepme");
+        var permanent = NewFile("byebye");
+
+        var t1 = await TokenFor(svc, recoverable);
+        await svc.ObliterateNodeAsync(new() { recoverable }, t1, useRecycleBin: true); // op A (bottom)
+
+        var t2 = await TokenFor(svc, permanent);
+        await svc.ObliterateNodeAsync(new() { permanent }, t2, useRecycleBin: false); // op B (top, permanent)
+
+        var peeked = svc.PeekUndo();
+        Assert.NotNull(peeked);
+        Assert.True(peeked!.UsedRecycleBin); // skipped the permanent op
+
+        svc.UndoNuke();
+        Assert.True(File.Exists(recoverable)); // recoverable restored
+        Assert.False(File.Exists(permanent)); // permanent stays gone
+    }
+
+    [Fact]
+    public async Task Undo_RestoreCollision_RestoresToUniquePath()
+    {
+        var svc = CreateService();
+        var file = NewFile("original");
+        var token = await TokenFor(svc, file);
+        await svc.ObliterateNodeAsync(new() { file }, token, useRecycleBin: true);
+
+        // Recreate a different file at the original path before undo
+        File.WriteAllText(file, "new occupant");
+
+        svc.UndoNuke();
+
+        Assert.Equal("new occupant", File.ReadAllText(file)); // current file untouched
+        var dir = Path.GetDirectoryName(file)!;
+        var name = Path.GetFileNameWithoutExtension(file);
+        var restored = Path.Combine(dir, $"{name}_Restored_1.txt");
+        Assert.True(File.Exists(restored));
+        Assert.Equal("original", File.ReadAllText(restored));
+    }
+
+    [Fact]
+    public async Task Clear_EmptiesStack_AndRemovesStaging()
+    {
+        var svc = CreateService();
+        var file = NewFile();
+        var token = await TokenFor(svc, file);
+        var result = await svc.ObliterateNodeAsync(new() { file }, token, useRecycleBin: true);
+
+        svc.ClearUndoStack();
+
+        Assert.Empty(svc.GetUndoHistory());
+        Assert.False(Directory.Exists(Path.Combine(_stagingBase, ".gsanalyzer_trash", result.OperationId)));
+    }
+
+    [Fact]
+    public async Task UndoStack_CapsAtFive_EvictsOldest_AndCleansItsStaging()
+    {
+        var svc = CreateService();
+        string? oldestOpId = null;
+
+        for (int i = 0; i < 6; i++)
         {
-            var file = Path.Combine(_sandboxRoot, "format_test.dat");
-            await File.WriteAllBytesAsync(file, new byte[byteSize]);
+            var file = NewFile();
+            var token = await TokenFor(svc, file);
+            var result = await svc.ObliterateNodeAsync(new() { file }, token, useRecycleBin: true);
+            oldestOpId ??= result.OperationId; // first one = oldest, should be evicted
         }
-        var paths = new List<string> { _sandboxRoot };
 
-        // Act
-        var result = await _service.PreviewNukeAsync(paths, CancellationToken.None);
-
-        // Assert
-        Assert.Equal(expectedFormat, result.TotalFormatted);
-    }
-
-    [Fact]
-    public async Task Preview_EmptyPathsArray_ReturnsZeroTotals()
-    {
-        // Arrange 
-        var paths = new List<string>();
-
-        // Act
-        var result = await _service.PreviewNukeAsync(paths, CancellationToken.None);
-
-        // Assert (empty paths array returns zero totals)
-        Assert.Equal(0, result.TotalFiles);
-        Assert.Equal(0, result.TotalBytes);
-        Assert.Equal("0.0 B", result.TotalFormatted);
-        Assert.Empty(result.Breakdown);
+        Assert.Equal(5, svc.GetUndoHistory().Count);
+        Assert.False(Directory.Exists(Path.Combine(_stagingBase, ".gsanalyzer_trash", oldestOpId!)));
     }
 }

--- a/backend/GSInteractiveDeviceAnalyzer.csproj
+++ b/backend/GSInteractiveDeviceAnalyzer.csproj
@@ -24,9 +24,6 @@
     <PackageReference Include="System.Management" Version="10.0.8" />
   </ItemGroup>
 
-  <!-- Recycle Bin API (Microsoft.VisualBasic.FileIO) — Windows only -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-windows'">
-    <FrameworkReference Include="Microsoft.WindowsDesktop.App" />
-  </ItemGroup>
+
 
 </Project>

--- a/backend/GSInteractiveDeviceAnalyzer.csproj
+++ b/backend/GSInteractiveDeviceAnalyzer.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -22,6 +22,11 @@
     <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.6" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="10.0.8" />
     <PackageReference Include="System.Management" Version="10.0.8" />
+  </ItemGroup>
+
+  <!-- Recycle Bin API (Microsoft.VisualBasic.FileIO) — Windows only -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0-windows'">
+    <FrameworkReference Include="Microsoft.WindowsDesktop.App" />
   </ItemGroup>
 
 </Project>

--- a/backend/Interfaces/IDiskScannerEngine.cs
+++ b/backend/Interfaces/IDiskScannerEngine.cs
@@ -1,7 +1,13 @@
-﻿namespace GSInteractiveDeviceAnalyzer.Interfaces
+using System.Collections.Generic;
+using System.Threading;
+
+namespace GSInteractiveDeviceAnalyzer.Interfaces
 {
     public interface IDiskScannerEngine
     {
         void ClearCache();
+        CancellationToken NukeToken();
+        void TriggerNukeAbort();
+        void InvalidatePaths(IEnumerable<string> paths);
     }
 }

--- a/backend/Interfaces/INukeProtocolService.cs
+++ b/backend/Interfaces/INukeProtocolService.cs
@@ -13,7 +13,7 @@ namespace GSInteractiveDeviceAnalyzer.Interfaces
 
         // Undo stack operations
         NukeOperation? PeekUndo();
-        NukeResultDto? UndoLastNuke();
+        NukeResultDto? UndoNuke(string? operationId = null);
         List<NukeOperation> GetUndoHistory();
         void ClearUndoStack();
     }

--- a/backend/Interfaces/INukeProtocolService.cs
+++ b/backend/Interfaces/INukeProtocolService.cs
@@ -8,7 +8,7 @@ namespace GSInteractiveDeviceAnalyzer.Interfaces
     public interface INukeProtocolService
     {
         Task<NukePreviewResponse> PreviewNukeAsync(List<string> paths, CancellationToken cancellationToken = default);
-        Task<NukeResultDto> ObliterateNodeAsync(List<string> paths, bool useRecycleBin = false);
+        Task<NukeResultDto> ObliterateNodeAsync(List<string> paths, string planToken, bool useRecycleBin = false);
         void TriggerNukeAbort();
 
         // Undo stack operations

--- a/backend/Interfaces/INukeProtocolService.cs
+++ b/backend/Interfaces/INukeProtocolService.cs
@@ -8,7 +8,13 @@ namespace GSInteractiveDeviceAnalyzer.Interfaces
     public interface INukeProtocolService
     {
         Task<NukePreviewResponse> PreviewNukeAsync(List<string> paths, CancellationToken cancellationToken = default);
-        Task<NukeResultDto> ObliterateNodeAsync(List<string> paths);
+        Task<NukeResultDto> ObliterateNodeAsync(List<string> paths, bool useRecycleBin = false);
         void TriggerNukeAbort();
+
+        // Undo stack operations
+        NukeOperation? PeekUndo();
+        NukeResultDto? UndoLastNuke();
+        List<NukeOperation> GetUndoHistory();
+        void ClearUndoStack();
     }
 }

--- a/backend/Models/NukeExecuteRequest.cs
+++ b/backend/Models/NukeExecuteRequest.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace GSInteractiveDeviceAnalyzer.Models;
+
+public class NukeExecuteRequest
+{
+    public List<string> Paths { get; set; } = new();
+    public bool UseRecycleBin { get; set; } = false;
+}

--- a/backend/Models/NukeExecuteRequest.cs
+++ b/backend/Models/NukeExecuteRequest.cs
@@ -5,5 +5,6 @@ namespace GSInteractiveDeviceAnalyzer.Models;
 public class NukeExecuteRequest
 {
     public List<string> Paths { get; set; } = new();
+    public string PlanToken { get; set; } = string.Empty;
     public bool UseRecycleBin { get; set; } = false;
 }

--- a/backend/Models/NukeOperation.cs
+++ b/backend/Models/NukeOperation.cs
@@ -11,5 +11,6 @@ public record NukeOperation(
     DateTime ExecutedAt,
     List<string> OriginalPaths,
     List<string> DeletedPaths,
-    bool UsedRecycleBin
+    bool UsedRecycleBin,
+    int DeletedFiles
 );

--- a/backend/Models/NukeOperation.cs
+++ b/backend/Models/NukeOperation.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+
+namespace GSInteractiveDeviceAnalyzer.Models;
+
+/// <summary>
+/// Represents a completed nuke operation stored in the session-scoped undo stack.
+/// </summary>
+public record NukeOperation(
+    string OperationId,
+    DateTime ExecutedAt,
+    List<string> OriginalPaths,
+    List<string> DeletedPaths,
+    bool UsedRecycleBin
+);

--- a/backend/Models/NukePreviewResponse.cs
+++ b/backend/Models/NukePreviewResponse.cs
@@ -7,5 +7,6 @@ public class NukePreviewResponse
     public int TotalFiles { get; set; }
     public long TotalBytes { get; set; }
     public string TotalFormatted { get; set; } = string.Empty;
+    public string PlanToken { get; set; } = string.Empty;
     public List<NukePathBreakdown> Breakdown { get; set; } = new();
 }

--- a/backend/Models/NukeResultDto.cs
+++ b/backend/Models/NukeResultDto.cs
@@ -5,6 +5,8 @@ namespace GSInteractiveDeviceAnalyzer.Models
         public int DeletedFiles { get; set; }
         public long FreedBytes { get; set; }
         public string FreedFormatted { get; set; } = string.Empty;
+        public long StagedBytes { get; set; }
+        public string StagedFormatted { get; set; } = string.Empty;
         public int SkippedFiles { get; set; }
         public bool RecycleBinUsed { get; set; }
         public bool Recoverable { get; set; }

--- a/backend/Models/NukeResultDto.cs
+++ b/backend/Models/NukeResultDto.cs
@@ -1,9 +1,13 @@
-﻿namespace GSInteractiveDeviceAnalyzer.Models
+namespace GSInteractiveDeviceAnalyzer.Models
 {
     public class NukeResultDto
     {
-        public string Message { get; set; } = string.Empty;
-        public string Path { get; set; } = string.Empty;
-        public string Type { get; set; } = string.Empty;
+        public int DeletedFiles { get; set; }
+        public long FreedBytes { get; set; }
+        public string FreedFormatted { get; set; } = string.Empty;
+        public int SkippedFiles { get; set; }
+        public bool RecycleBinUsed { get; set; }
+        public bool Recoverable { get; set; }
+        public string OperationId { get; set; } = string.Empty;
     }
 }

--- a/backend/Services/NukeProtocolService.cs
+++ b/backend/Services/NukeProtocolService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -23,15 +24,15 @@ public class NukeProtocolService : INukeProtocolService
     private readonly object _undoLock = new();
     private const int MaxUndoEntries = 5;
 
-    // Staging directory for recoverable deletes
-    private static readonly string StagingRoot = Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-        "GSAnalyzer", "nuke_trash");
+    // Cache of active plan tokens to their normalized paths
+    private readonly ConcurrentDictionary<string, HashSet<string>> _activePlanTokens = new();
 
     public NukeProtocolService(DiskScannerEngine scanner, IHubContext<SystemHub> hubContext)
     {
         _scanner = scanner;
         _hubContext = hubContext;
+
+        Task.Run(() => CleanupOrphanedStagingDirs());
     }
 
     public async Task<NukePreviewResponse> PreviewNukeAsync(List<string> paths, CancellationToken cancellationToken = default)
@@ -103,13 +104,39 @@ public class NukeProtocolService : INukeProtocolService
 
             response.TotalFormatted = FormatSize(response.TotalBytes);
 
+            var planToken = Guid.NewGuid().ToString("N");
+            response.PlanToken = planToken;
+
+            var normalizedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach(var p in paths) {
+                normalizedPaths.Add(Path.GetFullPath(p));
+            }
+            _activePlanTokens.TryAdd(planToken, normalizedPaths);
+
             return response;
 
         }, cancellationToken);
     }
 
-    public async Task<NukeResultDto> ObliterateNodeAsync(List<string> paths, bool useRecycleBin = false)
+    public async Task<NukeResultDto> ObliterateNodeAsync(List<string> paths, string planToken, bool useRecycleBin = false)
     {
+        if (string.IsNullOrWhiteSpace(planToken) || !_activePlanTokens.TryGetValue(planToken, out var validPaths))
+        {
+            throw new UnauthorizedAccessException("Execution requires a valid Dry-Run planToken.");
+        }
+
+        foreach(var path in paths)
+        {
+            var normalizedPath = Path.GetFullPath(path);
+            if (!validPaths.Contains(normalizedPath))
+            {
+                throw new UnauthorizedAccessException($"Path '{path}' was not part of the previewed plan.");
+            }
+        }
+
+        // Remove the token so it can't be reused
+        _activePlanTokens.TryRemove(planToken, out _);
+
         var totalNodes = paths.Count;
         var processedNodes = 0;
         var cancelToken = _scanner.NukeToken();
@@ -121,15 +148,13 @@ public class NukeProtocolService : INukeProtocolService
         // Counters for the new result shape
         int deletedFiles = 0;
         long freedBytes = 0;
+        long stagedBytes = 0;
         int skippedFiles = 0;
         var deletedPaths = new List<string>();
         var aborted = false;
 
         // Generate a unique operation ID for undo tracking
-        var operationId = $"nuke-{DateTime.UtcNow:yyyy-MM-ddTHH-mm-ss}";
-        var stagingDir = useRecycleBin
-            ? Path.Combine(StagingRoot, operationId)
-            : null;
+        var operationId = $"nuke-{Guid.NewGuid():N}";
 
         foreach (var path in paths)
         {
@@ -148,7 +173,7 @@ public class NukeProtocolService : INukeProtocolService
 
                     if (useRecycleBin)
                     {
-                        MoveToStaging(path, stagingDir!, isDirectory: false);
+                        MoveToStaging(path, operationId, isDirectory: false);
                     }
                     else
                     {
@@ -162,7 +187,8 @@ public class NukeProtocolService : INukeProtocolService
                     }
 
                     deletedFiles++;
-                    freedBytes += fileSize;
+                    if (useRecycleBin) stagedBytes += fileSize;
+                    else freedBytes += fileSize;
                     deletedPaths.Add(path);
                 }
                 else if (Directory.Exists(path))
@@ -172,7 +198,7 @@ public class NukeProtocolService : INukeProtocolService
 
                     if (useRecycleBin)
                     {
-                        MoveToStaging(path, stagingDir!, isDirectory: true);
+                        MoveToStaging(path, operationId, isDirectory: true);
                     }
                     else
                     {
@@ -180,7 +206,8 @@ public class NukeProtocolService : INukeProtocolService
                     }
 
                     deletedFiles += fileCount;
-                    freedBytes += totalSize;
+                    if (useRecycleBin) stagedBytes += totalSize;
+                    else freedBytes += totalSize;
                     deletedPaths.Add(path);
                 }
                 else
@@ -189,8 +216,6 @@ public class NukeProtocolService : INukeProtocolService
                     continue; // ghost path
                 }
 
-
-                InvalidateCacheBatch(new List<string> { path });
 
                 processedNodes++;
 
@@ -242,6 +267,8 @@ public class NukeProtocolService : INukeProtocolService
             DeletedFiles = deletedFiles,
             FreedBytes = freedBytes,
             FreedFormatted = FormatSize(freedBytes),
+            StagedBytes = stagedBytes,
+            StagedFormatted = FormatSize(stagedBytes),
             SkippedFiles = skippedFiles,
             RecycleBinUsed = useRecycleBin,
             Recoverable = useRecycleBin && deletedPaths.Count > 0,
@@ -257,8 +284,11 @@ public class NukeProtocolService : INukeProtocolService
     /// Moves a file or directory to the staging area, preserving its original
     /// path structure so it can be restored later.
     /// </summary>
-    private void MoveToStaging(string originalPath, string stagingDir, bool isDirectory)
+    private void MoveToStaging(string originalPath, string operationId, bool isDirectory)
     {
+        var driveRoot = Path.GetPathRoot(originalPath) ?? "C:\\";
+        var stagingDir = Path.Combine(driveRoot, ".gsanalyzer_trash", operationId);
+
         // Preserve the full path inside staging so we know where to restore.
         // e.g. "C:/projects/old" → "{stagingDir}/C/projects/old"
         var relativePath = originalPath
@@ -273,13 +303,19 @@ public class NukeProtocolService : INukeProtocolService
 
         if (isDirectory)
         {
-            // Clear read-only attributes before moving
+            // Clear only read-only attributes before moving, preserving others
             var dir = new DirectoryInfo(originalPath);
             foreach (var info in dir.GetFileSystemInfos("*", SearchOption.AllDirectories))
             {
-                info.Attributes = FileAttributes.Normal;
+                if ((info.Attributes & FileAttributes.ReadOnly) != 0)
+                {
+                    info.Attributes &= ~FileAttributes.ReadOnly;
+                }
             }
-            dir.Attributes = FileAttributes.Normal;
+            if ((dir.Attributes & FileAttributes.ReadOnly) != 0)
+            {
+                dir.Attributes &= ~FileAttributes.ReadOnly;
+            }
 
             Directory.Move(originalPath, destination);
         }
@@ -288,31 +324,24 @@ public class NukeProtocolService : INukeProtocolService
             var attributes = File.GetAttributes(originalPath);
             if ((attributes & FileAttributes.ReadOnly) != 0)
             {
-                File.SetAttributes(originalPath, FileAttributes.Normal);
+                File.SetAttributes(originalPath, attributes & ~FileAttributes.ReadOnly);
             }
             File.Move(originalPath, destination);
         }
     }
 
-    /// <summary>
-    /// Restores files from the staging directory back to their original paths.
-    /// </summary>
     private (int restoredCount, int failedCount) RestoreFromStaging(NukeOperation operation)
     {
-        var stagingDir = Path.Combine(StagingRoot, operation.OperationId);
         int restored = 0;
         int failed = 0;
-
-        if (!Directory.Exists(stagingDir))
-        {
-            Console.WriteLine($"[UNDO] Staging directory not found: {stagingDir}");
-            return (0, operation.DeletedPaths.Count);
-        }
 
         foreach (var originalPath in operation.DeletedPaths)
         {
             try
             {
+                var driveRoot = Path.GetPathRoot(originalPath) ?? "C:\\";
+                var stagingDir = Path.Combine(driveRoot, ".gsanalyzer_trash", operation.OperationId);
+
                 var relativePath = originalPath
                     .Replace(":", "_DRIVE_")
                     .Replace("\\", "/");
@@ -326,7 +355,8 @@ public class NukeProtocolService : INukeProtocolService
                     if (!string.IsNullOrEmpty(parentDir) && !Directory.Exists(parentDir))
                         Directory.CreateDirectory(parentDir);
 
-                    Directory.Move(stagedPath, originalPath);
+                    var finalPath = GetUniqueRestorePath(originalPath);
+                    Directory.Move(stagedPath, finalPath);
                     restored++;
                 }
                 else if (File.Exists(stagedPath))
@@ -335,7 +365,8 @@ public class NukeProtocolService : INukeProtocolService
                     if (!string.IsNullOrEmpty(parentDir) && !Directory.Exists(parentDir))
                         Directory.CreateDirectory(parentDir);
 
-                    File.Move(stagedPath, originalPath);
+                    var finalPath = GetUniqueRestorePath(originalPath);
+                    File.Move(stagedPath, finalPath);
                     restored++;
                 }
                 else
@@ -352,17 +383,46 @@ public class NukeProtocolService : INukeProtocolService
         }
 
         // Clean up staging directory for this operation
-        try
+        var drives = operation.OriginalPaths
+            .Select(p => Path.GetPathRoot(p))
+            .Where(r => !string.IsNullOrEmpty(r))
+            .Distinct();
+
+        foreach (var drive in drives)
         {
-            if (Directory.Exists(stagingDir))
-                Directory.Delete(stagingDir, true);
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"[UNDO] Failed to clean staging directory: {ex.Message}");
+            var stagingDir = Path.Combine(drive!, ".gsanalyzer_trash", operation.OperationId);
+            try
+            {
+                if (Directory.Exists(stagingDir))
+                    Directory.Delete(stagingDir, true);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[UNDO] Failed to clean staging directory {stagingDir}: {ex.Message}");
+            }
         }
 
         return (restored, failed);
+    }
+
+    private string GetUniqueRestorePath(string originalPath)
+    {
+        if (!File.Exists(originalPath) && !Directory.Exists(originalPath))
+            return originalPath;
+
+        var directory = Path.GetDirectoryName(originalPath) ?? string.Empty;
+        var name = Path.GetFileNameWithoutExtension(originalPath);
+        var ext = Path.GetExtension(originalPath);
+
+        int count = 1;
+        while (true)
+        {
+            var newName = $"{name}_Restored_{count}{ext}";
+            var newPath = Path.Combine(directory, newName);
+            if (!File.Exists(newPath) && !Directory.Exists(newPath))
+                return newPath;
+            count++;
+        }
     }
 
     // ──────────────────────────────────────────────
@@ -398,39 +458,32 @@ public class NukeProtocolService : INukeProtocolService
     {
         lock (_undoLock)
         {
-            return _undoStack.Count > 0 ? _undoStack.Peek() : null;
+            return _undoStack.FirstOrDefault(op => op.UsedRecycleBin);
         }
     }
 
     public NukeResultDto? UndoLastNuke()
     {
-        NukeOperation operation;
+        NukeOperation operation = null;
 
         lock (_undoLock)
         {
             if (_undoStack.Count == 0)
                 return null;
 
-            operation = _undoStack.Pop();
-        }
+            var items = _undoStack.ToList();
+            var targetIndex = items.FindIndex(op => op.UsedRecycleBin);
 
-        if (!operation.UsedRecycleBin)
-        {
-            // Can't undo permanent deletes — push it back and return null marker
-            lock (_undoLock)
-            {
-                _undoStack.Push(operation);
-            }
-            return new NukeResultDto
-            {
-                DeletedFiles = 0,
-                FreedBytes = 0,
-                FreedFormatted = "0 B",
-                SkippedFiles = 0,
-                RecycleBinUsed = false,
-                Recoverable = false,
-                OperationId = operation.OperationId
-            };
+            if (targetIndex == -1)
+                return null;
+
+            operation = items[targetIndex];
+            items.RemoveAt(targetIndex);
+
+            _undoStack.Clear();
+            items.Reverse();
+            foreach (var item in items)
+                _undoStack.Push(item);
         }
 
         var (restoredCount, failedCount) = RestoreFromStaging(operation);
@@ -443,6 +496,8 @@ public class NukeProtocolService : INukeProtocolService
             DeletedFiles = restoredCount,       // reusing field — "restored files" in undo context
             FreedBytes = 0,
             FreedFormatted = "0 B",
+            StagedBytes = 0,
+            StagedFormatted = "0 B",
             SkippedFiles = failedCount,
             RecycleBinUsed = true,
             Recoverable = false,                // no longer recoverable after undo
@@ -467,15 +522,23 @@ public class NukeProtocolService : INukeProtocolService
     {
         if (!operation.UsedRecycleBin) return;
 
-        try
+        var drives = operation.OriginalPaths
+            .Select(p => Path.GetPathRoot(p))
+            .Where(r => !string.IsNullOrEmpty(r))
+            .Distinct();
+
+        foreach (var drive in drives)
         {
-            var stagingDir = Path.Combine(StagingRoot, operation.OperationId);
-            if (Directory.Exists(stagingDir))
-                Directory.Delete(stagingDir, true);
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"[UNDO] Failed to clean staging for {operation.OperationId}: {ex.Message}");
+            var stagingDir = Path.Combine(drive!, ".gsanalyzer_trash", operation.OperationId);
+            try
+            {
+                if (Directory.Exists(stagingDir))
+                    Directory.Delete(stagingDir, true);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[UNDO] Failed to clean staging {stagingDir} for {operation.OperationId}: {ex.Message}");
+            }
         }
     }
 
@@ -598,5 +661,75 @@ public class NukeProtocolService : INukeProtocolService
     public void TriggerNukeAbort()
     {
         _scanner.TriggerNukeAbort();
+    }
+
+    // ──────────────────────────────────────────────
+    //  Startup Cleanup
+    // ──────────────────────────────────────────────
+
+    private void CleanupOrphanedStagingDirs()
+    {
+        long totalFreed = 0;
+
+        // 1. Clean up old StagingRoot (AppData) if it exists
+        try
+        {
+            var oldStagingRoot = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "GSAnalyzer", "nuke_trash");
+
+            if (Directory.Exists(oldStagingRoot))
+            {
+                totalFreed += GetDirectorySize(oldStagingRoot);
+                Directory.Delete(oldStagingRoot, true);
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[NUKE STARTUP] Failed to clean old staging root: {ex.Message}");
+        }
+
+        // 2. Clean up per-volume .gsanalyzer_trash
+        foreach (var drive in DriveInfo.GetDrives())
+        {
+            if (!drive.IsReady) continue;
+
+            try
+            {
+                var stagingDir = Path.Combine(drive.RootDirectory.FullName, ".gsanalyzer_trash");
+                if (Directory.Exists(stagingDir))
+                {
+                    totalFreed += GetDirectorySize(stagingDir);
+                    Directory.Delete(stagingDir, true);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[NUKE STARTUP] Failed to clean staging dir on {drive.Name}: {ex.Message}");
+            }
+        }
+
+        if (totalFreed > 0)
+        {
+            Console.WriteLine($"[NUKE STARTUP] Cleaned up {FormatSize(totalFreed)} of orphaned nuke trash.");
+        }
+    }
+
+    private long GetDirectorySize(string path)
+    {
+        long size = 0;
+        try
+        {
+            var dirInfo = new DirectoryInfo(path);
+            foreach (var file in dirInfo.EnumerateFiles("*", SearchOption.AllDirectories))
+            {
+                size += file.Length;
+            }
+        }
+        catch 
+        {
+            // Ignore access issues during size calculation
+        }
+        return size;
     }
 }

--- a/backend/Services/NukeProtocolService.cs
+++ b/backend/Services/NukeProtocolService.cs
@@ -28,13 +28,7 @@ public class NukeProtocolService : INukeProtocolService
     // Cache of active plan tokens to their normalized paths (TTL 15 mins)
     private readonly MemoryCache _activePlanTokens = new MemoryCache(new MemoryCacheOptions());
 
-    public NukeProtocolService(DiskScannerEngine scanner, IHubContext<SystemHub> hubContext)
-    {
-        _scanner = scanner;
-        _hubContext = hubContext;
 
-        Task.Run(() => CleanupOrphanedStagingDirs());
-    }
 
     public async Task<NukePreviewResponse> PreviewNukeAsync(List<string> paths, CancellationToken cancellationToken = default)
     {

--- a/backend/Services/NukeProtocolService.cs
+++ b/backend/Services/NukeProtocolService.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using GSInteractiveDeviceAnalyzer.Engine;
@@ -16,11 +18,22 @@ public class NukeProtocolService : INukeProtocolService
     private readonly DiskScannerEngine _scanner;
     private readonly IHubContext<SystemHub> _hubContext;
 
+    // Session-scoped undo stack — max 5 entries, not persisted across restarts.
+    private readonly Stack<NukeOperation> _undoStack = new();
+    private readonly object _undoLock = new();
+    private const int MaxUndoEntries = 5;
+
+    // Staging directory for recoverable deletes
+    private static readonly string StagingRoot = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "GSAnalyzer", "nuke_trash");
+
     public NukeProtocolService(DiskScannerEngine scanner, IHubContext<SystemHub> hubContext)
     {
         _scanner = scanner;
         _hubContext = hubContext;
     }
+
     public async Task<NukePreviewResponse> PreviewNukeAsync(List<string> paths, CancellationToken cancellationToken = default)
     {
         return await Task.Run(() =>
@@ -95,7 +108,7 @@ public class NukeProtocolService : INukeProtocolService
         }, cancellationToken);
     }
 
-    public async Task<NukeResultDto> ObliterateNodeAsync(List<string> paths)
+    public async Task<NukeResultDto> ObliterateNodeAsync(List<string> paths, bool useRecycleBin = false)
     {
         var totalNodes = paths.Count;
         var processedNodes = 0;
@@ -105,9 +118,18 @@ public class NukeProtocolService : INukeProtocolService
         var lastProgressSent = DateTime.MinValue;
         var progressInterval = TimeSpan.FromMilliseconds(150);
 
-        // Track what we actually removed so the cache is invalidated in ONE pass at the end.
-        var nukedPaths = new List<string>();
+        // Counters for the new result shape
+        int deletedFiles = 0;
+        long freedBytes = 0;
+        int skippedFiles = 0;
+        var deletedPaths = new List<string>();
         var aborted = false;
+
+        // Generate a unique operation ID for undo tracking
+        var operationId = $"nuke-{DateTime.UtcNow:yyyy-MM-ddTHH-mm-ss}";
+        var stagingDir = useRecycleBin
+            ? Path.Combine(StagingRoot, operationId)
+            : null;
 
         foreach (var path in paths)
         {
@@ -121,24 +143,53 @@ public class NukeProtocolService : INukeProtocolService
             {
                 if (File.Exists(path))
                 {
-                    // Only clear attributes when needed — skip a syscall on normal files.
-                    var attributes = File.GetAttributes(path);
-                    if ((attributes & FileAttributes.ReadOnly) != 0)
+                    var fileInfo = new FileInfo(path);
+                    var fileSize = fileInfo.Length;
+
+                    if (useRecycleBin)
                     {
-                        File.SetAttributes(path, FileAttributes.Normal);
+                        MoveToStaging(path, stagingDir!, isDirectory: false);
                     }
-                    File.Delete(path);
+                    else
+                    {
+                        // Only clear attributes when needed — skip a syscall on normal files.
+                        var attributes = File.GetAttributes(path);
+                        if ((attributes & FileAttributes.ReadOnly) != 0)
+                        {
+                            File.SetAttributes(path, FileAttributes.Normal);
+                        }
+                        File.Delete(path);
+                    }
+
+                    deletedFiles++;
+                    freedBytes += fileSize;
+                    deletedPaths.Add(path);
                 }
                 else if (Directory.Exists(path))
                 {
-                    AggressiveObliterate(path);
+                    // Count files and size before deletion
+                    var (fileCount, totalSize) = CountDirectoryContents(path);
+
+                    if (useRecycleBin)
+                    {
+                        MoveToStaging(path, stagingDir!, isDirectory: true);
+                    }
+                    else
+                    {
+                        AggressiveObliterate(path);
+                    }
+
+                    deletedFiles += fileCount;
+                    freedBytes += totalSize;
+                    deletedPaths.Add(path);
                 }
                 else
                 {
+                    skippedFiles++;
                     continue; // ghost path
-                } 
-                
-                
+                }
+
+
                 InvalidateCacheBatch(new List<string> { path });
 
                 processedNodes++;
@@ -161,19 +212,303 @@ public class NukeProtocolService : INukeProtocolService
             catch (Exception ex)
             {
                 Console.WriteLine($"[NUKE ERROR] Failed to Nuke {path}: {ex.Message}");
+                skippedFiles++;
             }
         }
 
         // Invalidate everything we removed in a single cache pass, then persist to disk ONCE.
-        InvalidateCacheBatch(nukedPaths);
+        InvalidateCacheBatch(deletedPaths);
+
+        // Push to undo stack
+        if (deletedPaths.Count > 0)
+        {
+            var operation = new NukeOperation(
+                OperationId: operationId,
+                ExecutedAt: DateTime.UtcNow,
+                OriginalPaths: new List<string>(paths),
+                DeletedPaths: new List<string>(deletedPaths),
+                UsedRecycleBin: useRecycleBin
+            );
+            PushUndo(operation);
+        }
 
         if (aborted)
         {
             await _hubContext.Clients.All.SendAsync("NukeAborted", "OPERATION ABORTED BY USER");
-            return new NukeResultDto { Message = "PARTIAL NUKE: ABORTED" };
         }
 
-        return new NukeResultDto { Message = "CARPET BOMBING COMPLETE" };
+        return new NukeResultDto
+        {
+            DeletedFiles = deletedFiles,
+            FreedBytes = freedBytes,
+            FreedFormatted = FormatSize(freedBytes),
+            SkippedFiles = skippedFiles,
+            RecycleBinUsed = useRecycleBin,
+            Recoverable = useRecycleBin && deletedPaths.Count > 0,
+            OperationId = operationId
+        };
+    }
+
+    // ──────────────────────────────────────────────
+    //  Staging Directory (Recoverable Delete)
+    // ──────────────────────────────────────────────
+
+    /// <summary>
+    /// Moves a file or directory to the staging area, preserving its original
+    /// path structure so it can be restored later.
+    /// </summary>
+    private void MoveToStaging(string originalPath, string stagingDir, bool isDirectory)
+    {
+        // Preserve the full path inside staging so we know where to restore.
+        // e.g. "C:/projects/old" → "{stagingDir}/C/projects/old"
+        var relativePath = originalPath
+            .Replace(":", "_DRIVE_")   // "C:" → "C_DRIVE_"
+            .Replace("\\", "/");
+
+        var destination = Path.Combine(stagingDir, relativePath);
+        var destinationDir = Path.GetDirectoryName(destination);
+
+        if (!string.IsNullOrEmpty(destinationDir))
+            Directory.CreateDirectory(destinationDir);
+
+        if (isDirectory)
+        {
+            // Clear read-only attributes before moving
+            var dir = new DirectoryInfo(originalPath);
+            foreach (var info in dir.GetFileSystemInfos("*", SearchOption.AllDirectories))
+            {
+                info.Attributes = FileAttributes.Normal;
+            }
+            dir.Attributes = FileAttributes.Normal;
+
+            Directory.Move(originalPath, destination);
+        }
+        else
+        {
+            var attributes = File.GetAttributes(originalPath);
+            if ((attributes & FileAttributes.ReadOnly) != 0)
+            {
+                File.SetAttributes(originalPath, FileAttributes.Normal);
+            }
+            File.Move(originalPath, destination);
+        }
+    }
+
+    /// <summary>
+    /// Restores files from the staging directory back to their original paths.
+    /// </summary>
+    private (int restoredCount, int failedCount) RestoreFromStaging(NukeOperation operation)
+    {
+        var stagingDir = Path.Combine(StagingRoot, operation.OperationId);
+        int restored = 0;
+        int failed = 0;
+
+        if (!Directory.Exists(stagingDir))
+        {
+            Console.WriteLine($"[UNDO] Staging directory not found: {stagingDir}");
+            return (0, operation.DeletedPaths.Count);
+        }
+
+        foreach (var originalPath in operation.DeletedPaths)
+        {
+            try
+            {
+                var relativePath = originalPath
+                    .Replace(":", "_DRIVE_")
+                    .Replace("\\", "/");
+
+                var stagedPath = Path.Combine(stagingDir, relativePath);
+
+                if (Directory.Exists(stagedPath))
+                {
+                    // Ensure parent directory exists
+                    var parentDir = Path.GetDirectoryName(originalPath);
+                    if (!string.IsNullOrEmpty(parentDir) && !Directory.Exists(parentDir))
+                        Directory.CreateDirectory(parentDir);
+
+                    Directory.Move(stagedPath, originalPath);
+                    restored++;
+                }
+                else if (File.Exists(stagedPath))
+                {
+                    var parentDir = Path.GetDirectoryName(originalPath);
+                    if (!string.IsNullOrEmpty(parentDir) && !Directory.Exists(parentDir))
+                        Directory.CreateDirectory(parentDir);
+
+                    File.Move(stagedPath, originalPath);
+                    restored++;
+                }
+                else
+                {
+                    Console.WriteLine($"[UNDO] Staged item not found: {stagedPath}");
+                    failed++;
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[UNDO ERROR] Failed to restore {originalPath}: {ex.Message}");
+                failed++;
+            }
+        }
+
+        // Clean up staging directory for this operation
+        try
+        {
+            if (Directory.Exists(stagingDir))
+                Directory.Delete(stagingDir, true);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[UNDO] Failed to clean staging directory: {ex.Message}");
+        }
+
+        return (restored, failed);
+    }
+
+    // ──────────────────────────────────────────────
+    //  Undo Stack
+    // ──────────────────────────────────────────────
+
+    private void PushUndo(NukeOperation operation)
+    {
+        lock (_undoLock)
+        {
+            // Enforce max capacity — drop oldest if at limit
+            if (_undoStack.Count >= MaxUndoEntries)
+            {
+                // Convert to list, remove bottom, rebuild stack
+                var items = _undoStack.ToList();
+                items.Reverse(); // Stack.ToList() gives newest-first — reverse to get chronological order
+                
+                // Remove oldest and clean up its staging directory
+                var oldest = items[0];
+                CleanupStagingForOperation(oldest);
+                items.RemoveAt(0);
+
+                _undoStack.Clear();
+                foreach (var item in items)
+                    _undoStack.Push(item);
+            }
+
+            _undoStack.Push(operation);
+        }
+    }
+
+    public NukeOperation? PeekUndo()
+    {
+        lock (_undoLock)
+        {
+            return _undoStack.Count > 0 ? _undoStack.Peek() : null;
+        }
+    }
+
+    public NukeResultDto? UndoLastNuke()
+    {
+        NukeOperation operation;
+
+        lock (_undoLock)
+        {
+            if (_undoStack.Count == 0)
+                return null;
+
+            operation = _undoStack.Pop();
+        }
+
+        if (!operation.UsedRecycleBin)
+        {
+            // Can't undo permanent deletes — push it back and return null marker
+            lock (_undoLock)
+            {
+                _undoStack.Push(operation);
+            }
+            return new NukeResultDto
+            {
+                DeletedFiles = 0,
+                FreedBytes = 0,
+                FreedFormatted = "0 B",
+                SkippedFiles = 0,
+                RecycleBinUsed = false,
+                Recoverable = false,
+                OperationId = operation.OperationId
+            };
+        }
+
+        var (restoredCount, failedCount) = RestoreFromStaging(operation);
+
+        // Invalidate cache for restored paths so the scanner picks up the restored files
+        InvalidateCacheBatch(operation.DeletedPaths);
+
+        return new NukeResultDto
+        {
+            DeletedFiles = restoredCount,       // reusing field — "restored files" in undo context
+            FreedBytes = 0,
+            FreedFormatted = "0 B",
+            SkippedFiles = failedCount,
+            RecycleBinUsed = true,
+            Recoverable = false,                // no longer recoverable after undo
+            OperationId = operation.OperationId
+        };
+    }
+
+    public void ClearUndoStack()
+    {
+        lock (_undoLock)
+        {
+            // Clean up all staging directories
+            foreach (var operation in _undoStack)
+            {
+                CleanupStagingForOperation(operation);
+            }
+            _undoStack.Clear();
+        }
+    }
+
+    private void CleanupStagingForOperation(NukeOperation operation)
+    {
+        if (!operation.UsedRecycleBin) return;
+
+        try
+        {
+            var stagingDir = Path.Combine(StagingRoot, operation.OperationId);
+            if (Directory.Exists(stagingDir))
+                Directory.Delete(stagingDir, true);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[UNDO] Failed to clean staging for {operation.OperationId}: {ex.Message}");
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    //  Existing Helpers (unchanged)
+    // ──────────────────────────────────────────────
+
+    private (int fileCount, long totalSize) CountDirectoryContents(string path)
+    {
+        int count = 0;
+        long size = 0;
+
+        try
+        {
+            var options = new EnumerationOptions
+            {
+                IgnoreInaccessible = true,
+                RecurseSubdirectories = true,
+                ReturnSpecialDirectories = false
+            };
+
+            foreach (var file in new DirectoryInfo(path).EnumerateFiles("*", options))
+            {
+                count++;
+                size += file.Length;
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[NUKE] Failed to count directory {path}: {ex.Message}");
+        }
+
+        return (count, size);
     }
 
     private void AggressiveObliterate(string targetPath)
@@ -250,6 +585,14 @@ public class NukeProtocolService : INukeProtocolService
         }
 
         return string.Format("{0:n1} {1}", number, suffixes[counter]);
+    }
+
+    public List<NukeOperation> GetUndoHistory()
+    {
+        lock (_undoLock)
+        {
+            return _undoStack.ToList();
+        }
     }
 
     public void TriggerNukeAbort()

--- a/backend/Services/NukeProtocolService.cs
+++ b/backend/Services/NukeProtocolService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.IO;
+using Microsoft.Extensions.Caching.Memory;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -16,7 +17,7 @@ namespace GSInteractiveDeviceAnalyzer.Services;
 
 public class NukeProtocolService : INukeProtocolService
 {
-    private readonly DiskScannerEngine _scanner;
+    private readonly IDiskScannerEngine _scanner;
     private readonly IHubContext<SystemHub> _hubContext;
 
     // Session-scoped undo stack — max 5 entries, not persisted across restarts.
@@ -24,8 +25,8 @@ public class NukeProtocolService : INukeProtocolService
     private readonly object _undoLock = new();
     private const int MaxUndoEntries = 5;
 
-    // Cache of active plan tokens to their normalized paths
-    private readonly ConcurrentDictionary<string, HashSet<string>> _activePlanTokens = new();
+    // Cache of active plan tokens to their normalized paths (TTL 15 mins)
+    private readonly MemoryCache _activePlanTokens = new MemoryCache(new MemoryCacheOptions());
 
     public NukeProtocolService(DiskScannerEngine scanner, IHubContext<SystemHub> hubContext)
     {
@@ -111,7 +112,7 @@ public class NukeProtocolService : INukeProtocolService
             foreach(var p in paths) {
                 normalizedPaths.Add(Path.GetFullPath(p));
             }
-            _activePlanTokens.TryAdd(planToken, normalizedPaths);
+            _activePlanTokens.Set(planToken, normalizedPaths, TimeSpan.FromMinutes(15));
 
             return response;
 
@@ -120,7 +121,7 @@ public class NukeProtocolService : INukeProtocolService
 
     public async Task<NukeResultDto> ObliterateNodeAsync(List<string> paths, string planToken, bool useRecycleBin = false)
     {
-        if (string.IsNullOrWhiteSpace(planToken) || !_activePlanTokens.TryGetValue(planToken, out var validPaths))
+        if (string.IsNullOrWhiteSpace(planToken) || !_activePlanTokens.TryGetValue(planToken, out HashSet<string> validPaths))
         {
             throw new UnauthorizedAccessException("Execution requires a valid Dry-Run planToken.");
         }
@@ -130,12 +131,12 @@ public class NukeProtocolService : INukeProtocolService
             var normalizedPath = Path.GetFullPath(path);
             if (!validPaths.Contains(normalizedPath))
             {
-                throw new UnauthorizedAccessException($"Path '{path}' was not part of the previewed plan.");
+                throw new UnauthorizedAccessException("Target path was not part of the previewed plan.");
             }
         }
 
         // Remove the token so it can't be reused
-        _activePlanTokens.TryRemove(planToken, out _);
+        _activePlanTokens.Remove(planToken);
 
         var totalNodes = paths.Count;
         var processedNodes = 0;
@@ -242,7 +243,7 @@ public class NukeProtocolService : INukeProtocolService
         }
 
         // Invalidate everything we removed in a single cache pass, then persist to disk ONCE.
-        InvalidateCacheBatch(deletedPaths);
+        _scanner.InvalidatePaths(deletedPaths);
 
         // Push to undo stack
         if (deletedPaths.Count > 0)
@@ -252,7 +253,8 @@ public class NukeProtocolService : INukeProtocolService
                 ExecutedAt: DateTime.UtcNow,
                 OriginalPaths: new List<string>(paths),
                 DeletedPaths: new List<string>(deletedPaths),
-                UsedRecycleBin: useRecycleBin
+                UsedRecycleBin: useRecycleBin,
+                DeletedFiles: deletedFiles
             );
             PushUndo(operation);
         }
@@ -276,14 +278,6 @@ public class NukeProtocolService : INukeProtocolService
         };
     }
 
-    // ──────────────────────────────────────────────
-    //  Staging Directory (Recoverable Delete)
-    // ──────────────────────────────────────────────
-
-    /// <summary>
-    /// Moves a file or directory to the staging area, preserving its original
-    /// path structure so it can be restored later.
-    /// </summary>
     private void MoveToStaging(string originalPath, string operationId, bool isDirectory)
     {
         var driveRoot = Path.GetPathRoot(originalPath) ?? "C:\\";
@@ -355,7 +349,7 @@ public class NukeProtocolService : INukeProtocolService
                     if (!string.IsNullOrEmpty(parentDir) && !Directory.Exists(parentDir))
                         Directory.CreateDirectory(parentDir);
 
-                    var finalPath = GetUniqueRestorePath(originalPath);
+                    var finalPath = GetUniqueRestorePath(originalPath, isDirectory: true);
                     Directory.Move(stagedPath, finalPath);
                     restored++;
                 }
@@ -365,7 +359,7 @@ public class NukeProtocolService : INukeProtocolService
                     if (!string.IsNullOrEmpty(parentDir) && !Directory.Exists(parentDir))
                         Directory.CreateDirectory(parentDir);
 
-                    var finalPath = GetUniqueRestorePath(originalPath);
+                    var finalPath = GetUniqueRestorePath(originalPath, isDirectory: false);
                     File.Move(stagedPath, finalPath);
                     restored++;
                 }
@@ -405,14 +399,14 @@ public class NukeProtocolService : INukeProtocolService
         return (restored, failed);
     }
 
-    private string GetUniqueRestorePath(string originalPath)
+    private string GetUniqueRestorePath(string originalPath, bool isDirectory)
     {
         if (!File.Exists(originalPath) && !Directory.Exists(originalPath))
             return originalPath;
 
         var directory = Path.GetDirectoryName(originalPath) ?? string.Empty;
-        var name = Path.GetFileNameWithoutExtension(originalPath);
-        var ext = Path.GetExtension(originalPath);
+        var name = isDirectory ? Path.GetFileName(originalPath) : Path.GetFileNameWithoutExtension(originalPath);
+        var ext = isDirectory ? "" : Path.GetExtension(originalPath);
 
         int count = 1;
         while (true)
@@ -424,10 +418,6 @@ public class NukeProtocolService : INukeProtocolService
             count++;
         }
     }
-
-    // ──────────────────────────────────────────────
-    //  Undo Stack
-    // ──────────────────────────────────────────────
 
     private void PushUndo(NukeOperation operation)
     {
@@ -462,9 +452,9 @@ public class NukeProtocolService : INukeProtocolService
         }
     }
 
-    public NukeResultDto? UndoLastNuke()
+    public NukeResultDto? UndoNuke(string? operationId = null)
     {
-        NukeOperation operation = null;
+        NukeOperation? operation = null;
 
         lock (_undoLock)
         {
@@ -472,7 +462,16 @@ public class NukeProtocolService : INukeProtocolService
                 return null;
 
             var items = _undoStack.ToList();
-            var targetIndex = items.FindIndex(op => op.UsedRecycleBin);
+            int targetIndex;
+
+            if (operationId != null)
+            {
+                targetIndex = items.FindIndex(op => op.OperationId == operationId && op.UsedRecycleBin);
+            }
+            else
+            {
+                targetIndex = items.FindIndex(op => op.UsedRecycleBin);
+            }
 
             if (targetIndex == -1)
                 return null;
@@ -489,7 +488,7 @@ public class NukeProtocolService : INukeProtocolService
         var (restoredCount, failedCount) = RestoreFromStaging(operation);
 
         // Invalidate cache for restored paths so the scanner picks up the restored files
-        InvalidateCacheBatch(operation.DeletedPaths);
+        _scanner.InvalidatePaths(operation.DeletedPaths);
 
         return new NukeResultDto
         {
@@ -542,10 +541,6 @@ public class NukeProtocolService : INukeProtocolService
         }
     }
 
-    // ──────────────────────────────────────────────
-    //  Existing Helpers (unchanged)
-    // ──────────────────────────────────────────────
-
     private (int fileCount, long totalSize) CountDirectoryContents(string path)
     {
         int count = 0;
@@ -587,54 +582,6 @@ public class NukeProtocolService : INukeProtocolService
         dir.Delete(true);
     }
 
-    private void InvalidateCacheBatch(IEnumerable<string> paths)
-    {
-        var nukedSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var parentsToRemove = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var subtreePrefixes = new List<string>();
-
-        foreach (var path in paths)
-        {
-            var normalizedPath = Path.GetFullPath(path);
-            nukedSet.Add(normalizedPath);
-
-            subtreePrefixes.Add(
-                normalizedPath.EndsWith(Path.DirectorySeparatorChar.ToString())
-                    ? normalizedPath
-                    : normalizedPath + Path.DirectorySeparatorChar);
-
-            // Every ancestor's cached size is now stale.
-            var parent = Path.GetDirectoryName(normalizedPath);
-            while (!string.IsNullOrEmpty(parent))
-            {
-                parentsToRemove.Add(parent);
-                parent = Path.GetDirectoryName(parent);
-            }
-        }
-
-        if (nukedSet.Count == 0)
-        {
-            return;
-        }
-
-        // ONE pass over the cache: drop nuked nodes, anything under a nuked directory,
-        // and every affected ancestor directory.
-        var keysToRemove = _scanner.DirectorySizeCache.Keys
-            .Where(k =>
-                nukedSet.Contains(k) ||
-                parentsToRemove.Contains(k) ||
-                subtreePrefixes.Any(prefix => k.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)))
-            .ToList();
-
-        foreach (var key in keysToRemove)
-        {
-            _scanner.DirectorySizeCache.TryRemove(key, out _);
-        }
-
-        // Persist the cache to disk exactly once for the whole batch.
-        _scanner.SaveMemoryToDisk();
-    }
-
     private string FormatSize(long bytes)
     {
         string[] suffixes = { "B", "KB", "MB", "GB", "TB" };
@@ -662,10 +609,6 @@ public class NukeProtocolService : INukeProtocolService
     {
         _scanner.TriggerNukeAbort();
     }
-
-    // ──────────────────────────────────────────────
-    //  Startup Cleanup
-    // ──────────────────────────────────────────────
 
     private void CleanupOrphanedStagingDirs()
     {
@@ -731,5 +674,15 @@ public class NukeProtocolService : INukeProtocolService
             // Ignore access issues during size calculation
         }
         return size;
+    }
+
+    public Func<string, string> StagingBaseResolver { get; set; } = p => Path.GetPathRoot(p) ?? "C:\\";
+
+    public NukeProtocolService(IDiskScannerEngine scanner, IHubContext<SystemHub> hubContext,
+        bool runStartupCleanup = true)
+    {
+        _scanner = scanner;
+        _hubContext = hubContext;
+        if (runStartupCleanup) Task.Run(() => CleanupOrphanedStagingDirs());
     }
 }

--- a/frontend/gs_anlyzer_ui/lib/models/nuke_preview.dart
+++ b/frontend/gs_anlyzer_ui/lib/models/nuke_preview.dart
@@ -18,12 +18,14 @@ class NukePreviewResponse {
   final int totalFiles;
   final int totalBytes;
   final String totalFormatted;
+  final String planToken;
   final List<NukePathBreakdown> breakdown;
 
   NukePreviewResponse({
     required this.totalFiles,
     required this.totalBytes,
     required this.totalFormatted,
+    required this.planToken,
     required this.breakdown,
 });
 
@@ -31,6 +33,11 @@ class NukePreviewResponse {
     var list = json['breakdown'] as List? ?? [];
     List<NukePathBreakdown> breakdownList = list.map((e) => NukePathBreakdown.fromJson(e)).toList();
 
-    return NukePreviewResponse(totalFiles: json['totalFiles'] ?? 0, totalBytes: json['totalBytes'] ?? 0, totalFormatted: json['totalFormatted'] ?? '', breakdown: breakdownList);
+    return NukePreviewResponse(
+        totalFiles: json['totalFiles'] ?? 0, 
+        totalBytes: json['totalBytes'] ?? 0, 
+        totalFormatted: json['totalFormatted'] ?? '', 
+        planToken: json['planToken'] ?? '',
+        breakdown: breakdownList);
   }
 }

--- a/frontend/gs_anlyzer_ui/lib/models/nuke_result.dart
+++ b/frontend/gs_anlyzer_ui/lib/models/nuke_result.dart
@@ -28,6 +28,8 @@ class NukeResultDto {
   final int deletedFiles;
   final int freedBytes;
   final String freedFormatted;
+  final int stagedBytes;
+  final String stagedFormatted;
   final int skippedFiles;
   final bool recycleBinUsed;
   final bool recoverable;
@@ -37,6 +39,8 @@ class NukeResultDto {
     required this.deletedFiles,
     required this.freedBytes,
     required this.freedFormatted,
+    required this.stagedBytes,
+    required this.stagedFormatted,
     required this.skippedFiles,
     required this.recycleBinUsed,
     required this.recoverable,
@@ -48,6 +52,8 @@ class NukeResultDto {
       deletedFiles: json['deletedFiles'] ?? 0,
       freedBytes: json['freedBytes'] ?? 0,
       freedFormatted: json['freedFormatted'] ?? '',
+      stagedBytes: json['stagedBytes'] ?? 0,
+      stagedFormatted: json['stagedFormatted'] ?? '',
       skippedFiles: json['skippedFiles'] ?? 0,
       recycleBinUsed: json['recycleBinUsed'] ?? false,
       recoverable: json['recoverable'] ?? false,

--- a/frontend/gs_anlyzer_ui/lib/models/nuke_result.dart
+++ b/frontend/gs_anlyzer_ui/lib/models/nuke_result.dart
@@ -4,6 +4,7 @@ class NukeOperation {
   final List<String> originalPaths;
   final List<String> deletedPaths;
   final bool usedRecycleBin;
+  final int deletedFiles;
 
   NukeOperation({
     required this.operationId,
@@ -11,6 +12,7 @@ class NukeOperation {
     required this.originalPaths,
     required this.deletedPaths,
     required this.usedRecycleBin,
+    required this.deletedFiles,
   });
 
   factory NukeOperation.fromJson(Map<String, dynamic> json) {
@@ -20,6 +22,7 @@ class NukeOperation {
       originalPaths: List<String>.from(json['originalPaths'] ?? []),
       deletedPaths: List<String>.from(json['deletedPaths'] ?? []),
       usedRecycleBin: json['usedRecycleBin'] ?? false,
+      deletedFiles: json['deletedFiles'] ?? 0,
     );
   }
 }

--- a/frontend/gs_anlyzer_ui/lib/models/nuke_result.dart
+++ b/frontend/gs_anlyzer_ui/lib/models/nuke_result.dart
@@ -1,0 +1,57 @@
+class NukeOperation {
+  final String operationId;
+  final DateTime executedAt;
+  final List<String> originalPaths;
+  final List<String> deletedPaths;
+  final bool usedRecycleBin;
+
+  NukeOperation({
+    required this.operationId,
+    required this.executedAt,
+    required this.originalPaths,
+    required this.deletedPaths,
+    required this.usedRecycleBin,
+  });
+
+  factory NukeOperation.fromJson(Map<String, dynamic> json) {
+    return NukeOperation(
+      operationId: json['operationId'] ?? '',
+      executedAt: json['executedAt'] != null ? DateTime.parse(json['executedAt']) : DateTime.now(),
+      originalPaths: List<String>.from(json['originalPaths'] ?? []),
+      deletedPaths: List<String>.from(json['deletedPaths'] ?? []),
+      usedRecycleBin: json['usedRecycleBin'] ?? false,
+    );
+  }
+}
+
+class NukeResultDto {
+  final int deletedFiles;
+  final int freedBytes;
+  final String freedFormatted;
+  final int skippedFiles;
+  final bool recycleBinUsed;
+  final bool recoverable;
+  final String operationId;
+
+  NukeResultDto({
+    required this.deletedFiles,
+    required this.freedBytes,
+    required this.freedFormatted,
+    required this.skippedFiles,
+    required this.recycleBinUsed,
+    required this.recoverable,
+    required this.operationId,
+  });
+
+  factory NukeResultDto.fromJson(Map<String, dynamic> json) {
+    return NukeResultDto(
+      deletedFiles: json['deletedFiles'] ?? 0,
+      freedBytes: json['freedBytes'] ?? 0,
+      freedFormatted: json['freedFormatted'] ?? '',
+      skippedFiles: json['skippedFiles'] ?? 0,
+      recycleBinUsed: json['recycleBinUsed'] ?? false,
+      recoverable: json['recoverable'] ?? false,
+      operationId: json['operationId'] ?? '',
+    );
+  }
+}

--- a/frontend/gs_anlyzer_ui/lib/screen/storage_screen.dart
+++ b/frontend/gs_anlyzer_ui/lib/screen/storage_screen.dart
@@ -62,7 +62,7 @@ class StorageScreen extends ConsumerWidget {
                     ],
                   ),
                 ),
-                const UndoHistoryPanel(),
+                UndoHistoryPanel(),
               ],
             ),
           )

--- a/frontend/gs_anlyzer_ui/lib/screen/storage_screen.dart
+++ b/frontend/gs_anlyzer_ui/lib/screen/storage_screen.dart
@@ -9,6 +9,7 @@ import 'package:gs_analyzer_ui/providers/directory_provider.dart';
 import 'package:gs_analyzer_ui/providers/storage_view_provider.dart';
 import 'package:gs_analyzer_ui/providers/storage_mode_provider.dart';
 import 'package:gs_analyzer_ui/widgets/file_type_analyzer_panel.dart';
+import 'package:gs_analyzer_ui/widgets/undo_history_panel.dart';
 
 class StorageScreen extends ConsumerWidget {
   const StorageScreen({Key? key}) : super(key: key);
@@ -61,6 +62,7 @@ class StorageScreen extends ConsumerWidget {
                     ],
                   ),
                 ),
+                const UndoHistoryPanel(),
               ],
             ),
           )

--- a/frontend/gs_anlyzer_ui/lib/services/api_service.dart
+++ b/frontend/gs_anlyzer_ui/lib/services/api_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'package:gs_analyzer_ui/models/age_heatmap_model.dart';
 import 'package:gs_analyzer_ui/models/drive_stats.dart';
 import 'package:gs_analyzer_ui/models/nuke_preview.dart';
+import 'package:gs_analyzer_ui/models/nuke_result.dart';
 import 'package:http/http.dart' as http;
 import 'package:gs_analyzer_ui/models/storage_node.dart';
 import 'package:gs_analyzer_ui/models/file_type_model.dart';
@@ -58,23 +59,61 @@ class ApiService {
     }
   }
 
-  Future<bool> executeNuke(List<String> paths) async {
+  Future<NukeResultDto> executeNuke(List<String> paths, {bool useRecycleBin = false}) async {
     final uri = Uri.parse('$nukeUrl/execute');
 
     print("INITIATING NUKE PROTOCOL ON: $uri");
 
-    final response = await http.delete(uri, headers: {'Content-Type': 'application/json'}, body: jsonEncode(paths));
+    final response = await http.delete(uri, headers: {'Content-Type': 'application/json'}, body: jsonEncode({
+      'paths': paths,
+      'useRecycleBin': useRecycleBin
+    }));
 
     if(response.statusCode == 200) {
       final jsonBody = json.decode(response.body);
 
       if (jsonBody['success'] == true) {
-        return true;
+        return NukeResultDto.fromJson(jsonBody['data']);
       } else {
         throw Exception(jsonBody['message']);
       }
     } else {
       throw Exception('Nuke Failed: ${response.statusCode} - ${response.body}');
+    }
+  }
+
+  Future<NukeResultDto> undoNuke() async {
+    final uri = Uri.parse('$nukeUrl/undo');
+    final response = await http.post(uri);
+
+    if (response.statusCode == 200) {
+      final jsonBody = json.decode(response.body);
+      if (jsonBody['success'] == true) {
+        return NukeResultDto.fromJson(jsonBody['data']);
+      } else {
+        throw Exception(jsonBody['message']);
+      }
+    } else if (response.statusCode == 409) {
+      throw Exception('PERMANENT_DELETE');
+    } else {
+      throw Exception('Undo Failed: ${response.statusCode} - ${response.body}');
+    }
+  }
+
+  Future<List<NukeOperation>> getUndoHistory() async {
+    final uri = Uri.parse('$nukeUrl/undo/history');
+    final response = await http.get(uri);
+
+    if (response.statusCode == 200) {
+      final jsonBody = json.decode(response.body);
+      if (jsonBody['success'] == true) {
+        List<dynamic> data = jsonBody['data'];
+        return data.map((json) => NukeOperation.fromJson(json)).toList();
+      } else {
+        throw Exception(jsonBody['message']);
+      }
+    } else {
+      throw Exception('Failed to load undo history: ${response.statusCode} - ${response.body}');
     }
   }
 

--- a/frontend/gs_anlyzer_ui/lib/services/api_service.dart
+++ b/frontend/gs_anlyzer_ui/lib/services/api_service.dart
@@ -83,8 +83,9 @@ class ApiService {
     }
   }
 
-  Future<NukeResultDto> undoNuke() async {
-    final uri = Uri.parse('$nukeUrl/undo');
+  Future<NukeResultDto> undoNuke([String? operationId]) async {
+    final uriStr = operationId != null ? '$nukeUrl/undo?operationId=$operationId' : '$nukeUrl/undo';
+    final uri = Uri.parse(uriStr);
     final response = await http.post(uri);
 
     if (response.statusCode == 200) {
@@ -94,8 +95,6 @@ class ApiService {
       } else {
         throw Exception(jsonBody['message']);
       }
-    } else if (response.statusCode == 409) {
-      throw Exception('PERMANENT_DELETE');
     } else {
       throw Exception('Undo Failed: ${response.statusCode} - ${response.body}');
     }
@@ -115,6 +114,14 @@ class ApiService {
       }
     } else {
       throw Exception('Failed to load undo history: ${response.statusCode} - ${response.body}');
+    }
+  }
+
+  Future<void> clearUndoStack() async {
+    final uri = Uri.parse('$nukeUrl/undo');
+    final response = await http.delete(uri);
+    if (response.statusCode != 200) {
+      throw Exception('Failed to clear undo stack');
     }
   }
 

--- a/frontend/gs_anlyzer_ui/lib/services/api_service.dart
+++ b/frontend/gs_anlyzer_ui/lib/services/api_service.dart
@@ -59,13 +59,14 @@ class ApiService {
     }
   }
 
-  Future<NukeResultDto> executeNuke(List<String> paths, {bool useRecycleBin = false}) async {
+  Future<NukeResultDto> executeNuke(List<String> paths, String planToken, {bool useRecycleBin = false}) async {
     final uri = Uri.parse('$nukeUrl/execute');
 
     print("INITIATING NUKE PROTOCOL ON: $uri");
 
     final response = await http.delete(uri, headers: {'Content-Type': 'application/json'}, body: jsonEncode({
       'paths': paths,
+      'planToken': planToken,
       'useRecycleBin': useRecycleBin
     }));
 

--- a/frontend/gs_anlyzer_ui/lib/services/api_service.dart
+++ b/frontend/gs_anlyzer_ui/lib/services/api_service.dart
@@ -10,6 +10,9 @@ import 'package:gs_analyzer_ui/providers/age_heatmap_provider.dart';
 import 'package:gs_analyzer_ui/providers/file_type_provider.dart';
 
 class ApiService {
+  final http.Client _client;
+  ApiService([http.Client? client]) : _client = client ?? http.Client();
+
   static  const String storageUrl = 'http://localhost:5200/api/storage';
   static const String telemetryUrl = 'http://localhost:5200/api/Telemetry';
   static const String nukeUrl = 'http://localhost:5200/api/nuke';
@@ -22,7 +25,7 @@ class ApiService {
     final uri = Uri.parse('$storageUrl/scan');
     print('MATRIX BRIDGE FIRING TO: $uri (root: $path)');
 
-    final response = await http.post(
+    final response = await _client.post(
       uri,
       headers: {'Content-Type': 'application/json'},
       body: jsonEncode({'Root': path}),
@@ -44,7 +47,7 @@ class ApiService {
   }
 
   Future<DriveStats> getDriveTelemetry(String driveLetter) async {
-    final response = await http.get(Uri.parse('$storageUrl/drive-stats?driveLetter=$driveLetter'));
+    final response = await _client.get(Uri.parse('$storageUrl/drive-stats?driveLetter=$driveLetter'));
 
     if(response.statusCode == 200) {
       final jsonBody = json.decode(response.body);
@@ -64,7 +67,7 @@ class ApiService {
 
     print("INITIATING NUKE PROTOCOL ON: $uri");
 
-    final response = await http.delete(uri, headers: {'Content-Type': 'application/json'}, body: jsonEncode({
+    final response = await _client.delete(uri, headers: {'Content-Type': 'application/json'}, body: jsonEncode({
       'paths': paths,
       'planToken': planToken,
       'useRecycleBin': useRecycleBin
@@ -84,9 +87,9 @@ class ApiService {
   }
 
   Future<NukeResultDto> undoNuke([String? operationId]) async {
-    final uriStr = operationId != null ? '$nukeUrl/undo?operationId=$operationId' : '$nukeUrl/undo';
+    final uriStr = operationId != null ? '$nukeUrl/undo/$operationId' : '$nukeUrl/undo';
     final uri = Uri.parse(uriStr);
-    final response = await http.post(uri);
+    final response = await _client.post(uri);
 
     if (response.statusCode == 200) {
       final jsonBody = json.decode(response.body);
@@ -102,7 +105,7 @@ class ApiService {
 
   Future<List<NukeOperation>> getUndoHistory() async {
     final uri = Uri.parse('$nukeUrl/undo/history');
-    final response = await http.get(uri);
+    final response = await _client.get(uri);
 
     if (response.statusCode == 200) {
       final jsonBody = json.decode(response.body);
@@ -119,7 +122,7 @@ class ApiService {
 
   Future<void> clearUndoStack() async {
     final uri = Uri.parse('$nukeUrl/undo');
-    final response = await http.delete(uri);
+    final response = await _client.delete(uri);
     if (response.statusCode != 200) {
       throw Exception('Failed to clear undo stack');
     }
@@ -128,7 +131,7 @@ class ApiService {
   Future<void> abortNuke() async {
     try {
       print('SENDING NUKE ABORT SIGNAL....');
-      await http.post(Uri.parse('$nukeUrl/abort'));
+      await _client.post(Uri.parse('$nukeUrl/abort'));
     } catch (e) {
       print('Failed to send abort signal: $e');
     }
@@ -137,7 +140,7 @@ class ApiService {
   Future<void> abortScan() async {
     try {
       print('SENDING SCAN ABORT SIGNAL...');
-      await http.post(Uri.parse('$storageUrl/abort-scan'));
+      await _client.post(Uri.parse('$storageUrl/abort-scan'));
     } catch (e) {
       print('Failed to send abort signal: $e');
     }
@@ -147,7 +150,7 @@ class ApiService {
     final uri = Uri.parse('$telemetryUrl/ram/kill');
     print('INITIATING ASSASSINATION PROTOCOL ON ${pids.length}: TARGETS AT:  $uri');
 
-    final response = await http.post(uri, headers: {'Content-Type': 'application/json'}, body: jsonEncode(pids));
+    final response = await _client.post(uri, headers: {'Content-Type': 'application/json'}, body: jsonEncode(pids));
 
     if(response.statusCode == 200) {
       return true;
@@ -159,7 +162,7 @@ class ApiService {
   Future<void> startRamRadar() async {
     final uri = Uri.parse('$telemetryUrl/ram/start');
     try {
-      final response = await http.post(uri);
+      final response = await _client.post(uri);
       if (response.statusCode == 200) {
         print('FLUTTER COMMAND: RAM Radar Started Successfully!');
       }
@@ -171,7 +174,7 @@ class ApiService {
   Future<void> startCpuRadar() async {
     final uri = Uri.parse('$telemetryUrl/cpu-load');
     try {
-      final response = await http.get(uri);
+      final response = await _client.get(uri);
       if (response.statusCode == 200) {
         print('FLUTTER COMMAND: CPU Radar Started Successfully!');
       } else {
@@ -186,14 +189,14 @@ class ApiService {
     final uri = Uri.parse('$storageUrl/stream-sector').replace(queryParameters: {
       'path': path
     });
-    await http.post(uri);
+    await _client.post(uri);
   }
 
   Future<List<dynamic>> scanForDuplicates(String path) async {
     final uri = Uri.parse('$storageUrl/duplicates');
     print('INITIATING DUPLICATE HUNTER ON: $uri (root: $path)');
 
-    final response = await http.post(
+    final response = await _client.post(
       uri,
       headers: {'Content-Type': 'application/json'},
       body: jsonEncode({'Root': path}),
@@ -223,7 +226,7 @@ class ApiService {
 
     print('INITIATING LARGE FILE HUNTER ON: $uri');
 
-    final response = await http.get(uri);
+    final response = await _client.get(uri);
 
     if (response.statusCode == 200) {
       final jsonBody = jsonDecode(response.body);
@@ -243,7 +246,7 @@ class ApiService {
     print('MATRIX BRIDGE: Requesting Instant Thermal Snapshot...');
 
     try {
-      final response = await http.get(uri);
+      final response = await _client.get(uri);
 
       if (response.statusCode == 200) {
         final jsonBody = jsonDecode(response.body);
@@ -268,7 +271,7 @@ class ApiService {
     final uri = Uri.parse('$nukeUrl/preview');
     print('MATRIX BRIDGE: REQUESTING BLAST RADIUS FOR ${paths.length} TARGETTs');
 
-    final response = await http.post(
+    final response = await _client.post(
       uri,
       headers: {'Content-Type': 'application/json'},
       body: jsonEncode({'paths': paths}),
@@ -289,7 +292,7 @@ class ApiService {
 
   Future<Map<String, dynamic>?> getSettings() async {
     try {
-      final response = await http.get(Uri.parse(settingsUrl));
+      final response = await _client.get(Uri.parse(settingsUrl));
       if (response.statusCode == 200) return jsonDecode(response.body)['data'];
     } catch (e) {
       print('[API] Settings Fetch Error: $e');
@@ -299,7 +302,7 @@ class ApiService {
 
   Future<Map<String, dynamic>?> saveSettings(Map<String, dynamic> payload) async {
     try {
-      final response = await http.post(Uri.parse(settingsUrl), headers: {'Content-Type': 'application/json'}, body: jsonEncode(payload));
+      final response = await _client.post(Uri.parse(settingsUrl), headers: {'Content-Type': 'application/json'}, body: jsonEncode(payload));
       return jsonDecode(response.body);
     } catch (e) {
       return {'success': false, 'message': 'Network Error'};
@@ -308,7 +311,7 @@ class ApiService {
 
   Future<Map<String, dynamic>?> resetSettings() async {
     try {
-      final response = await http.post(Uri.parse('$settingsUrl/reset'));
+      final response = await _client.post(Uri.parse('$settingsUrl/reset'));
       if (response.statusCode == 200) return jsonDecode(response.body)['data'];
     } catch (e) {
       print('[API] Reset Error: $e');
@@ -318,7 +321,7 @@ class ApiService {
 
   Future<List<dynamic>?> getDrives() async {
     try {
-      final response = await http.get(Uri.parse(driveUrl));
+      final response = await _client.get(Uri.parse(driveUrl));
 
       if (response.statusCode == 200) {
         final decoded = jsonDecode(response.body);
@@ -336,7 +339,7 @@ class ApiService {
   final uri = Uri.parse('$storageUrl/scan/filetypes')
       .replace(queryParameters: {'root': root});
 
-  final response = await http.get(uri);
+  final response = await _client.get(uri);
 
   if (response.statusCode == 409) {
     throw FileTypeNoScanException();
@@ -355,7 +358,7 @@ class ApiService {
 
   Future<bool> clearCache() async {
   try {
-    final response = await http.post(Uri.parse('$settingsUrl/cache/clear'));
+    final response = await _client.post(Uri.parse('$settingsUrl/cache/clear'));
     if (response.statusCode == 200) {
       print('[API] Cache cleared successfully.');
       return true;
@@ -374,7 +377,7 @@ class ApiService {
 
     print('MATRIX BRIDGE: Requesting Age Heatmap for $root');
 
-    final response = await http.get(uri);
+    final response = await _client.get(uri);
 
     if (response.statusCode == 409) {
       throw AgeHeatmapNoScanException();
@@ -391,4 +394,5 @@ class ApiService {
     );
   }
 }
+
 

--- a/frontend/gs_anlyzer_ui/lib/utils/nuke_protocol.dart
+++ b/frontend/gs_anlyzer_ui/lib/utils/nuke_protocol.dart
@@ -44,7 +44,7 @@ Future<void> executeNukeProtocol(BuildContext context, WidgetRef ref, {String? f
   final masterNavigator = Navigator.of(context, rootNavigator: true);
   try {
     final api = ApiService();
-    final result = await api.executeNuke(targetsToNuke, useRecycleBin: previewResult.useRecycleBin);
+    final result = await api.executeNuke(targetsToNuke, previewResult.planToken, useRecycleBin: previewResult.useRecycleBin);
 
     masterNavigator.pop();
 
@@ -73,7 +73,7 @@ Future<void> executeNukeProtocol(BuildContext context, WidgetRef ref, {String? f
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             Text(
-              '${result.freedFormatted} MOVED TO RECYCLE BIN',
+              '${result.stagedFormatted} MOVED TO RECYCLE BIN',
               style: const TextStyle(fontFamily: HudTheme.fontCore, fontWeight: FontWeight.bold),
             ),
             TextButton(

--- a/frontend/gs_anlyzer_ui/lib/utils/nuke_protocol.dart
+++ b/frontend/gs_anlyzer_ui/lib/utils/nuke_protocol.dart
@@ -24,13 +24,13 @@ Future<void> executeNukeProtocol(BuildContext context, WidgetRef ref, {String? f
   ref.invalidate(nukeCompletedProvider);
   ref.invalidate(nukeTargetProvider);
 
-  final confirmExecute = await showDialog<bool>(
+  final previewResult = await showDialog<NukePreviewResult>(
     context: context,
     barrierDismissible: false,
     builder: (context) => NukePreviewDialog(targetPaths: targetsToNuke),
   );
 
-  if (confirmExecute != true) {
+  if (previewResult == null || !previewResult.confirmed) {
     print('MATRIX: Nuke Sequence Aborted by System Administrator at Preview');
     return;
   }
@@ -44,7 +44,7 @@ Future<void> executeNukeProtocol(BuildContext context, WidgetRef ref, {String? f
   final masterNavigator = Navigator.of(context, rootNavigator: true);
   try {
     final api = ApiService();
-    bool allSuccess = await api.executeNuke(targetsToNuke);
+    final result = await api.executeNuke(targetsToNuke, useRecycleBin: previewResult.useRecycleBin);
 
     masterNavigator.pop();
 
@@ -65,15 +65,54 @@ Future<void> executeNukeProtocol(BuildContext context, WidgetRef ref, {String? f
     ref.invalidate(rootTreeProvider);
     ref.read(drivesProvider.notifier).refresh();
 
-    snackbarKey.currentState?.showSnackBar(SnackBar(
-      behavior: SnackBarBehavior.floating,
-      content: Text(
-        allSuccess ? (isBulk ? 'ALL TARGET NUKED SUCCESSFULLY' : 'TARGET NUKED SUCCESSFULLY') : 'PARTIAL NUKE: Some Files were Locked',
-        style: TextStyle(fontFamily: HudTheme.fontCore, fontWeight: FontWeight.bold,),
-      ),
-      backgroundColor: allSuccess ? HudTheme.accentGreen : HudTheme.accentAmber,
-    ),
-    );
+    if (result.recycleBinUsed) {
+      snackbarKey.currentState?.showSnackBar(SnackBar(
+        behavior: SnackBarBehavior.floating,
+        duration: const Duration(days: 365), // practically persistent
+        content: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              '${result.freedFormatted} MOVED TO RECYCLE BIN',
+              style: const TextStyle(fontFamily: HudTheme.fontCore, fontWeight: FontWeight.bold),
+            ),
+            TextButton(
+              onPressed: () async {
+                snackbarKey.currentState?.hideCurrentSnackBar();
+                try {
+                  final undoResult = await api.undoNuke();
+                  snackbarKey.currentState?.showSnackBar(SnackBar(
+                    content: Text('RESTORED ${undoResult.deletedFiles} FILES', style: const TextStyle(fontFamily: HudTheme.fontCore, fontWeight: FontWeight.bold)),
+                    backgroundColor: HudTheme.accentGreen,
+                  ));
+                  // Refresh directory view
+                  ref.invalidate(rootTreeProvider);
+                  ref.read(drivesProvider.notifier).refresh();
+                  final currentPath = ref.read(directoryProvider).currentPath;
+                  await ref.read(directoryProvider.notifier).scanDirectory(currentPath);
+                } catch (e) {
+                  snackbarKey.currentState?.showSnackBar(SnackBar(
+                    content: Text(e.toString() == 'Exception: PERMANENT_DELETE' ? 'CANNOT UNDO — FILES PERMANENTLY DELETED' : 'UNDO FAILED: $e', style: const TextStyle(fontFamily: HudTheme.fontCore)),
+                    backgroundColor: HudTheme.accentRed,
+                  ));
+                }
+              },
+              child: const Text('[UNDO]', style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold)),
+            ),
+          ],
+        ),
+        backgroundColor: HudTheme.accentAmber,
+      ));
+    } else {
+      snackbarKey.currentState?.showSnackBar(SnackBar(
+        behavior: SnackBarBehavior.floating,
+        content: Text(
+          '${result.freedFormatted} PERMANENTLY DELETED',
+          style: const TextStyle(fontFamily: HudTheme.fontCore, fontWeight: FontWeight.bold,),
+        ),
+        backgroundColor: HudTheme.accentGreen,
+      ));
+    }
   } catch (e) {
     masterNavigator.pop();
     snackbarKey.currentState?.showSnackBar(SnackBar(content: Text('ERROR: $e', style: TextStyle(fontFamily: HudTheme.fontCore),), backgroundColor: HudTheme.accentRed));

--- a/frontend/gs_anlyzer_ui/lib/utils/nuke_protocol.dart
+++ b/frontend/gs_anlyzer_ui/lib/utils/nuke_protocol.dart
@@ -10,6 +10,7 @@ import 'package:gs_analyzer_ui/utils/globals.dart';
 import 'package:gs_analyzer_ui/utils/hud_theme.dart';
 import '../widgets/nuke_preview_dialog.dart';
 import '../widgets/nuke_progress_dialog.dart';
+import '../widgets/undo_history_panel.dart';
 
 Future<void> executeNukeProtocol(BuildContext context, WidgetRef ref, {String? fileName, String? filePath, List<String>? customPath, VoidCallback? onComplete}) async {
   final dirState = ref.read(directoryProvider);
@@ -64,11 +65,12 @@ Future<void> executeNukeProtocol(BuildContext context, WidgetRef ref, {String? f
 
     ref.invalidate(rootTreeProvider);
     ref.read(drivesProvider.notifier).refresh();
+    ref.invalidate(undoHistoryProvider);
 
     if (result.recycleBinUsed) {
       snackbarKey.currentState?.showSnackBar(SnackBar(
         behavior: SnackBarBehavior.floating,
-        duration: const Duration(days: 365), // practically persistent
+        duration: const Duration(seconds: 15), 
         content: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
@@ -92,7 +94,7 @@ Future<void> executeNukeProtocol(BuildContext context, WidgetRef ref, {String? f
                   await ref.read(directoryProvider.notifier).scanDirectory(currentPath);
                 } catch (e) {
                   snackbarKey.currentState?.showSnackBar(SnackBar(
-                    content: Text(e.toString() == 'Exception: PERMANENT_DELETE' ? 'CANNOT UNDO — FILES PERMANENTLY DELETED' : 'UNDO FAILED: $e', style: const TextStyle(fontFamily: HudTheme.fontCore)),
+                    content: Text('UNDO FAILED: $e', style: const TextStyle(fontFamily: HudTheme.fontCore)),
                     backgroundColor: HudTheme.accentRed,
                   ));
                 }

--- a/frontend/gs_anlyzer_ui/lib/widgets/directory_node_widget.dart
+++ b/frontend/gs_anlyzer_ui/lib/widgets/directory_node_widget.dart
@@ -266,12 +266,13 @@ class _DirectoryNodeWidgetState extends ConsumerState<DirectoryNodeWidget> {
                   child: Text(
                     widget.node.lastModified.toString().split('.')[0],
                     style: HudTheme.bodyText,
+                    textAlign: TextAlign.center,
                   ),
                 ),
                 // TYPE Column
                 Expanded(
                   flex: 2,
-                  child: HudLabel(widget.node.type)
+                  child: Center(child: HudLabel(widget.node.type))
                 ),
                 // SIZE Column — colored by bucket when heatmap is active
                 Expanded(
@@ -281,19 +282,21 @@ class _DirectoryNodeWidgetState extends ConsumerState<DirectoryNodeWidget> {
                     style: HudTheme.statGreen.copyWith(
                       color: heatmapColor ?? HudTheme.accentCyan,
                     ),
-                    textAlign: TextAlign.right,
+                    textAlign: TextAlign.center,
                   ),
                 ),
                 // ACTION Column
                 Expanded(
                   flex: 1,
-                  child: IconButton(
-                    icon: Icon(
-                      isDir ? Icons.folder_delete_outlined : Icons.delete_forever_outlined,
-                      color: HudTheme.accentRed,
-                      size: 20,
+                  child: Center(
+                    child: IconButton(
+                      icon: Icon(
+                        isDir ? Icons.folder_delete_outlined : Icons.delete_forever_outlined,
+                        color: HudTheme.accentRed,
+                        size: 20,
+                      ),
+                      onPressed: () => widget.onNuke(widget.node.name, widget.node.path),
                     ),
-                    onPressed: () => widget.onNuke(widget.node.name, widget.node.path),
                   ),
                 ),
               ],

--- a/frontend/gs_anlyzer_ui/lib/widgets/directory_table_header.dart
+++ b/frontend/gs_anlyzer_ui/lib/widgets/directory_table_header.dart
@@ -20,13 +20,13 @@ class DirectoryTableHeader extends StatelessWidget {
             child: Row(
               children: [
                 SizedBox(width: 32), SizedBox(width: 20), SizedBox(width: 8),
-                HudLabel('NAME')
+                HudLabel('NAME') // Kept left aligned to match the tree view
               ],
             ),
           ),
-          Expanded(flex: 3, child: HudLabel('DATE MODIFIED')),
-          Expanded(flex: 3, child: HudLabel('TYPE')),
-          Expanded(flex: 2, child: Padding(padding: EdgeInsets.only(right: 16), child: HudLabel('SIZE'))),
+          Expanded(flex: 3, child: HudLabel('DATE MODIFIED', textAlign: TextAlign.center,)),
+          Expanded(flex: 2, child: HudLabel('TYPE', textAlign: TextAlign.center,)),
+          Expanded(flex: 2, child: HudLabel('SIZE', textAlign: TextAlign.center,)),
           Expanded(flex: 1, child: HudLabel('ACTION', textAlign: TextAlign.center,)),
         ],
       ),

--- a/frontend/gs_anlyzer_ui/lib/widgets/nuke_preview_dialog.dart
+++ b/frontend/gs_anlyzer_ui/lib/widgets/nuke_preview_dialog.dart
@@ -6,8 +6,9 @@ import 'package:gs_analyzer_ui/utils/hud_theme.dart';
 class NukePreviewResult {
   final bool confirmed;
   final bool useRecycleBin;
+  final String planToken;
 
-  NukePreviewResult({required this.confirmed, required this.useRecycleBin});
+  NukePreviewResult({required this.confirmed, required this.useRecycleBin, required this.planToken});
 }
 
 class NukePreviewDialog extends StatefulWidget {
@@ -66,7 +67,7 @@ class _NukePreviewDialogState extends State<NukePreviewDialog> {
       content: SizedBox(width: 500, child: _buildContent()),
       actions: [
         TextButton(
-          onPressed: () => Navigator.of(context).pop(NukePreviewResult(confirmed: false, useRecycleBin: false)),
+          onPressed: () => Navigator.of(context).pop(NukePreviewResult(confirmed: false, useRecycleBin: false, planToken: '')),
           child: const Text('ABORT', style: TextStyle(color: Colors.white70)),
         ),
         if(!_isLoading && _error == null)
@@ -75,7 +76,7 @@ class _NukePreviewDialogState extends State<NukePreviewDialog> {
               backgroundColor: HudTheme.accentRed.withValues(alpha: 0.2),
               side: const BorderSide(color: HudTheme.accentRed),
             ),
-            onPressed: () => Navigator.of(context).pop(NukePreviewResult(confirmed: true, useRecycleBin: _useRecycleBin)),
+            onPressed: () => Navigator.of(context).pop(NukePreviewResult(confirmed: true, useRecycleBin: _useRecycleBin, planToken: _preview!.planToken)),
             child: Text(_useRecycleBin ? 'MOVE TO RECYCLE BIN' : 'EXECUTE NUKE', style: const TextStyle(color: HudTheme.accentRed, fontWeight: FontWeight.bold)),
           )
       ],

--- a/frontend/gs_anlyzer_ui/lib/widgets/nuke_preview_dialog.dart
+++ b/frontend/gs_anlyzer_ui/lib/widgets/nuke_preview_dialog.dart
@@ -12,15 +12,16 @@ class NukePreviewResult {
 }
 
 class NukePreviewDialog extends StatefulWidget {
+  final ApiService apiService;
   final List<String> targetPaths;
-  const NukePreviewDialog({super.key, required this.targetPaths});
+  NukePreviewDialog({super.key, required this.targetPaths, ApiService? apiService}) : apiService = apiService ?? ApiService();
 
   @override
   State<NukePreviewDialog> createState() => _NukePreviewDialogState();
 }
 
 class _NukePreviewDialogState extends State<NukePreviewDialog> {
-  final ApiService _api = ApiService();
+  late final ApiService _api = widget.apiService;
   NukePreviewResponse? _preview;
   bool _isLoading = true;
   String? _error;
@@ -196,3 +197,4 @@ class _NukePreviewDialogState extends State<NukePreviewDialog> {
     );
   }
 }
+

--- a/frontend/gs_anlyzer_ui/lib/widgets/nuke_preview_dialog.dart
+++ b/frontend/gs_anlyzer_ui/lib/widgets/nuke_preview_dialog.dart
@@ -3,6 +3,13 @@ import 'package:gs_analyzer_ui/models/nuke_preview.dart';
 import 'package:gs_analyzer_ui/services/api_service.dart';
 import 'package:gs_analyzer_ui/utils/hud_theme.dart';
 
+class NukePreviewResult {
+  final bool confirmed;
+  final bool useRecycleBin;
+
+  NukePreviewResult({required this.confirmed, required this.useRecycleBin});
+}
+
 class NukePreviewDialog extends StatefulWidget {
   final List<String> targetPaths;
   const NukePreviewDialog({super.key, required this.targetPaths});
@@ -16,6 +23,7 @@ class _NukePreviewDialogState extends State<NukePreviewDialog> {
   NukePreviewResponse? _preview;
   bool _isLoading = true;
   String? _error;
+  bool _useRecycleBin = false;
 
   @override
   void initState() {
@@ -58,7 +66,7 @@ class _NukePreviewDialogState extends State<NukePreviewDialog> {
       content: SizedBox(width: 500, child: _buildContent()),
       actions: [
         TextButton(
-          onPressed: () => Navigator.of(context).pop(false),
+          onPressed: () => Navigator.of(context).pop(NukePreviewResult(confirmed: false, useRecycleBin: false)),
           child: const Text('ABORT', style: TextStyle(color: Colors.white70)),
         ),
         if(!_isLoading && _error == null)
@@ -67,8 +75,8 @@ class _NukePreviewDialogState extends State<NukePreviewDialog> {
               backgroundColor: HudTheme.accentRed.withValues(alpha: 0.2),
               side: const BorderSide(color: HudTheme.accentRed),
             ),
-            onPressed: () => Navigator.of(context).pop(true),
-            child: const Text('EXECUTE NUKE', style: TextStyle(color: HudTheme.accentRed, fontWeight: FontWeight.bold)),
+            onPressed: () => Navigator.of(context).pop(NukePreviewResult(confirmed: true, useRecycleBin: _useRecycleBin)),
+            child: Text(_useRecycleBin ? 'MOVE TO RECYCLE BIN' : 'EXECUTE NUKE', style: const TextStyle(color: HudTheme.accentRed, fontWeight: FontWeight.bold)),
           )
       ],
     );
@@ -130,6 +138,46 @@ class _NukePreviewDialogState extends State<NukePreviewDialog> {
                 ),
               );
             },
+          ),
+        ),
+        const SizedBox(height: 16),
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          decoration: BoxDecoration(
+            color: Colors.black45,
+            borderRadius: BorderRadius.circular(4),
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text('MOVE TO RECYCLE BIN', style: TextStyle(color: Colors.white, fontFamily: HudTheme.fontCore)),
+              Switch(
+                value: _useRecycleBin,
+                activeColor: HudTheme.accentAmber,
+                onChanged: (val) => setState(() => _useRecycleBin = val),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 8),
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: _useRecycleBin ? HudTheme.accentAmber.withValues(alpha: 0.1) : HudTheme.accentRed.withValues(alpha: 0.1),
+            border: Border.all(color: _useRecycleBin ? HudTheme.accentAmber : HudTheme.accentRed),
+            borderRadius: BorderRadius.circular(4),
+          ),
+          child: Text(
+            _useRecycleBin 
+                ? 'FILES WILL BE RECOVERABLE FROM YOUR SYSTEM RECYCLE BIN' 
+                : '⚠ THIS CANNOT BE UNDONE — FILES WILL BE PERMANENTLY DELETED',
+            style: TextStyle(
+              color: _useRecycleBin ? HudTheme.accentAmber : HudTheme.accentRed,
+              fontSize: 12,
+              fontWeight: FontWeight.bold,
+              fontFamily: HudTheme.fontCore,
+            ),
           ),
         ),
       ],

--- a/frontend/gs_anlyzer_ui/lib/widgets/undo_history_panel.dart
+++ b/frontend/gs_anlyzer_ui/lib/widgets/undo_history_panel.dart
@@ -49,7 +49,33 @@ class _UndoHistoryPanelState extends ConsumerState<UndoHistoryPanel> {
                       Text('UNDO HISTORY', style: HudTheme.headerCyan.copyWith(color: HudTheme.accentCyan)),
                     ],
                   ),
-                  Icon(_isExpanded ? Icons.expand_less : Icons.expand_more, color: HudTheme.accentCyan),
+                  Row(
+                    children: [
+                      IconButton(
+                        icon: Icon(Icons.refresh, color: HudTheme.accentCyan, size: 20),
+                        onPressed: () {
+                          ref.invalidate(undoHistoryProvider);
+                        },
+                        padding: EdgeInsets.zero,
+                        constraints: const BoxConstraints(),
+                      ),
+                      const SizedBox(width: 8),
+                      IconButton(
+                        icon: const Icon(Icons.delete_forever, color: HudTheme.accentRed, size: 20),
+                        tooltip: 'Empty Recycle Bin',
+                        onPressed: () async {
+                          final api = ApiService();
+                          await api.clearUndoStack();
+                          ref.invalidate(undoHistoryProvider);
+                          ref.read(drivesProvider.notifier).refresh();
+                        },
+                        padding: EdgeInsets.zero,
+                        constraints: const BoxConstraints(),
+                      ),
+                      const SizedBox(width: 16),
+                      Icon(_isExpanded ? Icons.expand_less : Icons.expand_more, color: HudTheme.accentCyan),
+                    ],
+                  ),
                 ],
               ),
             ),
@@ -71,7 +97,7 @@ class _UndoHistoryPanelState extends ConsumerState<UndoHistoryPanel> {
                   itemBuilder: (context, index) {
                     final op = history[index];
                     final timeFormatted = DateFormat('HH:mm:ss').format(op.executedAt.toLocal());
-                    final targets = op.deletedPaths.length;
+                    final targets = op.deletedFiles;
                     
                     return ListTile(
                       title: Text('$targets ITEMS', style: const TextStyle(fontFamily: HudTheme.fontCore, fontWeight: FontWeight.bold, color: Colors.white)),
@@ -111,7 +137,7 @@ class _UndoHistoryPanelState extends ConsumerState<UndoHistoryPanel> {
   Future<void> _handleUndo(String operationId) async {
     final api = ApiService();
     try {
-      final undoResult = await api.undoNuke();
+      final undoResult = await api.undoNuke(operationId);
       snackbarKey.currentState?.showSnackBar(SnackBar(
         content: Text('RESTORED ${undoResult.deletedFiles} FILES', style: const TextStyle(fontFamily: HudTheme.fontCore, fontWeight: FontWeight.bold)),
         backgroundColor: HudTheme.accentGreen,
@@ -126,7 +152,7 @@ class _UndoHistoryPanelState extends ConsumerState<UndoHistoryPanel> {
       ref.invalidate(undoHistoryProvider);
     } catch (e) {
       snackbarKey.currentState?.showSnackBar(SnackBar(
-        content: Text(e.toString() == 'Exception: PERMANENT_DELETE' ? 'CANNOT UNDO — FILES PERMANENTLY DELETED' : 'UNDO FAILED: $e', style: const TextStyle(fontFamily: HudTheme.fontCore)),
+        content: Text('UNDO FAILED: $e', style: const TextStyle(fontFamily: HudTheme.fontCore)),
         backgroundColor: HudTheme.accentRed,
       ));
     }

--- a/frontend/gs_anlyzer_ui/lib/widgets/undo_history_panel.dart
+++ b/frontend/gs_anlyzer_ui/lib/widgets/undo_history_panel.dart
@@ -15,7 +15,8 @@ final undoHistoryProvider = FutureProvider.autoDispose<List<NukeOperation>>((ref
 });
 
 class UndoHistoryPanel extends ConsumerStatefulWidget {
-  const UndoHistoryPanel({super.key});
+  final ApiService apiService;
+  UndoHistoryPanel({super.key, ApiService? apiService}) : apiService = apiService ?? ApiService();
 
   @override
   ConsumerState<UndoHistoryPanel> createState() => _UndoHistoryPanelState();
@@ -64,7 +65,7 @@ class _UndoHistoryPanelState extends ConsumerState<UndoHistoryPanel> {
                         icon: const Icon(Icons.delete_forever, color: HudTheme.accentRed, size: 20),
                         tooltip: 'Empty Recycle Bin',
                         onPressed: () async {
-                          final api = ApiService();
+                          final api = widget.apiService;
                           await api.clearUndoStack();
                           ref.invalidate(undoHistoryProvider);
                           ref.read(drivesProvider.notifier).refresh();
@@ -135,7 +136,7 @@ class _UndoHistoryPanelState extends ConsumerState<UndoHistoryPanel> {
   }
 
   Future<void> _handleUndo(String operationId) async {
-    final api = ApiService();
+    final api = widget.apiService;
     try {
       final undoResult = await api.undoNuke(operationId);
       snackbarKey.currentState?.showSnackBar(SnackBar(
@@ -158,3 +159,4 @@ class _UndoHistoryPanelState extends ConsumerState<UndoHistoryPanel> {
     }
   }
 }
+

--- a/frontend/gs_anlyzer_ui/lib/widgets/undo_history_panel.dart
+++ b/frontend/gs_anlyzer_ui/lib/widgets/undo_history_panel.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gs_analyzer_ui/models/nuke_result.dart';
+import 'package:gs_analyzer_ui/services/api_service.dart';
+import 'package:gs_analyzer_ui/utils/hud_theme.dart';
+import 'package:gs_analyzer_ui/utils/globals.dart';
+import 'package:gs_analyzer_ui/providers/directory_provider.dart';
+import 'package:gs_analyzer_ui/providers/root_tree_provider.dart';
+import 'package:gs_analyzer_ui/providers/drive_stats_provider.dart';
+import 'package:intl/intl.dart';
+
+final undoHistoryProvider = FutureProvider.autoDispose<List<NukeOperation>>((ref) async {
+  final api = ApiService();
+  return await api.getUndoHistory();
+});
+
+class UndoHistoryPanel extends ConsumerStatefulWidget {
+  const UndoHistoryPanel({super.key});
+
+  @override
+  ConsumerState<UndoHistoryPanel> createState() => _UndoHistoryPanelState();
+}
+
+class _UndoHistoryPanelState extends ConsumerState<UndoHistoryPanel> {
+  bool _isExpanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final historyAsync = ref.watch(undoHistoryProvider);
+
+    return Container(
+      margin: const EdgeInsets.all(16.0),
+      decoration: HudTheme.hudPanelDecoration,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          InkWell(
+            onTap: () => setState(() => _isExpanded = !_isExpanded),
+            child: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Row(
+                    children: [
+                      Icon(Icons.history, color: HudTheme.accentCyan),
+                      const SizedBox(width: 12),
+                      Text('UNDO HISTORY', style: HudTheme.headerCyan.copyWith(color: HudTheme.accentCyan)),
+                    ],
+                  ),
+                  Icon(_isExpanded ? Icons.expand_less : Icons.expand_more, color: HudTheme.accentCyan),
+                ],
+              ),
+            ),
+          ),
+          if (_isExpanded)
+            historyAsync.when(
+              data: (history) {
+                if (history.isEmpty) {
+                  return Padding(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Text('NO OPERATIONS RECORDED', style: HudTheme.bodyText.copyWith(color: HudTheme.textDim)),
+                  );
+                }
+
+                return ListView.separated(
+                  shrinkWrap: true,
+                  itemCount: history.length,
+                  separatorBuilder: (context, index) => const Divider(color: Colors.white10, height: 1),
+                  itemBuilder: (context, index) {
+                    final op = history[index];
+                    final timeFormatted = DateFormat('HH:mm:ss').format(op.executedAt.toLocal());
+                    final targets = op.deletedPaths.length;
+                    
+                    return ListTile(
+                      title: Text('$targets ITEMS', style: const TextStyle(fontFamily: HudTheme.fontCore, fontWeight: FontWeight.bold, color: Colors.white)),
+                      subtitle: Text(timeFormatted, style: TextStyle(color: HudTheme.textDim, fontFamily: HudTheme.fontCore)),
+                      trailing: op.usedRecycleBin
+                          ? ElevatedButton(
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: HudTheme.accentAmber.withValues(alpha: 0.2),
+                                side: const BorderSide(color: HudTheme.accentAmber),
+                              ),
+                              onPressed: () => _handleUndo(op.operationId),
+                              child: const Text('UNDO', style: TextStyle(color: HudTheme.accentAmber, fontWeight: FontWeight.bold)),
+                            )
+                          : Container(
+                              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                              decoration: BoxDecoration(
+                                color: Colors.black45,
+                                borderRadius: BorderRadius.circular(4),
+                              ),
+                              child: const Text('🔒 PERMANENT', style: TextStyle(color: Colors.white54, fontWeight: FontWeight.bold, fontSize: 12)),
+                            ),
+                    );
+                  },
+                );
+              },
+              loading: () => const Padding(padding: EdgeInsets.all(16.0), child: Center(child: CircularProgressIndicator())),
+              error: (err, stack) => Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Text('ERROR: $err', style: const TextStyle(color: HudTheme.accentRed)),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _handleUndo(String operationId) async {
+    final api = ApiService();
+    try {
+      final undoResult = await api.undoNuke();
+      snackbarKey.currentState?.showSnackBar(SnackBar(
+        content: Text('RESTORED ${undoResult.deletedFiles} FILES', style: const TextStyle(fontFamily: HudTheme.fontCore, fontWeight: FontWeight.bold)),
+        backgroundColor: HudTheme.accentGreen,
+      ));
+      
+      ref.invalidate(rootTreeProvider);
+      ref.read(drivesProvider.notifier).refresh();
+      final currentPath = ref.read(directoryProvider).currentPath;
+      await ref.read(directoryProvider.notifier).scanDirectory(currentPath);
+      
+      // Refresh the history panel
+      ref.invalidate(undoHistoryProvider);
+    } catch (e) {
+      snackbarKey.currentState?.showSnackBar(SnackBar(
+        content: Text(e.toString() == 'Exception: PERMANENT_DELETE' ? 'CANNOT UNDO — FILES PERMANENTLY DELETED' : 'UNDO FAILED: $e', style: const TextStyle(fontFamily: HudTheme.fontCore)),
+        backgroundColor: HudTheme.accentRed,
+      ));
+    }
+  }
+}

--- a/frontend/gs_anlyzer_ui/pubspec.lock
+++ b/frontend/gs_anlyzer_ui/pubspec.lock
@@ -239,6 +239,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.2"
   io:
     dependency: transitive
     description:

--- a/frontend/gs_anlyzer_ui/pubspec.yaml
+++ b/frontend/gs_anlyzer_ui/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   signalr_netcore: ^1.4.4
   flutter_riverpod: ^3.3.1
   fl_chart: ^1.2.0
+  intl: ^0.20.2
 
 dev_dependencies:
   flutter_test:

--- a/frontend/gs_anlyzer_ui/test/models/nuke_result_test.dart
+++ b/frontend/gs_anlyzer_ui/test/models/nuke_result_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gs_analyzer_ui/models/nuke_result.dart';
+
+void main() {
+  group('NukeOperation.fromJson', () {
+    test('parses all fields incl. deletedFiles', () {
+      final op = NukeOperation.fromJson({
+        'operationId': 'op-1',
+        'executedAt': '2026-06-24T10:00:00Z',
+        'originalPaths': ['C:\\a', 'C:\\b'],
+        'deletedPaths': ['C:\\a'],
+        'usedRecycleBin': true,
+        'deletedFiles': 3,
+      });
+      expect(op.operationId, 'op-1');
+      expect(op.usedRecycleBin, isTrue);
+      expect(op.deletedFiles, 3);
+      expect(op.originalPaths, hasLength(2));
+    });
+
+    test('applies safe defaults when fields are missing', () {
+      final op = NukeOperation.fromJson({});
+      expect(op.operationId, '');
+      expect(op.usedRecycleBin, isFalse);
+      expect(op.deletedFiles, 0);
+      expect(op.originalPaths, isEmpty);
+      expect(op.deletedPaths, isEmpty);
+    });
+  });
+
+  group('NukeResultDto.fromJson', () {
+    test('parses a recoverable recycle-bin result', () {
+      final dto = NukeResultDto.fromJson({
+        'deletedFiles': 2, 'freedBytes': 0, 'freedFormatted': '0 B',
+        'stagedBytes': 100, 'stagedFormatted': '100 B',
+        'skippedFiles': 1, 'recycleBinUsed': true, 'recoverable': true,
+        'operationId': 'op-9',
+      });
+      expect(dto.recycleBinUsed, isTrue);
+      expect(dto.recoverable, isTrue);
+      expect(dto.stagedBytes, 100);
+      expect(dto.freedBytes, 0);
+      expect(dto.operationId, 'op-9');
+    });
+
+    test('defaults are safe when fields absent', () {
+      final dto = NukeResultDto.fromJson({});
+      expect(dto.deletedFiles, 0);
+      expect(dto.recoverable, isFalse);
+      expect(dto.recycleBinUsed, isFalse);
+      expect(dto.operationId, '');
+    });
+  });
+}

--- a/frontend/gs_anlyzer_ui/test/services/api_service_test.dart
+++ b/frontend/gs_anlyzer_ui/test/services/api_service_test.dart
@@ -1,0 +1,101 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:gs_analyzer_ui/services/api_service.dart';
+
+http.Response _ok(Map<String, dynamic> data) =>
+    http.Response(jsonEncode({'success': true, 'data': data}), 200);
+
+void main() {
+  group('ApiService.undoNuke', () {
+    test('targeted undo uses /undo/{operationId} as a ROUTE segment (no query)', () async {
+      late Uri captured;
+      final client = MockClient((req) async {
+        captured = req.url;
+        return _ok({'deletedFiles': 1, 'recoverable': true, 'operationId': 'op-123'});
+      });
+
+      await ApiService(client).undoNuke('op-123');
+
+      // Backend route is POST undo/{operationId?}: it binds {operationId} from the
+      // PATH. A ?query string is ignored, so the wrong (most-recent) op is undone.
+      expect(captured.path, endsWith('/api/nuke/undo/op-123'));
+      expect(captured.query, isEmpty,
+          reason: 'operationId must be a path segment, not a query parameter');
+    });
+
+    test('untargeted undo posts to /undo with no id', () async {
+      late Uri captured;
+      late String method;
+      final client = MockClient((req) async {
+        captured = req.url;
+        method = req.method;
+        return _ok({'deletedFiles': 1, 'recoverable': true, 'operationId': 'op-1'});
+      });
+
+      await ApiService(client).undoNuke();
+
+      expect(method, 'POST');
+      expect(captured.path, endsWith('/api/nuke/undo'));
+      expect(captured.query, isEmpty);
+    });
+
+    test('throws on non-200', () async {
+      final client = MockClient((_) async => http.Response('nope', 500));
+      expect(() => ApiService(client).undoNuke('op-1'), throwsException);
+    });
+  });
+
+  group('ApiService.executeNuke', () {
+    test('DELETEs /execute with paths, planToken and useRecycleBin in body', () async {
+      late http.Request req;
+      final client = MockClient((r) async {
+        req = r;
+        return _ok({'deletedFiles': 1, 'recycleBinUsed': true, 'operationId': 'op-1'});
+      });
+
+      await ApiService(client).executeNuke(['C:\\temp\\x'], 'tok', useRecycleBin: true);
+
+      expect(req.method, 'DELETE');
+      expect(req.url.path, endsWith('/api/nuke/execute'));
+      final body = jsonDecode(req.body) as Map<String, dynamic>;
+      expect(body['paths'], ['C:\\temp\\x']);
+      expect(body['planToken'], 'tok');
+      expect(body['useRecycleBin'], isTrue);
+    });
+  });
+
+  group('ApiService.clearUndoStack', () {
+    test('DELETEs /undo', () async {
+      late http.Request req;
+      final client = MockClient((r) async {
+        req = r;
+        return http.Response('', 200);
+      });
+      await ApiService(client).clearUndoStack();
+      expect(req.method, 'DELETE');
+      expect(req.url.path, endsWith('/api/nuke/undo'));
+    });
+  });
+
+  group('ApiService.getUndoHistory', () {
+    test('GETs /undo/history and parses the list', () async {
+      final client = MockClient((_) async => http.Response(jsonEncode({
+            'success': true,
+            'data': [
+              {
+                'operationId': 'op-1', 'usedRecycleBin': true, 'deletedFiles': 2,
+                'originalPaths': [], 'deletedPaths': [],
+                'executedAt': '2026-06-24T10:00:00Z'
+              }
+            ]
+          }), 200));
+
+      final hist = await ApiService(client).getUndoHistory();
+      expect(hist, hasLength(1));
+      expect(hist.first.deletedFiles, 2);
+      expect(hist.first.usedRecycleBin, isTrue);
+    });
+  });
+}

--- a/frontend/gs_anlyzer_ui/test/widgets/nuke_preview_dialog_test.dart
+++ b/frontend/gs_anlyzer_ui/test/widgets/nuke_preview_dialog_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gs_analyzer_ui/widgets/nuke_preview_dialog.dart';
+import 'package:gs_analyzer_ui/services/api_service.dart';
+import 'package:gs_analyzer_ui/models/nuke_preview.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'dart:convert';
+
+void main() {
+  testWidgets('recycle-bin toggle updates NukePreviewResult correctly', (tester) async {
+    final client = MockClient((req) async {
+      return http.Response(jsonEncode({
+        'success': true,
+        'data': {
+          'totalBytes': 1000,
+          'totalFormatted': '1 KB',
+          'totalFiles': 2,
+          'totalDirectories': 1,
+          'planToken': 'plan-abc',
+          'stagedPaths': ['C:\\temp\\x'],
+          'errors': []
+        }
+      }), 200);
+    });
+
+    final apiService = ApiService(client);
+
+    dynamic dialogResult;
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () async {
+              dialogResult = await showDialog(
+                context: context,
+                builder: (context) => NukePreviewDialog(
+                  targetPaths: const ['C:\\temp\\x'],
+                  apiService: apiService,
+                ),
+              );
+            },
+            child: const Text('Show Dialog'),
+          ),
+        ),
+      ),
+    ));
+
+    // Open dialog
+    await tester.tap(find.text('Show Dialog'));
+    await tester.pumpAndSettle();
+
+    // The switch for recycle bin should be initially off (default)
+    expect(find.byType(Switch), findsOneWidget);
+    Switch switchWidget = tester.widget(find.byType(Switch));
+    expect(switchWidget.value, isFalse);
+
+    // Toggle the switch
+    await tester.tap(find.byType(Switch));
+    await tester.pumpAndSettle();
+
+    // The button should now be MOVE TO RECYCLE BIN, tap it
+    await tester.tap(find.text('MOVE TO RECYCLE BIN').last);
+    await tester.pumpAndSettle();
+
+    expect(dialogResult, isNotNull);
+    // Since dialog returns a Map or a typed record, I'll access fields
+    // Wait, NukePreviewDialog pops a map: {'execute': true, 'useRecycleBin': _useRecycleBin, 'planToken': _preview!.planToken}
+    expect(dialogResult.confirmed, isTrue);
+    expect(dialogResult.useRecycleBin, isTrue);
+    expect(dialogResult.planToken, 'plan-abc');
+  });
+}

--- a/frontend/gs_anlyzer_ui/test/widgets/undo_history_panel_test.dart
+++ b/frontend/gs_anlyzer_ui/test/widgets/undo_history_panel_test.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gs_analyzer_ui/models/nuke_result.dart';
+import 'package:gs_analyzer_ui/widgets/undo_history_panel.dart';
+import 'package:gs_analyzer_ui/services/api_service.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'dart:convert';
+
+NukeOperation _op({required String id, required bool recoverable, int files = 1}) =>
+    NukeOperation(
+      operationId: id,
+      executedAt: DateTime(2026, 6, 24, 10, 0, 0),
+      originalPaths: const [],
+      deletedPaths: const [],
+      usedRecycleBin: recoverable,
+      deletedFiles: files,
+    );
+
+Future<void> _pump(WidgetTester tester, List<NukeOperation> ops, {ApiService? apiService}) {
+  return tester.pumpWidget(
+    ProviderScope(
+      overrides: [undoHistoryProvider.overrideWith((ref) async => ops)],
+      child: MaterialApp(home: Scaffold(body: UndoHistoryPanel(apiService: apiService))),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('collapsed by default; expanding reveals a recoverable row with UNDO',
+      (tester) async {
+    await _pump(tester, [_op(id: 'op-1', recoverable: true, files: 3)]);
+    await tester.pumpAndSettle();
+
+    expect(find.text('UNDO HISTORY'), findsOneWidget);
+    expect(find.text('3 ITEMS'), findsNothing); // hidden while collapsed
+
+    await tester.tap(find.text('UNDO HISTORY'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('3 ITEMS'), findsOneWidget);
+    expect(find.text('UNDO'), findsOneWidget);
+  });
+
+  testWidgets('permanent op shows a lock, not an UNDO button', (tester) async {
+    await _pump(tester, [_op(id: 'op-2', recoverable: false, files: 5)]);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('UNDO HISTORY'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('5 ITEMS'), findsOneWidget);
+    expect(find.textContaining('PERMANENT'), findsOneWidget);
+    expect(find.text('UNDO'), findsNothing);
+  });
+
+  testWidgets('empty history shows the placeholder', (tester) async {
+    await _pump(tester, const []);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('UNDO HISTORY'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('NO OPERATIONS RECORDED'), findsOneWidget);
+  });
+
+  testWidgets('tapping UNDO row sends op.operationId to apiService', (tester) async {
+    late Uri capturedUrl;
+    final client = MockClient((req) async {
+      capturedUrl = req.url;
+      return http.Response(jsonEncode({
+        'success': true,
+        'data': {
+          'deletedFiles': 3,
+          'freedBytes': 0,
+          'freedFormatted': '0 B',
+          'stagedBytes': 100,
+          'stagedFormatted': '100 B',
+          'skippedFiles': 0,
+          'recycleBinUsed': true,
+          'recoverable': false,
+          'operationId': 'op-999',
+        }
+      }), 200);
+    });
+
+    final apiService = ApiService(client);
+    await _pump(tester, [_op(id: 'op-999', recoverable: true, files: 3)], apiService: apiService);
+    await tester.pumpAndSettle();
+    
+    await tester.tap(find.text('UNDO HISTORY'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('UNDO'));
+    await tester.pumpAndSettle();
+
+    expect(capturedUrl.path, endsWith('/api/nuke/undo/op-999'));
+  });
+}

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,0 +1,57 @@
+# Walkthrough: Recycle Bin + Undo Stack (Backend)
+
+## Summary
+
+Implemented the Recycle Bin mode and session-scoped Undo Stack for the Nuke Protocol. When `useRecycleBin` is enabled, files are moved to a staging directory instead of being permanently deleted, and can be restored via the undo endpoint.
+
+## Files Changed
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| [NukeExecuteRequest.cs](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/Models/NukeExecuteRequest.cs) | Request DTO with `Paths` + `UseRecycleBin` flag |
+| [NukeOperation.cs](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/Models/NukeOperation.cs) | Undo stack record (operation ID, timestamps, paths, recycle bin flag) |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| [NukeResultDto.cs](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/Models/NukeResultDto.cs) | Redesigned from `Message/Path/Type` → `DeletedFiles/FreedBytes/FreedFormatted/SkippedFiles/RecycleBinUsed/Recoverable/OperationId` |
+| [INukeProtocolService.cs](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/Interfaces/INukeProtocolService.cs) | Added `useRecycleBin` param + `PeekUndo()`, `UndoLastNuke()`, `ClearUndoStack()` |
+| [NukeProtocolService.cs](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/Services/NukeProtocolService.cs) | Staging directory logic, undo stack (max 5), file/byte counters, restore logic |
+| [NukeController.cs](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/Controllers/NukeController.cs) | `NukeExecuteRequest` body, 3 new undo endpoints |
+| [GSInteractiveDeviceAnalyzer.csproj](file:///c:/Users/USER/My%20Project/GSInteractiveDeviceAnalyzer/backend/GSInteractiveDeviceAnalyzer.csproj) | `Microsoft.WindowsDesktop.App` framework reference (Windows TFM) |
+
+## Design Decisions
+
+### Staging Directory over OS Recycle Bin
+Used `%APPDATA%/GSAnalyzer/nuke_trash/{operationId}/` instead of the OS recycle bin because:
+- The Windows recycle bin API (`Microsoft.VisualBasic.FileIO`) has no programmatic **restore** — making undo impossible
+- The staging directory approach is fully cross-platform
+- Files preserve their original path structure for reliable restoration
+
+### Undo Stack
+- In-memory `Stack<NukeOperation>` — max 5 entries, LIFO
+- Not persisted across restarts (session-scoped by design)
+- When stack overflows, oldest entry is evicted and its staging directory is cleaned up
+- Undo on permanent-delete operations returns `409 Conflict`
+
+## API Changes
+
+### `DELETE /api/nuke/execute` — Updated Request Body
+```diff
+- Body: ["path1", "path2"]            // raw List<string>
++ Body: { "paths": [...], "useRecycleBin": true }  // NukeExecuteRequest
+```
+
+### New Endpoints
+| Method | Route | Status Codes |
+|--------|-------|-------------|
+| `GET` | `/api/nuke/undo/peek` | 200, 404 |
+| `POST` | `/api/nuke/undo` | 200, 404, 409 |
+| `DELETE` | `/api/nuke/undo` | 200 |
+
+## Verification
+- **Build**: ✅ 0 errors
+- **Tests**: ✅ 52/52 passed on both `net10.0` and `net10.0-windows`


### PR DESCRIPTION
## Summary

Adds an opt-in **recoverable delete** path to the Nuke protocol. Users can now choose
"Move to Recycle Bin" instead of permanent deletion, and restore prior deletions from a
session-scoped **undo history** (FR-N2). Permanent delete remains available and explicit.

Backed by a per-drive staging area, a single-use plan-token gate, and a 5-entry undo
stack. Includes full backend unit coverage (controller + service) and frontend tests.

## What's included

**Backend**
- `useRecycleBin` flag on `DELETE /api/nuke/execute`. When set, targets are moved to a
  per-drive staging dir (`{driveRoot}\.gsanalyzer_trash\{operationId}`) instead of being
  obliterated.
- Undo endpoints: `GET /api/nuke/undo/peek`, `GET /api/nuke/undo/history`,
  `POST /api/nuke/undo/{operationId?}` (targeted or most-recent), `DELETE /api/nuke/undo`
  (empty the bin).
- Single-use, path-bound plan tokens with a 15-minute TTL; execution validates the token
  before any deletion occurs.
- 5-entry undo stack; evicting the oldest entry cleans up its staging directory. Startup
  sweep removes orphaned staging dirs across all ready drives.
- Restore handles collisions via unique `_Restored_N` paths and skips permanent ops.

**Frontend**
- "Move to Recycle Bin" toggle in the preview dialog (defaults off → explicit permanent
  delete).
- Post-delete snackbar with inline `[UNDO]`, plus an **Undo History** panel (per-row undo,
  "empty recycle bin", and refresh).
- Restored item counts surfaced via `deletedFiles`.

## Review fixes folded in
- Cross-volume staging bug fixed (stage to the source drive root, not AppData).
- `operationId` switched to a GUID to remove collision risk.
- Removed the dead `409 / PERMANENT_DELETE` branch (peek already filters to recoverable ops).
- Plan-token TTL added to prevent unbounded growth.
- Undo history panel now invalidates after a delete (no more stale list); snackbar duration
  reduced from 365 days to 15s.
- **Per-row undo now targets the clicked operation** via `POST /undo/{operationId}` instead
  of always undoing the most-recent op.

## Testing
- **Backend (xUnit + Moq):** `NukeControllerTests` (15) and `NukeProtocolServiceTests` (14)
  cover token gating, recycle-vs-permanent counters, ghost-path skips, undo round-trips,
  permanent-skip, restore collisions, stack cap/eviction, and clear.
- **Frontend (flutter_test):** model parsing, `ApiService` URL/verb contracts (incl. the
  undo route-segment regression), and `UndoHistoryPanel` rendering/visibility.
- A small `http.Client` seam was added to `ApiService` and an `IDiskScannerEngine` seam on
  the service to enable isolated testing.

## Safety / out of scope
- OS-critical paths (`C:\Windows...`) remain protected and rejected.
- Undo stack is session-scoped and not persisted across restarts.