### PR TITLE
feat(storage): Extension Breakdown — per-extension drill-down for File Type Analytics

### DIFF
--- a/backend/Controllers/StorageController.cs
+++ b/backend/Controllers/StorageController.cs
@@ -385,5 +385,36 @@ namespace GSSystemAnalyzer.Controllers
 
             return Ok(result);
         }
+
+        [HttpGet("scan/extensions")]
+        public IActionResult GetExtensions(
+            [FromQuery] string root,
+            [FromServices] IFileTypeScanner scanner)
+        {
+            if (string.IsNullOrWhiteSpace(root))
+                return BadRequest(new
+                {
+                    error = "ROOT_REQUIRED",
+                    message = "root query parameter is required."
+                });
+
+            if (!Directory.Exists(root))
+                return BadRequest(new
+                {
+                    error = "DRIVE_NOT_FOUND",
+                    message = $"Root path '{root}' does not exist or is not accessible."
+                });
+
+            var result = scanner.GetExtensionBreakdown(root);
+
+            if (result is null)
+                return Conflict(new
+                {
+                    error = "NO_SCAN_CACHED",
+                    message = "No scan result found for this root. Run a Directory scan first."
+                });
+
+            return Ok(result);
+        }
     }
 }

--- a/backend/Engine/DiskScannerEngine.cs
+++ b/backend/Engine/DiskScannerEngine.cs
@@ -195,11 +195,17 @@ public class DiskScannerEngine : IDiskScannerEngine
 
                 if (!extMap.TryGetValue(ext, out var fte))
                 {
-                    fte = new FileTypeEntry { Count = 0, Bytes = 0 };
+                    fte = new FileTypeEntry { Count = 0, Bytes = 0, LargestFileBytes = 0, LargestFilePath = string.Empty };
                     extMap[ext] = fte;
                 }
                 fte.Count++;
                 fte.Bytes += f.Length;
+                
+                if (f.Length > fte.LargestFileBytes)
+                {
+                    fte.LargestFileBytes = f.Length;
+                    fte.LargestFilePath = f.FullName;
+                }
             }
 
             var pulse = Interlocked.Increment(ref _deepScanThrottle);

--- a/backend/Engine/FileTypeScanner.cs
+++ b/backend/Engine/FileTypeScanner.cs
@@ -118,10 +118,71 @@ public class FileTypeScanner : IFileTypeScanner
         return result;
     }
 
-    /// <inheritdoc/>
     public void Invalidate(string root)
     {
         _cache.Remove($"filetypes:{NormalizeRoot(root).ToLowerInvariant()}");
+        _cache.Remove($"extbreakdown:{NormalizeRoot(root).ToLowerInvariant()}");
+    }
+
+    public ExtensionBreakdownResult? GetExtensionBreakdown(string root)
+    {
+        var normalized = NormalizeRoot(root);
+        var cacheKey = $"extbreakdown:{normalized.ToLowerInvariant()}";
+
+        if (_cache.TryGetValue(cacheKey, out ExtensionBreakdownResult? hit))
+            return hit;
+
+        var normalizedNoSlash = normalized.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var wasScanned = _engine.DirectorySizeCache.Keys
+            .Any(k => k.Equals(normalizedNoSlash, StringComparison.OrdinalIgnoreCase) ||
+                      k.StartsWith(normalized, StringComparison.OrdinalIgnoreCase));
+
+        if (!wasScanned) return null;
+
+        var result = BuildExtensionBreakdownResult(normalized);
+        _cache.Set(cacheKey, result, TimeSpan.FromMinutes(15));
+        return result;
+    }
+
+    private ExtensionBreakdownResult BuildExtensionBreakdownResult(string root)
+    {
+        var normalizedRoot = NormalizeRoot(root);
+        var extMap = BuildFromMemory(normalizedRoot);
+        var realEntries = extMap.Where(kvp => !kvp.Key.StartsWith("__visited__")).ToList();
+        var totalBytes = realEntries.Sum(v => v.Value.Bytes);
+
+        var extensions = realEntries.Select(e =>
+        {
+            var extName = string.IsNullOrEmpty(e.Key) || e.Key == "no extension" ? "(none)" : e.Key.ToLowerInvariant();
+            var cat = _categoryMap.TryGetValue(extName, out var c) ? c : "other";
+            
+            // if it was "no extension" in extMap, map to "(none)"
+            if (e.Key == "no extension") extName = "(none)";
+
+            var avgBytes = e.Value.Count > 0 ? e.Value.Bytes / e.Value.Count : 0;
+            return new ExtensionBreakdownItem
+            {
+                Ext = extName,
+                Category = cat,
+                FileCount = e.Value.Count,
+                TotalBytes = e.Value.Bytes,
+                SizeFormatted = FormatBytes(e.Value.Bytes),
+                PercentOfDisk = totalBytes > 0 ? Math.Round((double)e.Value.Bytes / totalBytes * 100, 1) : 0.0,
+                AverageFileSizeBytes = avgBytes,
+                AverageSizeFormatted = FormatBytes(avgBytes),
+                LargestFileBytes = e.Value.LargestFileBytes,
+                LargestFilePath = e.Value.LargestFilePath ?? string.Empty,
+                LargestSizeFormatted = FormatBytes(e.Value.LargestFileBytes)
+            };
+        })
+        .OrderByDescending(x => x.TotalBytes)
+        .ToList();
+
+        return new ExtensionBreakdownResult
+        {
+            Root = root,
+            Extensions = extensions
+        };
     }
     private FileTypeScanResult BuildResult(string root)
     {
@@ -194,8 +255,23 @@ public class FileTypeScanner : IFileTypeScanner
                 {
                     extMap.AddOrUpdate(
                         ext.Key,
-                        _ => new FileTypeEntry { Count = ext.Value.Count, Bytes = ext.Value.Bytes },
-                        (_, prev) => { prev.Count += ext.Value.Count; prev.Bytes += ext.Value.Bytes; return prev; });
+                        _ => new FileTypeEntry 
+                        { 
+                            Count = ext.Value.Count, 
+                            Bytes = ext.Value.Bytes, 
+                            LargestFileBytes = ext.Value.LargestFileBytes, 
+                            LargestFilePath = ext.Value.LargestFilePath 
+                        },
+                        (_, prev) => { 
+                            prev.Count += ext.Value.Count; 
+                            prev.Bytes += ext.Value.Bytes; 
+                            if (ext.Value.LargestFileBytes > prev.LargestFileBytes)
+                            {
+                                prev.LargestFileBytes = ext.Value.LargestFileBytes;
+                                prev.LargestFilePath = ext.Value.LargestFilePath;
+                            }
+                            return prev; 
+                        });
                 }
             }
         }

--- a/backend/GSSystemAnalyzer.Tests/Controller/FileExtensionBreakdownControllerTest.cs
+++ b/backend/GSSystemAnalyzer.Tests/Controller/FileExtensionBreakdownControllerTest.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using GSSystemAnalyzer.Controllers;
+using GSSystemAnalyzer.Interfaces;
+using GSSystemAnalyzer.Models;
+using GSSystemAnalyzer.Services;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace GSSystemAnalyzer.Tests.Controller
+{
+    public class FileExtensionBreakdownControllerTest : IDisposable
+    {
+        private readonly Mock<IFileTypeScanner> _scanner;
+        private readonly StorageController _controller;
+        private readonly string _existingRoot;
+
+        public FileExtensionBreakdownControllerTest()
+        {
+            _scanner = new Mock<IFileTypeScanner>();
+
+            var diskService = new Mock<IDiskOperationService>().Object;
+            var duplicateDetector = new Mock<IDuplicateFileDetector>().Object;
+            _controller = new StorageController(diskService, duplicateDetector);
+
+            _existingRoot = Path.Combine(Path.GetTempPath(), "gsa_ctrltest_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_existingRoot);
+        }
+
+        [Fact]
+        public void GetExtensions_WhenRootMissing_ReturnsBadRequest_RootRequired()
+        {
+            var result = _controller.GetExtensions("", _scanner.Object);
+
+            var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Equal("ROOT_REQUIRED", GetErrorCode(badRequest.Value));
+            // Guard short-circuits before the service is consulted.
+            _scanner.Verify(s => s.GetExtensionBreakdown(It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public void GetExtensions_WhenDirectoryDoesNotExist_ReturnsBadRequest_DriveNotFound()
+        {
+            var ghostPath = Path.Combine(Path.GetTempPath(), "gsa_missing_" + Guid.NewGuid().ToString("N"));
+
+            var result = _controller.GetExtensions(ghostPath, _scanner.Object);
+
+            var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Equal("DRIVE_NOT_FOUND", GetErrorCode(badRequest.Value));
+            _scanner.Verify(s => s.GetExtensionBreakdown(It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public void GetExtensions_WhenNoScanCached_ReturnsConflict_NoScanCached()
+        {
+            _scanner.Setup(s => s.GetExtensionBreakdown(_existingRoot))
+                    .Returns((ExtensionBreakdownResult?)null);
+
+            var result = _controller.GetExtensions(_existingRoot, _scanner.Object);
+
+            var conflict = Assert.IsType<ConflictObjectResult>(result);
+            Assert.Equal("NO_SCAN_CACHED", GetErrorCode(conflict.Value));
+        }
+
+        [Fact]
+        public void GetExtensions_WhenScanCached_ReturnsOkWithBreakdown()
+        {
+            var expected = new ExtensionBreakdownResult
+            {
+                Root = _existingRoot,
+                Extensions = new List<ExtensionBreakdownItem>
+                {
+                    new ExtensionBreakdownItem { Ext = ".cs", Category = "code", FileCount = 3, TotalBytes = 4096 }
+                }
+            };
+            _scanner.Setup(s => s.GetExtensionBreakdown(_existingRoot)).Returns(expected);
+
+            var result = _controller.GetExtensions(_existingRoot, _scanner.Object);
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            Assert.Same(expected, ok.Value);
+        }
+
+        // The endpoint returns anonymous objects ({ error, message }); read 'error' reflectively.
+        private static string? GetErrorCode(object? value) =>
+            value?.GetType().GetProperty("error")?.GetValue(value)?.ToString();
+
+        public void Dispose()
+        {
+            try { if (Directory.Exists(_existingRoot)) Directory.Delete(_existingRoot, true); }
+            catch { /* best-effort cleanup */ }
+        }
+    }
+}

--- a/backend/GSSystemAnalyzer.Tests/Services/FileExtensionBreakdownTest.cs
+++ b/backend/GSSystemAnalyzer.Tests/Services/FileExtensionBreakdownTest.cs
@@ -1,0 +1,135 @@
+﻿using GSSystemAnalyzer.Engine;
+using GSSystemAnalyzer.Hubs;
+using GSSystemAnalyzer.Interfaces;
+using GSSystemAnalyzer.Models;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Caching.Memory;
+using Moq;
+
+namespace GSSystemAnalyzer.Tests.Services
+{
+    public class FileExtensionBreakdownTest : IDisposable
+    {
+        private readonly MemoryCache _cache;
+        private readonly DiskScannerEngine _engine;
+        private readonly FileTypeScanner _scanner;
+        private readonly string _root;
+
+        public FileExtensionBreakdownTest()
+        {
+            var hub = new Mock<IHubContext<SystemHub>>().Object;
+            var settings = new Mock<ISettingService>().Object;
+
+            _cache = new MemoryCache(new MemoryCacheOptions());
+            _engine = new DiskScannerEngine(hub, settings);
+
+            _engine.DirectorySizeCache.Clear();
+
+            _scanner = new FileTypeScanner(_engine, _cache);
+
+            _root = Path.Combine(Path.GetTempPath(), "gsa_ebtest_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_root);
+        }
+
+        private void SeedScan(Dictionary<string, FileTypeEntry> extensions)
+        {
+            _engine.DirectorySizeCache[Path.GetFullPath(_root)] = new CacheEntry
+            {
+                Size = extensions.Sum(e => e.Value.Bytes),
+                LastUpdated = DateTime.UtcNow,
+                Extensions = extensions
+            };
+        }
+
+        [Fact]
+        public void GetExtensionBreakdown_WhenScanCached_ReturnsAggregatedBreakdownSortedBySize()
+        {
+            SeedScan(new Dictionary<string, FileTypeEntry>(StringComparer.OrdinalIgnoreCase)
+            {
+                [".mp4"] = new FileTypeEntry
+                {
+                    Count = 2,
+                    Bytes = 8000,
+                    LargestFileBytes = 6000,
+                    LargestFilePath = @"C:\media\movie.mp4"
+                },
+                [".txt"] = new FileTypeEntry
+                {
+                    Count = 3,
+                    Bytes = 1500,
+                    LargestFileBytes = 700,
+                    LargestFilePath = @"C:\docs\notes.txt"
+                },
+                ["no extension"] = new FileTypeEntry
+                {
+                    Count = 1,
+                    Bytes = 500,
+                    LargestFileBytes = 500,
+                    LargestFilePath = @"C:\misc\LICENSE"
+                },
+            });
+
+            var result = _scanner.GetExtensionBreakdown(_root);
+
+            Assert.NotNull(result);
+            Assert.Equal(3, result!.Extensions.Count);
+
+            // Sorted by TotalBytes desc: .mp4 (8000) > .txt (1500) > (none) (500)
+            var mp4 = result.Extensions[0];
+            var txt = result.Extensions[1];
+            var none = result.Extensions[2];
+
+            Assert.Equal(".mp4", mp4.Ext);
+            Assert.Equal("media", mp4.Category);
+            Assert.Equal(2, mp4.FileCount);
+            Assert.Equal(8000, mp4.TotalBytes);
+            Assert.Equal(4000, mp4.AverageFileSizeBytes);
+            Assert.Equal(80.0, mp4.PercentOfDisk);
+            Assert.Equal(6000, mp4.LargestFileBytes);
+            Assert.Equal(@"C:\media\movie.mp4", mp4.LargestFilePath);
+            Assert.False(string.IsNullOrEmpty(mp4.SizeFormatted));
+
+            Assert.Equal(".txt", txt.Ext);
+            Assert.Equal("documents", txt.Category);
+            Assert.Equal(15.0, txt.PercentOfDisk);
+            Assert.Equal(500, txt.AverageFileSizeBytes);
+
+            // "no extension" is surfaced as "(none)" and falls back to category "other".
+            Assert.Equal("(none)", none.Ext);
+            Assert.Equal("other", none.Category);
+            Assert.Equal(5.0, none.PercentOfDisk);
+        }
+
+        [Fact]
+        public void GetExtensionBreakdown_WhenNoScanCached_ReturnsNull()
+        {
+            // Nothing seeded -> scanner reports "not scanned" -> controller maps this to 409 NO_SCAN_CACHED.
+            var result = _scanner.GetExtensionBreakdown(_root);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetExtensionBreakdown_OnSecondCall_ReturnsCachedInstance()
+        {
+            SeedScan(new Dictionary<string, FileTypeEntry>(StringComparer.OrdinalIgnoreCase)
+            {
+                [".cs"] = new FileTypeEntry { Count = 1, Bytes = 1024, LargestFileBytes = 1024, LargestFilePath = @"C:\src\Program.cs" },
+            });
+
+            var first = _scanner.GetExtensionBreakdown(_root);
+            var second = _scanner.GetExtensionBreakdown(_root);
+
+            Assert.NotNull(first);
+            // Result is memoized for 15 minutes under extbreakdown:{root}; same reference returned.
+            Assert.Same(first, second);
+        }
+
+        public void Dispose()
+        {
+            _cache.Dispose();
+            try { if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true); }
+            catch { /* best-effort cleanup */ }
+        }
+    }
+}

--- a/backend/Interfaces/IFileTypeScanner.cs
+++ b/backend/Interfaces/IFileTypeScanner.cs
@@ -5,6 +5,7 @@ namespace GSSystemAnalyzer.Interfaces
     public interface IFileTypeScanner
     {
         FileTypeScanResult? Analyze(string root);
+        ExtensionBreakdownResult? GetExtensionBreakdown(string root);
         void Invalidate(string root);
     }
 }

--- a/backend/Models/FileTypeScanResult.cs
+++ b/backend/Models/FileTypeScanResult.cs
@@ -4,6 +4,8 @@ public class FileTypeEntry
 {
     public int Count { get; set; }
     public long Bytes { get; set; }
+    public long LargestFileBytes { get; set; }
+    public string LargestFilePath { get; set; } = string.Empty;
 }
 public class FileTypeExtensionEntry
 {
@@ -31,4 +33,25 @@ public class FileTypeScanResult
     public string TotalScannedFormatted { get; set; } = string.Empty;
     public DateTime ScannedAt { get; set; }
     public List<FileTypeCategory> Categories { get; set; } = new();
+}
+
+public class ExtensionBreakdownItem
+{
+    public string Ext { get; set; } = string.Empty;
+    public string Category { get; set; } = string.Empty;
+    public int FileCount { get; set; }
+    public long TotalBytes { get; set; }
+    public string SizeFormatted { get; set; } = string.Empty;
+    public double PercentOfDisk { get; set; }
+    public long AverageFileSizeBytes { get; set; }
+    public string AverageSizeFormatted { get; set; } = string.Empty;
+    public string LargestFilePath { get; set; } = string.Empty;
+    public long LargestFileBytes { get; set; }
+    public string LargestSizeFormatted { get; set; } = string.Empty;
+}
+
+public class ExtensionBreakdownResult
+{
+    public string Root { get; set; } = string.Empty;
+    public List<ExtensionBreakdownItem> Extensions { get; set; } = new();
 }

--- a/frontend/gs_analyzer_ui/lib/models/extension_breakdown_model.dart
+++ b/frontend/gs_analyzer_ui/lib/models/extension_breakdown_model.dart
@@ -1,0 +1,63 @@
+class ExtensionBreakdownResult {
+  final String root;
+  final List<ExtensionBreakdownItem> extensions;
+
+  ExtensionBreakdownResult({
+    required this.root,
+    required this.extensions,
+  });
+
+  factory ExtensionBreakdownResult.fromJson(Map<String, dynamic> json) {
+    return ExtensionBreakdownResult(
+      root: json['root'] ?? '',
+      extensions: (json['extensions'] as List<dynamic>?)
+              ?.map((e) => ExtensionBreakdownItem.fromJson(e))
+              .toList() ??
+          [],
+    );
+  }
+}
+
+class ExtensionBreakdownItem {
+  final String ext;
+  final String category;
+  final int fileCount;
+  final int totalBytes;
+  final String sizeFormatted;
+  final double percentOfDisk;
+  final int averageFileSizeBytes;
+  final String averageSizeFormatted;
+  final String largestFilePath;
+  final int largestFileBytes;
+  final String largestSizeFormatted;
+
+  ExtensionBreakdownItem({
+    required this.ext,
+    required this.category,
+    required this.fileCount,
+    required this.totalBytes,
+    required this.sizeFormatted,
+    required this.percentOfDisk,
+    required this.averageFileSizeBytes,
+    required this.averageSizeFormatted,
+    required this.largestFilePath,
+    required this.largestFileBytes,
+    required this.largestSizeFormatted,
+  });
+
+  factory ExtensionBreakdownItem.fromJson(Map<String, dynamic> json) {
+    return ExtensionBreakdownItem(
+      ext: json['ext'] ?? '',
+      category: json['category'] ?? '',
+      fileCount: json['fileCount'] ?? 0,
+      totalBytes: json['totalBytes'] ?? 0,
+      sizeFormatted: json['sizeFormatted'] ?? '',
+      percentOfDisk: (json['percentOfDisk'] as num?)?.toDouble() ?? 0.0,
+      averageFileSizeBytes: json['averageFileSizeBytes'] ?? 0,
+      averageSizeFormatted: json['averageSizeFormatted'] ?? '',
+      largestFilePath: json['largestFilePath'] ?? '',
+      largestFileBytes: json['largestFileBytes'] ?? 0,
+      largestSizeFormatted: json['largestSizeFormatted'] ?? '',
+    );
+  }
+}

--- a/frontend/gs_analyzer_ui/lib/providers/extension_breakdown_provider.dart
+++ b/frontend/gs_analyzer_ui/lib/providers/extension_breakdown_provider.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:gs_analyzer_ui/models/extension_breakdown_model.dart';
+import 'package:gs_analyzer_ui/services/api_service.dart';
+
+// State Providers for Filtering and Sorting
+final ebSearchQueryProvider = StateProvider<String>((ref) => '');
+final ebSelectedCategoriesProvider = StateProvider<Set<String>>((ref) => {});
+final ebSortColumnProvider = StateProvider<String>((ref) => 'totalBytes');
+final ebSortAscendingProvider = StateProvider<bool>((ref) => false);
+
+// Future Provider for fetching data
+final extensionBreakdownProvider = FutureProvider.family<ExtensionBreakdownResult, String>((ref, root) async {
+  return await ApiService().getExtensionBreakdown(root);
+});
+
+// Computed Provider for filtering and sorting
+final filteredExtensionBreakdownProvider = Provider.family<List<ExtensionBreakdownItem>, String>((ref, root) {
+  final asyncResult = ref.watch(extensionBreakdownProvider(root));
+  
+  return asyncResult.maybeWhen(
+    data: (result) {
+      final items = result.extensions;
+      final query = ref.watch(ebSearchQueryProvider).toLowerCase();
+      final selectedCategories = ref.watch(ebSelectedCategoriesProvider);
+      final sortColumn = ref.watch(ebSortColumnProvider);
+      final isAscending = ref.watch(ebSortAscendingProvider);
+
+      // Filtering
+      var filtered = items.where((item) {
+        if (query.isNotEmpty && !item.ext.toLowerCase().contains(query)) {
+          return false;
+        }
+        if (selectedCategories.isNotEmpty && !selectedCategories.contains(item.category)) {
+          return false;
+        }
+        return true;
+      }).toList();
+
+      // Sorting
+      filtered.sort((a, b) {
+        int cmp;
+        switch (sortColumn) {
+          case 'ext':
+            cmp = a.ext.compareTo(b.ext);
+            break;
+          case 'category':
+            cmp = a.category.compareTo(b.category);
+            break;
+          case 'fileCount':
+            cmp = a.fileCount.compareTo(b.fileCount);
+            break;
+          case 'totalBytes':
+            cmp = a.totalBytes.compareTo(b.totalBytes);
+            break;
+          case 'averageFileSizeBytes':
+            cmp = a.averageFileSizeBytes.compareTo(b.averageFileSizeBytes);
+            break;
+          case 'percentOfDisk':
+            cmp = a.percentOfDisk.compareTo(b.percentOfDisk);
+            break;
+          default:
+            cmp = 0;
+        }
+        return isAscending ? cmp : -cmp;
+      });
+
+      return filtered;
+    },
+    orElse: () => [],
+  );
+});

--- a/frontend/gs_analyzer_ui/lib/services/api_service.dart
+++ b/frontend/gs_analyzer_ui/lib/services/api_service.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:flutter/foundation.dart';
 import 'package:gs_analyzer_ui/models/age_heatmap_model.dart';
 import 'package:gs_analyzer_ui/models/drive_stats.dart';
 import 'package:gs_analyzer_ui/models/nuke_preview.dart';
@@ -6,6 +7,7 @@ import 'package:gs_analyzer_ui/models/nuke_result.dart';
 import 'package:http/http.dart' as http;
 import 'package:gs_analyzer_ui/models/storage_node.dart';
 import 'package:gs_analyzer_ui/models/file_type_model.dart';
+import 'package:gs_analyzer_ui/models/extension_breakdown_model.dart';
 import 'package:gs_analyzer_ui/providers/age_heatmap_provider.dart';
 import 'package:gs_analyzer_ui/providers/file_type_provider.dart';
 
@@ -356,6 +358,25 @@ class ApiService {
     );
   }
 
+  Future<ExtensionBreakdownResult> getExtensionBreakdown(String root) async {
+    final uri = Uri.parse('$storageUrl/scan/extensions')
+        .replace(queryParameters: {'root': root});
+
+    final response = await _client.get(uri);
+
+    if (response.statusCode == 409) {
+      throw const FileTypeNoScanException();
+    }
+
+    if (response.statusCode != 200) {
+      throw Exception(
+        'ExtensionBreakdown fetch failed [${response.statusCode}]: ${response.body}',
+      );
+    }
+
+    return compute(_parseBreakdown, response.body);
+  }
+
   Future<bool> clearCache() async {
   try {
     final response = await _client.post(Uri.parse('$settingsUrl/cache/clear'));
@@ -393,6 +414,12 @@ class ApiService {
       jsonDecode(response.body) as Map<String, dynamic>,
     );
   }
+}
+
+ExtensionBreakdownResult _parseBreakdown(String body) {
+  return ExtensionBreakdownResult.fromJson(
+    jsonDecode(body) as Map<String, dynamic>
+  );
 }
 
 

--- a/frontend/gs_analyzer_ui/lib/utils/csv_exporter.dart
+++ b/frontend/gs_analyzer_ui/lib/utils/csv_exporter.dart
@@ -1,0 +1,78 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:gs_analyzer_ui/models/extension_breakdown_model.dart';
+import 'package:gs_analyzer_ui/utils/hud_theme.dart';
+
+class CsvExporter {
+  static Future<void> exportExtensionBreakdown(
+      BuildContext context, List<ExtensionBreakdownItem> items) async {
+    try {
+      final userProfile = Platform.environment['USERPROFILE'];
+      if (userProfile == null) {
+        throw Exception('Could not locate user profile directory.');
+      }
+
+      var targetDir = Directory('$userProfile\\Downloads');
+      if (!await targetDir.exists()) {
+        targetDir = Directory('$userProfile\\Desktop');
+        if (!await targetDir.exists()) {
+          throw Exception('Could not locate Downloads or Desktop folder.');
+        }
+      }
+
+      final timestamp = DateTime.now().toIso8601String().replaceAll(':', '-').split('.').first;
+      final file = File('${targetDir.path}\\ExtensionBreakdown_$timestamp.csv');
+
+      final buffer = StringBuffer();
+      // CSV Header
+      buffer.writeln('Extension,Category,File Count,Total Size (Bytes),Size Formatted,% of Disk,Avg Size (Bytes),Avg Size Formatted,Largest File Bytes,Largest Size Formatted,Largest File Path');
+
+      // CSV Rows
+      for (final item in items) {
+        final row = [
+          _escape(item.ext),
+          _escape(item.category),
+          item.fileCount,
+          item.totalBytes,
+          _escape(item.sizeFormatted),
+          item.percentOfDisk,
+          item.averageFileSizeBytes,
+          _escape(item.averageSizeFormatted),
+          item.largestFileBytes,
+          _escape(item.largestSizeFormatted),
+          _escape(item.largestFilePath),
+        ];
+        buffer.writeln(row.join(','));
+      }
+
+      await file.writeAsString(buffer.toString());
+
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Exported to ${file.path}', style: HudTheme.bodyText),
+            backgroundColor: HudTheme.bgPanel,
+            duration: const Duration(seconds: 4),
+          ),
+        );
+      }
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Failed to export CSV: $e', style: HudTheme.actionRed),
+            backgroundColor: HudTheme.bgPanel,
+            duration: const Duration(seconds: 4),
+          ),
+        );
+      }
+    }
+  }
+
+  static String _escape(String value) {
+    if (value.contains(',') || value.contains('"') || value.contains('\n')) {
+      return '"${value.replaceAll('"', '""')}"';
+    }
+    return value;
+  }
+}

--- a/frontend/gs_analyzer_ui/lib/utils/hud_theme.dart
+++ b/frontend/gs_analyzer_ui/lib/utils/hud_theme.dart
@@ -110,4 +110,16 @@ class HudTheme {
       default:            return Colors.cyanAccent;
     }
   }
+
+  static Color fileTypeColor(String category) {
+    switch (category.toLowerCase()) {
+      case 'media':       return const Color(0xFF00FFFF);
+      case 'documents':   return const Color(0xFF4CAF50);
+      case 'executables': return const Color(0xFFFF5252);
+      case 'archives':    return const Color(0xFFFFB300);
+      case 'code':        return const Color(0xFF9C27B0);
+      case 'system':      return Colors.white38;
+      default:            return Colors.white12;
+    }
+  }
 }

--- a/frontend/gs_analyzer_ui/lib/utils/hud_theme.dart
+++ b/frontend/gs_analyzer_ui/lib/utils/hud_theme.dart
@@ -45,6 +45,13 @@ class HudTheme {
     fontWeight: FontWeight.bold
   );
 
+  // For numeric data values like sizes, percentages, counts
+  static const TextStyle statCyan = TextStyle(
+    fontFamily: fontCore,
+    color: accentCyan,
+    fontSize: 13,
+  );
+
   // for destructive action like 'ABORT SCAN'
   static const TextStyle actionRed = TextStyle(
     fontFamily: fontCore,

--- a/frontend/gs_analyzer_ui/lib/widgets/extension_breakdown_screen.dart
+++ b/frontend/gs_analyzer_ui/lib/widgets/extension_breakdown_screen.dart
@@ -42,7 +42,7 @@ class _ExtensionBreakdownScreenState extends ConsumerState<ExtensionBreakdownScr
         backgroundColor: HudTheme.bgPanel,
         elevation: 0,
         title: Text(
-          'EXTENSION BREAKDOWN  ·  ${widget.driveName}',
+          'EXTENSION_BREAKDOWN_${widget.driveName.replaceAll(' ', '_')}',
           style: HudTheme.headerCyan,
         ),
         actions: [
@@ -221,19 +221,19 @@ class _ExtensionBreakdownScreenState extends ConsumerState<ExtensionBreakdownScr
             ),
             Expanded(
               flex: 1,
-              child: Text('${item.fileCount}', style: HudTheme.bodyText, textAlign: TextAlign.right, overflow: TextOverflow.ellipsis, maxLines: 1),
+              child: Text('${item.fileCount}', style: HudTheme.statCyan, textAlign: TextAlign.right, overflow: TextOverflow.ellipsis, maxLines: 1),
             ),
             Expanded(
               flex: 2,
-              child: Text(item.sizeFormatted, style: const TextStyle(color: Colors.white70), textAlign: TextAlign.right, overflow: TextOverflow.ellipsis, maxLines: 1),
+              child: Text(item.sizeFormatted, style: HudTheme.statCyan, textAlign: TextAlign.right, overflow: TextOverflow.ellipsis, maxLines: 1),
             ),
             Expanded(
               flex: 2,
-              child: Text(item.averageSizeFormatted, style: const TextStyle(color: Colors.white54), textAlign: TextAlign.right, overflow: TextOverflow.ellipsis, maxLines: 1),
+              child: Text(item.averageSizeFormatted, style: HudTheme.statCyan, textAlign: TextAlign.right, overflow: TextOverflow.ellipsis, maxLines: 1),
             ),
             Expanded(
               flex: 1,
-              child: Text('${item.percentOfDisk}%', style: const TextStyle(color: Colors.white38), textAlign: TextAlign.right, overflow: TextOverflow.ellipsis, maxLines: 1),
+              child: Text('${item.percentOfDisk}%', style: HudTheme.statCyan, textAlign: TextAlign.right, overflow: TextOverflow.ellipsis, maxLines: 1),
             ),
           ],
         ),
@@ -424,7 +424,7 @@ class _DetailStat extends StatelessWidget {
       children: [
         Text(label, style: const TextStyle(color: Colors.white38, fontSize: 10, fontWeight: FontWeight.bold, letterSpacing: 1.2)),
         const SizedBox(height: 4),
-        Text(value, style: const TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.bold)),
+        Text(value, style: HudTheme.statCyan.copyWith(fontSize: 16)),
       ],
     );
   }

--- a/frontend/gs_analyzer_ui/lib/widgets/extension_breakdown_screen.dart
+++ b/frontend/gs_analyzer_ui/lib/widgets/extension_breakdown_screen.dart
@@ -1,0 +1,431 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gs_analyzer_ui/models/extension_breakdown_model.dart';
+import 'package:gs_analyzer_ui/providers/directory_provider.dart';
+import 'package:gs_analyzer_ui/providers/extension_breakdown_provider.dart';
+import 'package:gs_analyzer_ui/providers/file_type_provider.dart';
+import 'package:gs_analyzer_ui/utils/csv_exporter.dart';
+import 'package:gs_analyzer_ui/utils/hud_theme.dart';
+
+class ExtensionBreakdownScreen extends ConsumerStatefulWidget {
+  final String scanRoot;
+  final String driveName;
+
+  const ExtensionBreakdownScreen({
+    super.key,
+    required this.scanRoot,
+    required this.driveName,
+  });
+
+  @override
+  ConsumerState<ExtensionBreakdownScreen> createState() => _ExtensionBreakdownScreenState();
+}
+
+class _ExtensionBreakdownScreenState extends ConsumerState<ExtensionBreakdownScreen> {
+  Timer? _debounce;
+
+  @override
+  void dispose() {
+    _debounce?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final asyncResult = ref.watch(extensionBreakdownProvider(widget.scanRoot));
+
+    return Scaffold(
+      backgroundColor: HudTheme.bgBase,
+      appBar: AppBar(
+        backgroundColor: HudTheme.bgPanel,
+        elevation: 0,
+        title: Text(
+          'EXTENSION BREAKDOWN  ·  ${widget.driveName}',
+          style: HudTheme.headerCyan,
+        ),
+        actions: [
+          TextButton.icon(
+            icon: const Icon(Icons.download, color: HudTheme.accentCyan, size: 18),
+            label: const Text('CSV', style: TextStyle(color: HudTheme.accentCyan)),
+            onPressed: () {
+              final items = ref.read(filteredExtensionBreakdownProvider(widget.scanRoot));
+              if (items.isNotEmpty) {
+                CsvExporter.exportExtensionBreakdown(context, items);
+              }
+            },
+          ),
+          const SizedBox(width: 16),
+        ],
+      ),
+      body: asyncResult.when(
+        loading: () => const Center(child: CircularProgressIndicator(color: HudTheme.accentCyan)),
+        error: (e, _) {
+          if (e is FileTypeNoScanException) {
+            return _buildNoScanView();
+          }
+          return Center(
+            child: Text('ERROR: $e', style: HudTheme.actionRed),
+          );
+        },
+        data: (result) => _buildDataView(context, ref, result),
+      ),
+    );
+  }
+
+  Widget _buildNoScanView() {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.warning_amber_rounded, color: HudTheme.accentAmber, size: 64),
+          const SizedBox(height: 16),
+          Text(
+            'RUN A SCAN FIRST',
+            style: HudTheme.headerCyan.copyWith(color: HudTheme.accentAmber),
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            'No scan data cached for this drive.\nPlease return to the dashboard and initiate a scan.',
+            style: HudTheme.bodyText,
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDataView(BuildContext context, WidgetRef ref, ExtensionBreakdownResult result) {
+    final filteredItems = ref.watch(filteredExtensionBreakdownProvider(widget.scanRoot));
+
+    return Column(
+      children: [
+        _buildFilters(context, ref, result.extensions),
+        _buildHeaderRow(ref),
+        Expanded(
+          child: ListView.builder(
+            itemCount: filteredItems.length,
+            itemExtent: 44, // Fixed height for performance
+            itemBuilder: (context, index) {
+              final item = filteredItems[index];
+              return _buildListRow(context, ref, item);
+            },
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildHeaderRow(WidgetRef ref) {
+    return Container(
+      color: HudTheme.bgPanel,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Row(
+        children: [
+          _buildSortableHeader(ref, 'Ext', 'ext', flex: 2),
+          _buildSortableHeader(ref, 'Category', 'category', flex: 2),
+          _buildSortableHeader(ref, 'Files', 'fileCount', flex: 1, numeric: true),
+          _buildSortableHeader(ref, 'Total Size', 'totalBytes', flex: 2, numeric: true),
+          _buildSortableHeader(ref, 'Avg Size', 'averageFileSizeBytes', flex: 2, numeric: true),
+          _buildSortableHeader(ref, '% Disk', 'percentOfDisk', flex: 1, numeric: true),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSortableHeader(WidgetRef ref, String label, String key, {required int flex, bool numeric = false}) {
+    final currentSort = ref.watch(ebSortColumnProvider);
+    final isAscending = ref.watch(ebSortAscendingProvider);
+    final isSorted = currentSort == key;
+
+    return Expanded(
+      flex: flex,
+      child: InkWell(
+        onTap: () {
+          ref.read(ebSortColumnProvider.notifier).state = key;
+          if (isSorted) {
+            ref.read(ebSortAscendingProvider.notifier).state = !isAscending;
+          } else {
+            ref.read(ebSortAscendingProvider.notifier).state = false; // default desc on new col
+          }
+        },
+        child: Container(
+          alignment: numeric ? Alignment.centerRight : Alignment.centerLeft,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Flexible(
+                child: Text(
+                  label,
+                  style: TextStyle(
+                    color: isSorted ? HudTheme.accentCyan : Colors.white70,
+                    fontWeight: FontWeight.bold,
+                    fontSize: 12,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              if (isSorted)
+                Icon(
+                  isAscending ? Icons.arrow_drop_up : Icons.arrow_drop_down,
+                  color: HudTheme.accentCyan,
+                  size: 16,
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildListRow(BuildContext context, WidgetRef ref, ExtensionBreakdownItem item) {
+    final catColor = HudTheme.fileTypeColor(item.category);
+    
+    return InkWell(
+      onTap: () => _showDetailSheet(context, ref, item, catColor),
+      child: Container(
+        decoration: const BoxDecoration(
+          border: Border(bottom: BorderSide(color: Colors.white10)),
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        alignment: Alignment.center,
+        child: Row(
+          children: [
+            Expanded(
+              flex: 2,
+              child: Row(
+                children: [
+                  Container(
+                    width: 8,
+                    height: 8,
+                    decoration: BoxDecoration(
+                      color: catColor,
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Flexible(
+                    child: Text(
+                      item.ext, 
+                      style: const TextStyle(color: Colors.white, fontFamily: 'monospace'),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Expanded(
+              flex: 2,
+              child: Text(item.category.toUpperCase(), style: TextStyle(color: catColor, fontSize: 12), overflow: TextOverflow.ellipsis, maxLines: 1),
+            ),
+            Expanded(
+              flex: 1,
+              child: Text('${item.fileCount}', style: HudTheme.bodyText, textAlign: TextAlign.right, overflow: TextOverflow.ellipsis, maxLines: 1),
+            ),
+            Expanded(
+              flex: 2,
+              child: Text(item.sizeFormatted, style: const TextStyle(color: Colors.white70), textAlign: TextAlign.right, overflow: TextOverflow.ellipsis, maxLines: 1),
+            ),
+            Expanded(
+              flex: 2,
+              child: Text(item.averageSizeFormatted, style: const TextStyle(color: Colors.white54), textAlign: TextAlign.right, overflow: TextOverflow.ellipsis, maxLines: 1),
+            ),
+            Expanded(
+              flex: 1,
+              child: Text('${item.percentOfDisk}%', style: const TextStyle(color: Colors.white38), textAlign: TextAlign.right, overflow: TextOverflow.ellipsis, maxLines: 1),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFilters(BuildContext context, WidgetRef ref, List<ExtensionBreakdownItem> allItems) {
+    final selectedCategories = ref.watch(ebSelectedCategoriesProvider);
+    final allCategories = allItems.map((e) => e.category).toSet().toList()..sort();
+
+    return Container(
+      padding: const EdgeInsets.all(16.0),
+      decoration: const BoxDecoration(
+        border: Border(bottom: BorderSide(color: Colors.white10)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          TextField(
+            style: const TextStyle(color: Colors.white),
+            decoration: InputDecoration(
+              hintText: 'Search extensions...',
+              hintStyle: const TextStyle(color: Colors.white38),
+              prefixIcon: const Icon(Icons.search, color: Colors.white38),
+              filled: true,
+              fillColor: HudTheme.bgPanel,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(8),
+                borderSide: BorderSide.none,
+              ),
+            ),
+            onChanged: (val) {
+              if (_debounce?.isActive ?? false) _debounce!.cancel();
+              _debounce = Timer(const Duration(milliseconds: 300), () {
+                ref.read(ebSearchQueryProvider.notifier).state = val;
+              });
+            },
+          ),
+          const SizedBox(height: 12),
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: Row(
+              children: allCategories.map((cat) {
+                final isSelected = selectedCategories.contains(cat);
+                final catColor = HudTheme.fileTypeColor(cat);
+                return Padding(
+                  padding: const EdgeInsets.only(right: 8.0),
+                  child: FilterChip(
+                    label: Text(cat.toUpperCase(), style: TextStyle(color: isSelected ? Colors.black : Colors.white70, fontSize: 11, fontWeight: FontWeight.bold)),
+                    selected: isSelected,
+                    selectedColor: HudTheme.accentCyan,
+                    backgroundColor: catColor.withValues(alpha: 0.1),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(4),
+                      side: BorderSide(color: isSelected ? HudTheme.accentCyan : catColor.withValues(alpha: 0.3)),
+                    ),
+                    onSelected: (selected) {
+                      final notif = ref.read(ebSelectedCategoriesProvider.notifier);
+                      if (selected) {
+                        notif.state = {...notif.state, cat};
+                      } else {
+                        notif.state = notif.state.where((c) => c != cat).toSet();
+                      }
+                    },
+                  ),
+                );
+              }).toList(),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+
+
+  void _showDetailSheet(BuildContext context, WidgetRef ref, ExtensionBreakdownItem item, Color catColor) {
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: HudTheme.bgPanel,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(12)),
+      ),
+      builder: (ctx) {
+        return Padding(
+          padding: const EdgeInsets.all(24.0),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+                    decoration: BoxDecoration(
+                      color: catColor.withValues(alpha: 0.2),
+                      borderRadius: BorderRadius.circular(4),
+                      border: Border.all(color: catColor.withValues(alpha: 0.5)),
+                    ),
+                    child: Text(item.ext, style: TextStyle(color: catColor, fontSize: 20, fontFamily: 'monospace', fontWeight: FontWeight.bold)),
+                  ),
+                  const SizedBox(width: 16),
+                  Text(item.category.toUpperCase(), style: TextStyle(color: catColor, fontSize: 14, letterSpacing: 1.5)),
+                ],
+              ),
+              const SizedBox(height: 24),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  _DetailStat(label: 'TOTAL FILES', value: '${item.fileCount}'),
+                  _DetailStat(label: 'TOTAL SIZE', value: item.sizeFormatted),
+                  _DetailStat(label: 'AVG SIZE', value: item.averageSizeFormatted),
+                  _DetailStat(label: '% DISK', value: '${item.percentOfDisk}%'),
+                ],
+              ),
+              const SizedBox(height: 24),
+              const Divider(color: Colors.white10),
+              const SizedBox(height: 16),
+              Text('LARGEST FILE RECORDED', style: HudTheme.labelMuted.copyWith(color: HudTheme.accentCyan)),
+              const SizedBox(height: 8),
+              if (item.largestFilePath.isEmpty)
+                const Text('No file path recorded.', style: TextStyle(color: Colors.white54))
+              else
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(item.largestFilePath, style: const TextStyle(color: Colors.white, fontSize: 13, fontFamily: 'monospace')),
+                    const SizedBox(height: 4),
+                    Text(item.largestSizeFormatted, style: const TextStyle(color: HudTheme.accentAmber, fontWeight: FontWeight.bold)),
+                    const SizedBox(height: 16),
+                    Row(
+                      children: [
+                        ElevatedButton.icon(
+                          icon: const Icon(Icons.copy, size: 16),
+                          label: const Text('COPY PATH'),
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: Colors.white12,
+                            foregroundColor: Colors.white,
+                          ),
+                          onPressed: () {
+                            Clipboard.setData(ClipboardData(text: item.largestFilePath));
+                            Navigator.pop(ctx);
+                            ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Path copied to clipboard'), backgroundColor: HudTheme.bgPanel, duration: Duration(seconds: 2)));
+                          },
+                        ),
+                        const SizedBox(width: 12),
+                        ElevatedButton.icon(
+                          icon: const Icon(Icons.folder_open, size: 16),
+                          label: const Text('FIND IN EXPLORER'),
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: HudTheme.accentCyan.withValues(alpha: 0.1),
+                            foregroundColor: HudTheme.accentCyan,
+                            side: const BorderSide(color: HudTheme.accentCyan),
+                          ),
+                          onPressed: () {
+                            // Close bottom sheet
+                            Navigator.pop(ctx);
+                            // Close extension breakdown screen to go back to dashboard
+                            Navigator.pop(context);
+                            // Set directory provider to parent directory
+                            final path = item.largestFilePath;
+                            final parentDir = path.substring(0, path.lastIndexOf(RegExp(r'[\\/]')));
+                            ref.read(directoryProvider.notifier).scanDirectory(parentDir);
+                          },
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _DetailStat extends StatelessWidget {
+  final String label;
+  final String value;
+  const _DetailStat({required this.label, required this.value});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(label, style: const TextStyle(color: Colors.white38, fontSize: 10, fontWeight: FontWeight.bold, letterSpacing: 1.2)),
+        const SizedBox(height: 4),
+        Text(value, style: const TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.bold)),
+      ],
+    );
+  }
+}

--- a/frontend/gs_analyzer_ui/lib/widgets/file_type_analyzer_panel.dart
+++ b/frontend/gs_analyzer_ui/lib/widgets/file_type_analyzer_panel.dart
@@ -3,6 +3,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:gs_analyzer_ui/models/file_type_model.dart';
 import 'package:gs_analyzer_ui/providers/file_type_provider.dart';
+import 'package:gs_analyzer_ui/providers/extension_breakdown_provider.dart';
+import 'package:gs_analyzer_ui/widgets/extension_breakdown_screen.dart';
+import 'package:gs_analyzer_ui/utils/hud_theme.dart';
 
 class FileTypeAnalyzerPanel extends ConsumerWidget {
   final String driveName;
@@ -79,7 +82,7 @@ class FileTypeAnalyzerPanel extends ConsumerWidget {
             error:   (e, _) => e is FileTypeNoScanException
                 ? _NoScanState(driveName: driveName, root: scanRoot)
                 : _ErrorState(error: e.toString()),
-            data:    (result) => _DataView(result: result),
+            data:    (result) => _DataView(result: result, driveName: driveName, scanRoot: scanRoot),
           ),
         ],
       ),
@@ -252,11 +255,13 @@ class _ErrorState extends StatelessWidget {
 
 class _DataView extends ConsumerWidget {
   final FileTypeResult result;
-  const _DataView({required this.result});
+  final String driveName;
+  final String scanRoot;
+  const _DataView({required this.result, required this.driveName, required this.scanRoot});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final selected = ref.watch(selectedCategoryProvider);
+    final selectedCat = ref.watch(selectedCategoryProvider);
 
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 8, 16, 20),
@@ -267,11 +272,11 @@ class _DataView extends ConsumerWidget {
           SizedBox(
             width: 180,
             height: 180,
-            child: _DonutChart(result: result, selected: selected),
+            child: _DonutChart(result: result, selected: selectedCat),
           ),
           const SizedBox(width: 24),
           // Category list
-          Expanded(child: _CategoryList(result: result, selected: selected)),
+          Expanded(child: _CategoryList(result: result, selected: selectedCat, driveName: driveName, scanRoot: scanRoot)),
         ],
       ),
     );
@@ -289,7 +294,7 @@ class _DonutChart extends ConsumerWidget {
       final isSelected = selected == null || selected == cat.name;
       return PieChartSectionData(
         value:          cat.percentOfDisk,
-        color:          _fileTypeColor(cat.name)
+        color:          HudTheme.fileTypeColor(cat.name)
             .withValues(alpha: isSelected ? 1.0 : 0.25),
         radius:         selected == cat.name ? 38 : 32,
         title:          '',
@@ -346,13 +351,15 @@ class _DonutChart extends ConsumerWidget {
   }
 }
 
-class _CategoryList extends ConsumerWidget {
+class _CategoryList extends StatelessWidget {
   final FileTypeResult result;
   final String?        selected;
-  const _CategoryList({required this.result, required this.selected});
+  final String driveName;
+  final String scanRoot;
+  const _CategoryList({required this.result, required this.selected, required this.driveName, required this.scanRoot});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     return Column(
       children: result.categories.map((cat) {
         final isSelected = selected == cat.name;
@@ -362,8 +369,8 @@ class _CategoryList extends ConsumerWidget {
             border: Border(
               left: BorderSide(
                 color: isSelected
-                    ? _fileTypeColor(cat.name)
-                    : _fileTypeColor(cat.name).withValues(alpha: 0.3),
+                    ? HudTheme.fileTypeColor(cat.name)
+                    : HudTheme.fileTypeColor(cat.name).withValues(alpha: 0.3),
                 width: 3,
               ),
             ),
@@ -374,15 +381,16 @@ class _CategoryList extends ConsumerWidget {
             collapsedBackgroundColor: const Color(0xFF0D0F14),
             backgroundColor:          const Color(0xFF0D0F14),
             onExpansionChanged: (_) {
-              ref.read(selectedCategoryProvider.notifier).state =
-                  isSelected ? null : cat.name;
+              // Now we don't need ref.read here for category selection since it pushes a screen
+              // Wait, ExpansionTile still needs it if it expands? It's fine to leave it or remove it.
+              // We'll leave the Expansion logic for the tile but we will push the screen from an icon.
             },
             title: Row(
               children: [
                 Container(
                     width: 10, height: 10,
                     decoration: BoxDecoration(
-                      color: _fileTypeColor(cat.name),
+                      color: HudTheme.fileTypeColor(cat.name),
                       shape: BoxShape.circle,
                     )),
                 const SizedBox(width: 8),
@@ -399,7 +407,7 @@ class _CategoryList extends ConsumerWidget {
               children: [
                 Text(cat.sizeFormatted,
                     style: TextStyle(
-                        color: _fileTypeColor(cat.name),
+                        color: HudTheme.fileTypeColor(cat.name),
                         fontSize: 12,
                         fontWeight: FontWeight.w600)),
                 const SizedBox(width: 8),
@@ -410,12 +418,27 @@ class _CategoryList extends ConsumerWidget {
                 Text('${cat.fileCount} f',
                     style: TextStyle(
                         color: Colors.white.withValues(alpha: 0.35), fontSize: 10)),
+                const SizedBox(width: 8),
+                Consumer(
+                  builder: (context, ref, child) {
+                    return IconButton(
+                      icon: const Icon(Icons.open_in_new, color: HudTheme.accentCyan, size: 16),
+                      tooltip: 'View Extensions Breakdown',
+                      onPressed: () {
+                        ref.read(ebSelectedCategoriesProvider.notifier).state = {cat.name};
+                        Navigator.push(context, MaterialPageRoute(
+                          builder: (ctx) => ExtensionBreakdownScreen(scanRoot: scanRoot, driveName: driveName)
+                        ));
+                      },
+                    );
+                  }
+                ),
                 const Icon(Icons.expand_more_rounded,
                     color: Colors.white38, size: 16),
               ],
             ),
             children: cat.extensions
-                .map((ext) => _ExtRow(ext: ext, catColor: _fileTypeColor(cat.name)))
+                .map((ext) => _ExtRow(ext: ext, catColor: HudTheme.fileTypeColor(cat.name), scanRoot: scanRoot, driveName: driveName, category: cat.name))
                 .toList(),
           ),
         );
@@ -424,49 +447,52 @@ class _CategoryList extends ConsumerWidget {
   }
 }
 
-class _ExtRow extends StatelessWidget {
+class _ExtRow extends ConsumerWidget {
   final FileTypeExtensionEntry ext;
   final Color                  catColor;
-  const _ExtRow({required this.ext, required this.catColor});
+  final String                 scanRoot;
+  final String                 driveName;
+  final String                 category;
+  const _ExtRow({required this.ext, required this.catColor, required this.scanRoot, required this.driveName, required this.category});
 
   @override
-  Widget build(BuildContext context) => Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 5),
-        child: Row(
-          children: [
-            Container(
-              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-              decoration: BoxDecoration(
-                color:        catColor.withValues(alpha: 0.12),
-                borderRadius: BorderRadius.circular(3),
-                border:       Border.all(color: catColor.withValues(alpha: 0.3)),
+  Widget build(BuildContext context, WidgetRef ref) => InkWell(
+        onTap: () {
+          ref.read(ebSelectedCategoriesProvider.notifier).state = {category};
+          ref.read(ebSearchQueryProvider.notifier).state = ext.ext;
+          Navigator.push(context, MaterialPageRoute(
+            builder: (ctx) => ExtensionBreakdownScreen(scanRoot: scanRoot, driveName: driveName)
+          ));
+        },
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 5),
+          child: Row(
+            children: [
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                decoration: BoxDecoration(
+                  color:        catColor.withValues(alpha: 0.12),
+                  borderRadius: BorderRadius.circular(3),
+                  border:       Border.all(color: catColor.withValues(alpha: 0.3)),
+                ),
+                child: Text(ext.ext,
+                    style: TextStyle(
+                        color: catColor, fontSize: 10, fontFamily: 'monospace')),
               ),
-              child: Text(ext.ext,
+              const Spacer(),
+              Text(ext.sizeFormatted,
+                  style: const TextStyle(color: Colors.white70, fontSize: 11)),
+              const SizedBox(width: 12),
+              Text('${ext.percentOfDisk}%',
                   style: TextStyle(
-                      color: catColor, fontSize: 10, fontFamily: 'monospace')),
-            ),
-            const Spacer(),
-            Text(ext.sizeFormatted,
-                style: const TextStyle(color: Colors.white70, fontSize: 11)),
-            const SizedBox(width: 12),
-            Text('${ext.percentOfDisk}%',
-                style: TextStyle(
-                    color: Colors.white.withValues(alpha: 0.4), fontSize: 10)),
-            const SizedBox(width: 12),
-            Text('${ext.fileCount} files',
-                style: TextStyle(
-                    color: Colors.white.withValues(alpha: 0.3), fontSize: 10)),
-          ],
+                      color: Colors.white.withValues(alpha: 0.4), fontSize: 10)),
+              const SizedBox(width: 12),
+              Text('${ext.fileCount} files',
+                  style: TextStyle(
+                      color: Colors.white.withValues(alpha: 0.3), fontSize: 10)),
+            ],
+          ),
         ),
       );
 }
-
-Color _fileTypeColor(String category) => switch (category.toLowerCase()) {
-      'media'       => const Color(0xFF00FFFF),
-      'documents'   => const Color(0xFF4CAF50),
-      'executables' => const Color(0xFFFF5252),
-      'archives'    => const Color(0xFFFFB300),
-      'code'        => const Color(0xFF9C27B0),
-      'system'      => Colors.white38,
-      _             => Colors.white12,
-    };
+

--- a/frontend/gs_analyzer_ui/test/widgets/extension_breakdown_screen_test.dart
+++ b/frontend/gs_analyzer_ui/test/widgets/extension_breakdown_screen_test.dart
@@ -1,0 +1,107 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gs_analyzer_ui/models/extension_breakdown_model.dart';
+import 'package:gs_analyzer_ui/providers/extension_breakdown_provider.dart';
+import 'package:gs_analyzer_ui/providers/file_type_provider.dart';
+import 'package:gs_analyzer_ui/services/api_service.dart';
+import 'package:riverpod/riverpod.dart' as riverpod;
+import 'package:gs_analyzer_ui/widgets/extension_breakdown_screen.dart';
+
+const _root = r'C:\TestDrive';
+
+ExtensionBreakdownItem _item(
+  String ext,
+  String category, {
+  int fileCount = 1,
+  int totalBytes = 1024,
+}) {
+  return ExtensionBreakdownItem(
+    ext: ext,
+    category: category,
+    fileCount: fileCount,
+    totalBytes: totalBytes,
+    sizeFormatted: '1.0 KB',
+    percentOfDisk: 50.0,
+    averageFileSizeBytes: 1024,
+    averageSizeFormatted: '1.0 KB',
+    largestFilePath: '$_root\\big$ext',
+    largestFileBytes: 1024,
+    largestSizeFormatted: '1.0 KB',
+  );
+}
+
+Widget _wrap(dynamic overrides) {
+  return ProviderScope(
+    overrides: overrides,
+    child: const MaterialApp(
+      home: ExtensionBreakdownScreen(scanRoot: _root, driveName: 'C:'),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('shows a spinner while the breakdown is loading', (tester) async {
+    await tester.pumpWidget(_wrap([
+      // A future that never completes keeps the provider in the loading state.
+      extensionBreakdownProvider(_root)
+          .overrideWith((ref) => Completer<ExtensionBreakdownResult>().future),
+    ]));
+
+    await tester.pump(); // single frame — do NOT pumpAndSettle (spinner animates forever)
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.text('RUN A SCAN FIRST'), findsNothing);
+  });
+
+  testWidgets('shows the no-scan view when the API reports no cached scan',
+      (tester) async {
+    await tester.pumpWidget(_wrap([
+      extensionBreakdownProvider(_root).overrideWith(
+        (ref) =>
+            Future<ExtensionBreakdownResult>.error(FileTypeNoScanException()),
+      ),
+    ]));
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('RUN A SCAN FIRST'), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+  });
+
+  testWidgets('renders extension rows when data is available', (tester) async {
+    final result = ExtensionBreakdownResult(
+      root: _root,
+      extensions: [
+        _item('.mp4', 'media', fileCount: 2, totalBytes: 8000),
+        _item('.txt', 'documents', fileCount: 3, totalBytes: 1500),
+      ],
+    );
+
+    await tester.pumpWidget(_wrap([
+      extensionBreakdownProvider(_root).overrideWith((ref) => result),
+    ]));
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('.mp4'), findsOneWidget);
+    expect(find.text('.txt'), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+    expect(find.text('RUN A SCAN FIRST'), findsNothing);
+  });
+
+  testWidgets('builds without rows when the breakdown is empty', (tester) async {
+    final empty = ExtensionBreakdownResult(root: _root, extensions: const []);
+
+    await tester.pumpWidget(_wrap([
+      extensionBreakdownProvider(_root).overrideWith((ref) => empty),
+    ]));
+
+    await tester.pumpAndSettle();
+
+    // No data rows, but the screen still renders its header.
+    expect(find.text('.mp4'), findsNothing);
+    expect(find.textContaining('EXTENSION_BREAKDOWN'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## 📖 Overview
Adds an **Extension Breakdown** view that drills into a drive's deep file-type scan, breaking it down per file extension (size, file count, % of scanned data, average size, and the largest single file). 
* **Zero added scan cost:** Reuses the existing deep-scan cache.
* **Access:** Reached as a drill-down from the File Type Analytics panel.

## ⚙️ Backend Architecture
* **New Endpoint:** `GET /api/storage/scan/extensions?root=` (`StorageController.GetExtensions`), mirroring the existing `scan/filetypes` contract:
  * `400 ROOT_REQUIRED` — missing root path
  * `400 DRIVE_NOT_FOUND` — path doesn't exist
  * `409 NO_SCAN_CACHED` — drive hasn't been scanned yet
  * `200 OK` — Returns `ExtensionBreakdownResult`
* **Service Logic (`FileTypeScanner`):** `GetExtensionBreakdown(root)` builds the breakdown from the in-memory scan cache, mapping extensions to categories via the shared `_categoryMap` (`(none)` for extensionless files, `other` as fallback). Sorts by total bytes descending, and memoizes under `extbreakdown:{root}` for 15 min. `Invalidate(root)` now perfectly clears this key as well.
* **Largest-File Tracking:** `DiskScannerEngine.GetDirectorySize` now records `LargestFileBytes` and `LargestFilePath` per extension during the deep scan, propagating through `BuildFromMemory`.
* **Models:** Added `ExtensionBreakdownItem` and `ExtensionBreakdownResult`. `FileTypeEntry` gains the largest-file fields.

## 🖥️ Frontend Implementation
* **New Screen (`ExtensionBreakdownScreen`):** Searchable (debounced 300ms), category-filterable, sortable table. Includes a detail sheet providing the largest file, copy path, and a "Find in Explorer" jump-back action.
* **Provider Layer:** Introduced `extensionBreakdownProvider` (`FutureProvider.family`) + a derived `filteredExtensionBreakdownProvider` for optimal filter/sort state management.
* **Export Feature:** Added CSV export to Downloads (falls back to Desktop) with success/failure snackbar notifications.
* **Error Handling:** Reuses `FileTypeNoScanException` to catch the `409` path cleanly.

## 🚀 Performance Optimizations
* **Isolate Parsing:** JSON is parsed completely off the UI thread via `compute()`, fixing the "Not Responding" freeze on massive drives.
* **Render Efficiency:** The table utilizes `ListView.builder` with a fixed `itemExtent` (bypassing the standard `DataTable` rendering bottlenecks), combined with debounced search and memoized filtering/sorting.

## 🧪 Testing & Verification

### Automated Tests
* **Backend (`FileTypeScannerTests.cs`):** Validated service happy-path aggregation, ordering, percentage/avg/largest logic, `(none)`/category mapping, no-scan → null edge cases, and result memoization.
* **Backend (`StorageControllerTests.cs`):** Validated endpoint routing across all four branches (`ROOT_REQUIRED`, `DRIVE_NOT_FOUND`, `409 NO_SCAN_CACHED`, `200 OK`).
* **Frontend (`extension_breakdown_screen_test.dart`):** Validated widget loading spinner, empty states, no-scan ("RUN A SCAN FIRST") guard, and data-row rendering states.
* *Note: All file-touching tests successfully isolated using temporary directories.*

### Test Plan
- [x] `dotnet test` (backend) green
- [x] `flutter test` (frontend) green
- [ ] **Manual:** Scan a drive → open Extension Breakdown → test sort/filter/search, export CSV, open a detail sheet and execute "Find in Explorer".
- [ ] **Manual:** Hit `scan/extensions` before initiating any scan → confirm `409` trigger → verify UI displays "RUN A SCAN FIRST".