### PR TITLE
feat: Historical Telemetry Charts (in-memory ring buffer + CPU/RAM/thermal line charts)

### DIFF
--- a/backend/Controllers/TelemetryHistoryController.cs
+++ b/backend/Controllers/TelemetryHistoryController.cs
@@ -27,7 +27,6 @@ namespace GSSystemAnalyzer.Controllers
             {
                 return BadRequest(new
                 {
-                    success = false,
                     message = "The 'metric' query parameter is required.",
                     supportedMetrics = _historyBuffer.GetSupportedMetrics()
                 });
@@ -43,7 +42,6 @@ namespace GSSystemAnalyzer.Controllers
             {
                 return BadRequest(new
                 {
-                    success = false,
                     message = $"Unknown metric '{metric}'.",
                     supportedMetrics = _historyBuffer.GetSupportedMetrics()
                 });

--- a/backend/Controllers/TelemetryHistoryController.cs
+++ b/backend/Controllers/TelemetryHistoryController.cs
@@ -1,0 +1,68 @@
+using GSSystemAnalyzer.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GSSystemAnalyzer.Controllers
+{
+    [ApiController]
+    [Route("api/telemetry")]
+    public class TelemetryHistoryController : ControllerBase
+    {
+        private readonly ITelemetryHistoryBuffer _historyBuffer;
+
+        public TelemetryHistoryController(ITelemetryHistoryBuffer historyBuffer)
+        {
+            _historyBuffer = historyBuffer;
+        }
+
+        /// <summary>
+        /// GET /api/telemetry/history?metric=cpu&amp;minutes=5
+        /// Returns the rolling history for a given metric within the requested time window.
+        /// </summary>
+        [HttpGet("history")]
+        public IActionResult GetHistory(
+            [FromQuery] string metric = "",
+            [FromQuery] int minutes = 5)
+        {
+            if (string.IsNullOrWhiteSpace(metric))
+            {
+                return BadRequest(new
+                {
+                    success = false,
+                    message = "The 'metric' query parameter is required.",
+                    supportedMetrics = _historyBuffer.GetSupportedMetrics()
+                });
+            }
+
+            // Normalise to lowercase for case-insensitive matching
+            metric = metric.Trim().ToLowerInvariant();
+            minutes = Math.Clamp(minutes, 1, 60);
+
+            var result = _historyBuffer.GetHistory(metric, minutes);
+
+            if (result == null)
+            {
+                return BadRequest(new
+                {
+                    success = false,
+                    message = $"Unknown metric '{metric}'.",
+                    supportedMetrics = _historyBuffer.GetSupportedMetrics()
+                });
+            }
+
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// GET /api/telemetry/history/metrics
+        /// Returns the list of all supported metric keys.
+        /// </summary>
+        [HttpGet("history/metrics")]
+        public IActionResult GetSupportedMetrics()
+        {
+            return Ok(new
+            {
+                metrics = _historyBuffer.GetSupportedMetrics()
+            });
+        }
+    }
+}

--- a/backend/Engine/CpuSamplerEngine.cs
+++ b/backend/Engine/CpuSamplerEngine.cs
@@ -8,12 +8,14 @@ namespace GSSystemAnalyzer.Engine
     {
         private readonly ICpuMetricsProvider _cpuProvider;
         private readonly IHubContext<SystemHub> _hubContext;
+        private readonly ITelemetryHistoryBuffer _historyBuffer;
         private TimeSpan _pollInterval;
 
-        public CpuSamplerEngine(ICpuMetricsProvider cpuProvider, IHubContext<SystemHub> hubContext, ISettingService settings)
+        public CpuSamplerEngine(ICpuMetricsProvider cpuProvider, IHubContext<SystemHub> hubContext, ISettingService settings, ITelemetryHistoryBuffer historyBuffer)
         {
             _cpuProvider = cpuProvider;
             _hubContext = hubContext;
+            _historyBuffer = historyBuffer;
 
             _pollInterval = TimeSpan.FromMilliseconds(settings.Current.Monitoring.CpuPollIntervalMs);
             settings.OnSettingsChanged += (_, s) =>
@@ -31,6 +33,9 @@ namespace GSSystemAnalyzer.Engine
                 {
                     var telemetry = await _cpuProvider.GetNextSampleAsync();
                     await _hubContext.Clients.All.SendAsync("ReceiveCpuTelemetry", telemetry, cancellationToken: stoppingToken);
+
+                    // Record to history buffer for historical charts
+                    _historyBuffer.Record("cpu", telemetry.AverageLoad);
                 }
                 catch (OperationCanceledException)
                 {

--- a/backend/Engine/RamMonitoringEngine.cs
+++ b/backend/Engine/RamMonitoringEngine.cs
@@ -13,6 +13,7 @@ namespace GSSystemAnalyzer.Engine
         private CancellationTokenSource? _radarCts;
         private readonly IHubContext<SystemHub> _hub;
         private readonly IProcessOwnerResolver _ownerResolver;
+        private readonly ITelemetryHistoryBuffer _historyBuffer;
         private readonly object _lock = new object();
         private TimeSpan _pollInterval;
 
@@ -22,10 +23,11 @@ namespace GSSystemAnalyzer.Engine
         // Consecutive zero-CPU-tick counter per PID for status heuristic
         private readonly ConcurrentDictionary<int, int> _zeroTickCounts = new();
 
-        public RamMonitoringEngine(IHubContext<SystemHub> hub, ISettingService settings, IProcessOwnerResolver ownerResolver)
+        public RamMonitoringEngine(IHubContext<SystemHub> hub, ISettingService settings, IProcessOwnerResolver ownerResolver, ITelemetryHistoryBuffer historyBuffer)
         {
             _hub = hub;
             _ownerResolver = ownerResolver;
+            _historyBuffer = historyBuffer;
             _pollInterval = TimeSpan.FromMilliseconds(settings.Current.Monitoring.RamPollIntervalMs);
             settings.OnSettingsChanged += (_, s) =>
                 _pollInterval = TimeSpan.FromMilliseconds(s.Monitoring.RamPollIntervalMs);
@@ -86,6 +88,18 @@ namespace GSSystemAnalyzer.Engine
                         };
 
                         await _hub.Clients.All.SendAsync("RamUpdate", payload, cancellationToken: token);
+
+                        // Record to history buffer for historical charts
+                        if (globalMetrics != null)
+                        {
+                            var metrics = (dynamic)globalMetrics;
+                            double activeGb = (double)metrics.activeGb;
+                            double totalGb  = (double)metrics.totalGb;
+                            double percent  = totalGb > 0 ? Math.Round((activeGb / totalGb) * 100, 1) : 0;
+
+                            _historyBuffer.Record("ram", activeGb);
+                            _historyBuffer.Record("ram_percent", percent);
+                        }
 
                         Console.WriteLine($"[RAM SWEEP {DateTime.Now:HH:mm:ss}] Engine Fired - Sent {snapshot.Count} processes");
                     }

--- a/backend/Engine/RamMonitoringEngine.cs
+++ b/backend/Engine/RamMonitoringEngine.cs
@@ -77,12 +77,12 @@ namespace GSSystemAnalyzer.Engine
 
                         var payload = new
                         {
-                            Global = globalMetrics ?? new
+                            Global = globalMetrics ?? new SystemMemoryMetrics.GlobalMemoryMetrics
                             {
-                                activeGb = 0.0,
-                                cachedGb = 0.0,
-                                swapGb = 0.0,
-                                totalGb = 16.0,
+                                ActiveGb = 0.0,
+                                CacheGb = 0.0,
+                                SwapGb = 0.0,
+                                TotalGb = 16.0,
                             },
                             Processes = snapshot
                         };
@@ -92,9 +92,8 @@ namespace GSSystemAnalyzer.Engine
                         // Record to history buffer for historical charts
                         if (globalMetrics != null)
                         {
-                            var metrics = (dynamic)globalMetrics;
-                            double activeGb = (double)metrics.activeGb;
-                            double totalGb  = (double)metrics.totalGb;
+                            double activeGb = globalMetrics.ActiveGb;
+                            double totalGb  = globalMetrics.TotalGb;
                             double percent  = totalGb > 0 ? Math.Round((activeGb / totalGb) * 100, 1) : 0;
 
                             _historyBuffer.Record("ram", activeGb);

--- a/backend/Engine/ThermalMonitoringEngine.cs
+++ b/backend/Engine/ThermalMonitoringEngine.cs
@@ -11,12 +11,14 @@ namespace GSSystemAnalyzer.Engine
     {
         private readonly IHubContext<SystemHub> _hubContext;
         private readonly IThermalProvider _thermalProvider;
+        private readonly ITelemetryHistoryBuffer _historyBuffer;
         private TimeSpan _pollInterval;
 
-        public ThermalMonitoringEngine(IHubContext<SystemHub> hubContext, IThermalProvider thermalProvider, ISettingService settings)
+        public ThermalMonitoringEngine(IHubContext<SystemHub> hubContext, IThermalProvider thermalProvider, ISettingService settings, ITelemetryHistoryBuffer historyBuffer)
         {
             _hubContext = hubContext;
             _thermalProvider = thermalProvider;
+            _historyBuffer = historyBuffer;
             
             _pollInterval = TimeSpan.FromMilliseconds(settings.Current.Monitoring.ThermalPollIntervalMs);
 
@@ -45,6 +47,10 @@ namespace GSSystemAnalyzer.Engine
                     if (payload != null)
                     {
                         await _hubContext.Clients.All.SendAsync("ReceiveThermalTelemetry", payload, stoppingToken);
+
+                        // Record to history buffer for historical charts
+                        if (payload.CpuPackageCelsius != null)
+                            _historyBuffer.Record("thermal_cpu_package", payload.CpuPackageCelsius.Value);
                     }
                 }
                 catch (Exception ex)
@@ -57,3 +63,4 @@ namespace GSSystemAnalyzer.Engine
         }
     }
 }
+

--- a/backend/GSSystemAnalyzer.Tests/Controller/TelemetryControllerTest.cs
+++ b/backend/GSSystemAnalyzer.Tests/Controller/TelemetryControllerTest.cs
@@ -34,7 +34,9 @@ public class TelemetryControllerTests
         var mockResolver = new Mock<IProcessOwnerResolver>();
         mockResolver.Setup(r => r.Resolve(It.IsAny<int>())).Returns("SYSTEM");
 
-        return new RamMonitoringEngine(mockHub.Object, mockSettings.Object, mockResolver.Object);
+        var mockHistoryBuffer = new Mock<ITelemetryHistoryBuffer>();
+
+        return new RamMonitoringEngine(mockHub.Object, mockSettings.Object, mockResolver.Object, mockHistoryBuffer.Object);
     }
 
 

--- a/backend/GSSystemAnalyzer.Tests/Controller/TelemetryHistoryControllerTests.cs
+++ b/backend/GSSystemAnalyzer.Tests/Controller/TelemetryHistoryControllerTests.cs
@@ -1,0 +1,143 @@
+using GSSystemAnalyzer.Controllers;
+using GSSystemAnalyzer.Interfaces;
+using GSSystemAnalyzer.Models;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+
+namespace GSSystemAnalyzer.Tests.Controller
+{
+    public class TelemetryHistoryControllerTests
+    {
+        private readonly Mock<ITelemetryHistoryBuffer> _mockBuffer;
+        private readonly TelemetryHistoryController _controller;
+
+        public TelemetryHistoryControllerTests()
+        {
+            _mockBuffer = new Mock<ITelemetryHistoryBuffer>();
+            _controller = new TelemetryHistoryController(_mockBuffer.Object);
+
+            _mockBuffer.Setup(b => b.GetSupportedMetrics())
+                .Returns(new List<string> { "cpu", "ram", "ram_percent", "thermal_cpu_package" }.AsReadOnly());
+        }
+
+        [Fact]
+        public void ValidMetric_ReturnsOkWithData()
+        {
+            var response = new TelemetryHistoryResponse
+            {
+                Metric = "cpu",
+                Minutes = 5,
+                Unit = "%",
+                Points = new List<TelemetryPoint>
+                {
+                    new() { Timestamp = DateTime.UtcNow, Value = 42.5 }
+                },
+                Stats = new TelemetryStats { Min = 42.5, Max = 42.5, Avg = 42.5, Current = 42.5 }
+            };
+
+            _mockBuffer.Setup(b => b.GetHistory("cpu", 5)).Returns(response);
+
+            var result = _controller.GetHistory("cpu", 5) as OkObjectResult;
+
+            Assert.NotNull(result);
+            Assert.Equal(200, result!.StatusCode);
+
+            var body = result.Value as TelemetryHistoryResponse;
+            Assert.NotNull(body);
+            Assert.Equal("cpu", body!.Metric);
+            Assert.Single(body.Points);
+        }
+
+        [Fact]
+        public void UnknownMetric_ReturnsBadRequest()
+        {
+            _mockBuffer.Setup(b => b.GetHistory("fake", 5)).Returns((TelemetryHistoryResponse?)null);
+
+            var result = _controller.GetHistory("fake", 5) as BadRequestObjectResult;
+
+            Assert.NotNull(result);
+            Assert.Equal(400, result!.StatusCode);
+        }
+
+        [Fact]
+        public void EmptyMetricParam_ReturnsBadRequest()
+        {
+            var result = _controller.GetHistory("", 5) as BadRequestObjectResult;
+
+            Assert.NotNull(result);
+            Assert.Equal(400, result!.StatusCode);
+        }
+
+        [Fact]
+        public void DefaultMinutes_Is5()
+        {
+            var response = new TelemetryHistoryResponse
+            {
+                Metric = "cpu",
+                Minutes = 5,
+                Unit = "%",
+                Points = new List<TelemetryPoint>(),
+                Stats = new TelemetryStats()
+            };
+
+            _mockBuffer.Setup(b => b.GetHistory("cpu", 5)).Returns(response);
+
+            var result = _controller.GetHistory("cpu") as OkObjectResult;
+
+            Assert.NotNull(result);
+            _mockBuffer.Verify(b => b.GetHistory("cpu", 5), Times.Once);
+        }
+
+        [Theory]
+        [InlineData(-5, 1)]   // Below min → clamped to 1
+        [InlineData(0, 1)]    // Zero → clamped to 1
+        [InlineData(100, 60)] // Above max → clamped to 60
+        public void MinutesClamped_ToValidRange(int input, int expected)
+        {
+            var response = new TelemetryHistoryResponse
+            {
+                Metric = "cpu",
+                Minutes = expected,
+                Unit = "%",
+                Points = new List<TelemetryPoint>(),
+                Stats = new TelemetryStats()
+            };
+
+            _mockBuffer.Setup(b => b.GetHistory("cpu", expected)).Returns(response);
+
+            var result = _controller.GetHistory("cpu", input) as OkObjectResult;
+
+            Assert.NotNull(result);
+            _mockBuffer.Verify(b => b.GetHistory("cpu", expected), Times.Once);
+        }
+
+        [Fact]
+        public void MetricIsCaseInsensitive()
+        {
+            var response = new TelemetryHistoryResponse
+            {
+                Metric = "cpu",
+                Minutes = 5,
+                Unit = "%",
+                Points = new List<TelemetryPoint>(),
+                Stats = new TelemetryStats()
+            };
+
+            _mockBuffer.Setup(b => b.GetHistory("cpu", 5)).Returns(response);
+
+            var result = _controller.GetHistory("CPU", 5) as OkObjectResult;
+
+            Assert.NotNull(result);
+            Assert.Equal(200, result!.StatusCode);
+        }
+
+        [Fact]
+        public void GetSupportedMetrics_ReturnsMetricsList()
+        {
+            var result = _controller.GetSupportedMetrics() as OkObjectResult;
+
+            Assert.NotNull(result);
+            Assert.Equal(200, result!.StatusCode);
+        }
+    }
+}

--- a/backend/GSSystemAnalyzer.Tests/Engine/RamMonitoringEngineTests.cs
+++ b/backend/GSSystemAnalyzer.Tests/Engine/RamMonitoringEngineTests.cs
@@ -26,7 +26,9 @@ public class RamMonitoringEngineTests
         var mockResolver = new Mock<IProcessOwnerResolver>();
         mockResolver.Setup(r => r.Resolve(It.IsAny<int>())).Returns("SYSTEM");
 
-        return new RamMonitoringEngine(mockHub.Object, mockSettings.Object, mockResolver.Object);
+        var mockHistoryBuffer = new Mock<ITelemetryHistoryBuffer>();
+
+        return new RamMonitoringEngine(mockHub.Object, mockSettings.Object, mockResolver.Object, mockHistoryBuffer.Object);
     }
 
 

--- a/backend/GSSystemAnalyzer.Tests/Services/TelemetryHistoryBufferTests.cs
+++ b/backend/GSSystemAnalyzer.Tests/Services/TelemetryHistoryBufferTests.cs
@@ -1,11 +1,27 @@
 using GSSystemAnalyzer.Interfaces;
 using GSSystemAnalyzer.Services;
+using Moq;
 
 namespace GSSystemAnalyzer.Tests.Services
 {
     public class TelemetryHistoryBufferTests
     {
-        private readonly ITelemetryHistoryBuffer _buffer = new TelemetryHistoryBuffer();
+        private readonly Mock<TimeProvider> _mockTime;
+        private readonly ITelemetryHistoryBuffer _buffer;
+        private DateTimeOffset _currentTime;
+
+        public TelemetryHistoryBufferTests()
+        {
+            _mockTime = new Mock<TimeProvider>();
+            _currentTime = new DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero);
+            _mockTime.Setup(t => t.GetUtcNow()).Returns(() => _currentTime);
+            _buffer = new TelemetryHistoryBuffer(_mockTime.Object);
+        }
+
+        private void AdvanceTime(TimeSpan duration)
+        {
+            _currentTime = _currentTime.Add(duration);
+        }
 
         [Fact]
         public void Record_AddsPointToBuffer()
@@ -17,38 +33,50 @@ namespace GSSystemAnalyzer.Tests.Services
             Assert.NotNull(result);
             Assert.Single(result!.Points);
             Assert.Equal(42.5, result.Points[0].Value);
+            Assert.Equal(_currentTime.UtcDateTime, result.Points[0].Timestamp);
         }
 
         [Fact]
-        public void GetHistory_ReturnsCorrectWindow_5Min()
+        public void GetHistory_ExcludesPointsOutsideRequestedWindow()
         {
-            var buffer = new TelemetryHistoryBuffer();
+            // Record at T=0
+            _buffer.Record("cpu", 10.0);
+            
+            AdvanceTime(TimeSpan.FromMinutes(10));
+            
+            // Record at T=10
+            _buffer.Record("cpu", 20.0);
 
-            // Use reflection-free approach: record points, then query
-            // Points recorded now should appear in a 5-minute window
-            buffer.Record("cpu", 10.0);
-            buffer.Record("cpu", 20.0);
-            buffer.Record("cpu", 30.0);
-
-            var result = buffer.GetHistory("cpu", 5);
-
-            Assert.NotNull(result);
-            Assert.Equal(3, result!.Points.Count);
-            Assert.Equal(5, result.Minutes);
-        }
-
-        [Fact]
-        public void GetHistory_ReturnsCorrectWindow_60Min()
-        {
-            var buffer = new TelemetryHistoryBuffer();
-
-            buffer.Record("cpu", 55.0);
-
-            var result = buffer.GetHistory("cpu", 60);
+            // Query last 5 minutes (from T=10, looks back to T=5)
+            // The T=0 point should be excluded
+            var result = _buffer.GetHistory("cpu", 5);
 
             Assert.NotNull(result);
             Assert.Single(result!.Points);
-            Assert.Equal(60, result.Minutes);
+            Assert.Equal(20.0, result.Points[0].Value); // Only the recent one
+        }
+
+        [Fact]
+        public void Record_PrunesPointsOlderThan60Minutes()
+        {
+            // T=0
+            _buffer.Record("cpu", 10.0);
+            
+            AdvanceTime(TimeSpan.FromMinutes(30));
+            // T=30
+            _buffer.Record("cpu", 20.0);
+            
+            AdvanceTime(TimeSpan.FromMinutes(35));
+            // T=65 (The T=0 point is now older than 60m and should be pruned when we Record)
+            _buffer.Record("cpu", 30.0);
+
+            // Ask for 60 minutes history
+            var result = _buffer.GetHistory("cpu", 60);
+
+            Assert.NotNull(result);
+            Assert.Equal(2, result!.Points.Count); 
+            Assert.Equal(20.0, result.Points[0].Value); // T=30 point
+            Assert.Equal(30.0, result.Points[1].Value); // T=65 point
         }
 
         [Fact]
@@ -79,9 +107,7 @@ namespace GSSystemAnalyzer.Tests.Services
         [Fact]
         public void GetHistory_ReturnsEmptyPointsWhenNoData()
         {
-            // "cpu" is a valid metric but we haven't recorded anything
-            var buffer = new TelemetryHistoryBuffer();
-            var result = buffer.GetHistory("cpu", 5);
+            var result = _buffer.GetHistory("cpu", 5);
 
             Assert.NotNull(result);
             Assert.Empty(result!.Points);
@@ -100,17 +126,12 @@ namespace GSSystemAnalyzer.Tests.Services
             Assert.Contains("ram", metrics);
             Assert.Contains("ram_percent", metrics);
             Assert.Contains("thermal_cpu_package", metrics);
-            Assert.Contains("network_rx", metrics);
-            Assert.Contains("network_tx", metrics);
-            Assert.Contains("disk_io_read", metrics);
-            Assert.Contains("disk_io_write", metrics);
-            Assert.Equal(8, metrics.Count);
+            Assert.Equal(4, metrics.Count); // Unwired metrics were removed
         }
 
         [Fact]
         public void Record_IgnoresUnknownMetric()
         {
-            // Should not throw, just silently ignored
             _buffer.Record("unknown_metric", 99.0);
 
             var result = _buffer.GetHistory("unknown_metric", 5);
@@ -163,38 +184,17 @@ namespace GSSystemAnalyzer.Tests.Services
         }
 
         [Fact]
-        public void GetHistory_PointsAreOrderedByTimestamp()
-        {
-            // Record multiple points rapidly
-            for (int i = 0; i < 10; i++)
-            {
-                _buffer.Record("cpu", i * 10.0);
-            }
-
-            var result = _buffer.GetHistory("cpu", 5);
-
-            Assert.NotNull(result);
-
-            for (int i = 1; i < result!.Points.Count; i++)
-            {
-                Assert.True(result.Points[i].Timestamp >= result.Points[i - 1].Timestamp);
-            }
-        }
-
-        [Fact]
         public void ConcurrentAccess_DoesNotThrow()
         {
-            var buffer = new TelemetryHistoryBuffer();
             var exceptions = new System.Collections.Concurrent.ConcurrentBag<Exception>();
 
-            // Parallel writes
             var writeTask = Task.Run(() =>
             {
                 Parallel.For(0, 1000, i =>
                 {
                     try
                     {
-                        buffer.Record("cpu", i % 100);
+                        _buffer.Record("cpu", i % 100);
                     }
                     catch (Exception ex)
                     {
@@ -203,14 +203,13 @@ namespace GSSystemAnalyzer.Tests.Services
                 });
             });
 
-            // Parallel reads
             var readTask = Task.Run(() =>
             {
                 Parallel.For(0, 500, _ =>
                 {
                     try
                     {
-                        buffer.GetHistory("cpu", 5);
+                        _buffer.GetHistory("cpu", 5);
                     }
                     catch (Exception ex)
                     {

--- a/backend/GSSystemAnalyzer.Tests/Services/TelemetryHistoryBufferTests.cs
+++ b/backend/GSSystemAnalyzer.Tests/Services/TelemetryHistoryBufferTests.cs
@@ -1,0 +1,227 @@
+using GSSystemAnalyzer.Interfaces;
+using GSSystemAnalyzer.Services;
+
+namespace GSSystemAnalyzer.Tests.Services
+{
+    public class TelemetryHistoryBufferTests
+    {
+        private readonly ITelemetryHistoryBuffer _buffer = new TelemetryHistoryBuffer();
+
+        [Fact]
+        public void Record_AddsPointToBuffer()
+        {
+            _buffer.Record("cpu", 42.5);
+
+            var result = _buffer.GetHistory("cpu", 5);
+
+            Assert.NotNull(result);
+            Assert.Single(result!.Points);
+            Assert.Equal(42.5, result.Points[0].Value);
+        }
+
+        [Fact]
+        public void GetHistory_ReturnsCorrectWindow_5Min()
+        {
+            var buffer = new TelemetryHistoryBuffer();
+
+            // Use reflection-free approach: record points, then query
+            // Points recorded now should appear in a 5-minute window
+            buffer.Record("cpu", 10.0);
+            buffer.Record("cpu", 20.0);
+            buffer.Record("cpu", 30.0);
+
+            var result = buffer.GetHistory("cpu", 5);
+
+            Assert.NotNull(result);
+            Assert.Equal(3, result!.Points.Count);
+            Assert.Equal(5, result.Minutes);
+        }
+
+        [Fact]
+        public void GetHistory_ReturnsCorrectWindow_60Min()
+        {
+            var buffer = new TelemetryHistoryBuffer();
+
+            buffer.Record("cpu", 55.0);
+
+            var result = buffer.GetHistory("cpu", 60);
+
+            Assert.NotNull(result);
+            Assert.Single(result!.Points);
+            Assert.Equal(60, result.Minutes);
+        }
+
+        [Fact]
+        public void GetHistory_ComputesStatsCorrectly()
+        {
+            _buffer.Record("cpu", 10.0);
+            _buffer.Record("cpu", 50.0);
+            _buffer.Record("cpu", 30.0);
+            _buffer.Record("cpu", 90.0);
+
+            var result = _buffer.GetHistory("cpu", 5);
+
+            Assert.NotNull(result);
+            Assert.Equal(10.0, result!.Stats.Min);
+            Assert.Equal(90.0, result.Stats.Max);
+            Assert.Equal(45.0, result.Stats.Avg);
+            Assert.Equal(90.0, result.Stats.Current); // Last recorded point
+        }
+
+        [Fact]
+        public void GetHistory_ReturnsNullForUnknownMetric()
+        {
+            var result = _buffer.GetHistory("does_not_exist", 5);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetHistory_ReturnsEmptyPointsWhenNoData()
+        {
+            // "cpu" is a valid metric but we haven't recorded anything
+            var buffer = new TelemetryHistoryBuffer();
+            var result = buffer.GetHistory("cpu", 5);
+
+            Assert.NotNull(result);
+            Assert.Empty(result!.Points);
+            Assert.Equal(0, result.Stats.Min);
+            Assert.Equal(0, result.Stats.Max);
+            Assert.Equal(0, result.Stats.Avg);
+            Assert.Equal(0, result.Stats.Current);
+        }
+
+        [Fact]
+        public void GetSupportedMetrics_ReturnsAllRegisteredKeys()
+        {
+            var metrics = _buffer.GetSupportedMetrics();
+
+            Assert.Contains("cpu", metrics);
+            Assert.Contains("ram", metrics);
+            Assert.Contains("ram_percent", metrics);
+            Assert.Contains("thermal_cpu_package", metrics);
+            Assert.Contains("network_rx", metrics);
+            Assert.Contains("network_tx", metrics);
+            Assert.Contains("disk_io_read", metrics);
+            Assert.Contains("disk_io_write", metrics);
+            Assert.Equal(8, metrics.Count);
+        }
+
+        [Fact]
+        public void Record_IgnoresUnknownMetric()
+        {
+            // Should not throw, just silently ignored
+            _buffer.Record("unknown_metric", 99.0);
+
+            var result = _buffer.GetHistory("unknown_metric", 5);
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Record_BothRamMetrics_StoresSeparately()
+        {
+            _buffer.Record("ram", 8.5);
+            _buffer.Record("ram_percent", 53.1);
+
+            var ramResult = _buffer.GetHistory("ram", 5);
+            var pctResult = _buffer.GetHistory("ram_percent", 5);
+
+            Assert.NotNull(ramResult);
+            Assert.NotNull(pctResult);
+            Assert.Single(ramResult!.Points);
+            Assert.Single(pctResult!.Points);
+            Assert.Equal(8.5, ramResult.Points[0].Value);
+            Assert.Equal(53.1, pctResult.Points[0].Value);
+            Assert.Equal("GB", ramResult.Unit);
+            Assert.Equal("%", pctResult.Unit);
+        }
+
+        [Fact]
+        public void GetHistory_RoundsValuesToTwoDecimals()
+        {
+            _buffer.Record("cpu", 42.5678);
+
+            var result = _buffer.GetHistory("cpu", 5);
+
+            Assert.NotNull(result);
+            Assert.Equal(42.57, result!.Points[0].Value);
+        }
+
+        [Fact]
+        public void GetHistory_ClampsMinutesToValidRange()
+        {
+            _buffer.Record("cpu", 50.0);
+
+            var tooLow = _buffer.GetHistory("cpu", -10);
+            var tooHigh = _buffer.GetHistory("cpu", 200);
+
+            Assert.NotNull(tooLow);
+            Assert.Equal(1, tooLow!.Minutes);
+
+            Assert.NotNull(tooHigh);
+            Assert.Equal(60, tooHigh!.Minutes);
+        }
+
+        [Fact]
+        public void GetHistory_PointsAreOrderedByTimestamp()
+        {
+            // Record multiple points rapidly
+            for (int i = 0; i < 10; i++)
+            {
+                _buffer.Record("cpu", i * 10.0);
+            }
+
+            var result = _buffer.GetHistory("cpu", 5);
+
+            Assert.NotNull(result);
+
+            for (int i = 1; i < result!.Points.Count; i++)
+            {
+                Assert.True(result.Points[i].Timestamp >= result.Points[i - 1].Timestamp);
+            }
+        }
+
+        [Fact]
+        public void ConcurrentAccess_DoesNotThrow()
+        {
+            var buffer = new TelemetryHistoryBuffer();
+            var exceptions = new System.Collections.Concurrent.ConcurrentBag<Exception>();
+
+            // Parallel writes
+            var writeTask = Task.Run(() =>
+            {
+                Parallel.For(0, 1000, i =>
+                {
+                    try
+                    {
+                        buffer.Record("cpu", i % 100);
+                    }
+                    catch (Exception ex)
+                    {
+                        exceptions.Add(ex);
+                    }
+                });
+            });
+
+            // Parallel reads
+            var readTask = Task.Run(() =>
+            {
+                Parallel.For(0, 500, _ =>
+                {
+                    try
+                    {
+                        buffer.GetHistory("cpu", 5);
+                    }
+                    catch (Exception ex)
+                    {
+                        exceptions.Add(ex);
+                    }
+                });
+            });
+
+            Task.WaitAll(writeTask, readTask);
+
+            Assert.Empty(exceptions);
+        }
+    }
+}

--- a/backend/Interfaces/ITelemetryHistoryBuffer.cs
+++ b/backend/Interfaces/ITelemetryHistoryBuffer.cs
@@ -1,0 +1,23 @@
+using GSSystemAnalyzer.Models;
+
+namespace GSSystemAnalyzer.Interfaces
+{
+    public interface ITelemetryHistoryBuffer
+    {
+        /// <summary>
+        /// Record a new data point for the specified metric.
+        /// </summary>
+        void Record(string metric, double value);
+
+        /// <summary>
+        /// Retrieve the history for a metric within the given time window.
+        /// Returns null if the metric is not in the supported registry.
+        /// </summary>
+        TelemetryHistoryResponse? GetHistory(string metric, int minutes);
+
+        /// <summary>
+        /// Returns all metric keys registered in the buffer (both wired and TODO).
+        /// </summary>
+        IReadOnlyCollection<string> GetSupportedMetrics();
+    }
+}

--- a/backend/Models/SystemMemoryMetrics.cs
+++ b/backend/Models/SystemMemoryMetrics.cs
@@ -19,10 +19,18 @@ namespace GSSystemAnalyzer.Models
             public ulong ullAvailExtendedVirtual;
         }
 
+        public class GlobalMemoryMetrics
+        {
+            public double ActiveGb { get; set; }
+            public double CacheGb { get; set; }
+            public double SwapGb { get; set; }
+            public double TotalGb { get; set; }
+        }
+
         [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
         public static extern bool GlobalMemoryStatusEx(ref MEMORYSTATUSEX lpBuffer);
 
-        public static object GetLiveMetrics()
+        public static GlobalMemoryMetrics? GetLiveMetrics()
         {
             var memStatus = new MEMORYSTATUSEX();
             memStatus.dwLength = (uint)Marshal.SizeOf(typeof(MEMORYSTATUSEX));
@@ -36,18 +44,16 @@ namespace GSSystemAnalyzer.Models
                 double availPageGb = memStatus.ulAvailPagePhys / (1024.0 * 1024.0 * 1024.0);
                 double swapGb = totalPageGb - availPageGb;
 
-                return new
+                return new GlobalMemoryMetrics
                 {
-                    activeGb = Math.Round(activeRamGb, 2),
-                    cacheGb = Math.Round(availRamGb, 2),
-                    swapGb = Math.Round(swapGb, 2),
-                    totalGb = Math.Round(totalRamGb, 2)
+                    ActiveGb = Math.Round(activeRamGb, 2),
+                    CacheGb = Math.Round(availRamGb, 2),
+                    SwapGb = Math.Round(swapGb, 2),
+                    TotalGb = Math.Round(totalRamGb, 2)
                 };
             }
 
             return null;
         }
-
-    
     }
 }

--- a/backend/Models/TelemetryHistoryResponse.cs
+++ b/backend/Models/TelemetryHistoryResponse.cs
@@ -1,0 +1,19 @@
+namespace GSSystemAnalyzer.Models
+{
+    public class TelemetryHistoryResponse
+    {
+        public string Metric { get; set; } = string.Empty;
+        public int Minutes { get; set; }
+        public string Unit { get; set; } = string.Empty;
+        public List<TelemetryPoint> Points { get; set; } = new();
+        public TelemetryStats Stats { get; set; } = new();
+    }
+
+    public class TelemetryStats
+    {
+        public double Min { get; set; }
+        public double Max { get; set; }
+        public double Avg { get; set; }
+        public double Current { get; set; }
+    }
+}

--- a/backend/Models/TelemetryPoint.cs
+++ b/backend/Models/TelemetryPoint.cs
@@ -1,0 +1,8 @@
+namespace GSSystemAnalyzer.Models
+{
+    public class TelemetryPoint
+    {
+        public DateTime Timestamp { get; set; }
+        public double Value { get; set; }
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -38,6 +38,9 @@ builder.Services.AddSingleton<IProcessOwnerResolver, ProcessOwnerResolver>();
 builder.Services.AddSingleton<IFileTypeScanner, FileTypeScanner>();
 builder.Services.AddSingleton<IAgeHeatmapEngine, AgeHeatmapEngine>();
 
+// Telemetry history buffer — must be registered before background services that inject it
+builder.Services.AddSingleton<ITelemetryHistoryBuffer, TelemetryHistoryBuffer>();
+
 // Platform-specific CPU provider
 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 {

--- a/backend/Services/TelemetryHistoryBuffer.cs
+++ b/backend/Services/TelemetryHistoryBuffer.cs
@@ -8,21 +8,29 @@ namespace GSSystemAnalyzer.Services
     {
         // Registry of supported metrics and their display units.
         // Wired metrics are populated by background services.
-        // TODO metrics are registered but not yet wired — will return empty points until a provider is built.
         private static readonly Dictionary<string, string> MetricUnits = new()
         {
             ["cpu"]                 = "%",
             ["ram"]                 = "GB",
             ["ram_percent"]         = "%",
             ["thermal_cpu_package"] = "°C",
-            ["network_rx"]          = "MB/s",   // TODO: wire when Network provider is built
-            ["network_tx"]          = "MB/s",   // TODO: wire when Network provider is built
-            ["disk_io_read"]        = "MB/s",   // TODO: wire when Disk I/O provider is built
-            ["disk_io_write"]       = "MB/s",   // TODO: wire when Disk I/O provider is built
         };
 
         private readonly ConcurrentDictionary<string, ConcurrentQueue<TelemetryPoint>> _buffers = new();
         private static readonly TimeSpan MaxRetention = TimeSpan.FromMinutes(60);
+        private const int MaxQueueLength = 10000;
+
+        private readonly TimeProvider _timeProvider;
+
+        public TelemetryHistoryBuffer(TimeProvider timeProvider)
+        {
+            _timeProvider = timeProvider;
+        }
+
+        // Overload for ease of manual instantiation in tests if needed without Moq
+        public TelemetryHistoryBuffer() : this(TimeProvider.System)
+        {
+        }
 
         /// <inheritdoc />
         public void Record(string metric, double value)
@@ -33,7 +41,7 @@ namespace GSSystemAnalyzer.Services
 
             queue.Enqueue(new TelemetryPoint
             {
-                Timestamp = DateTime.UtcNow,
+                Timestamp = _timeProvider.GetUtcNow().UtcDateTime,
                 Value = Math.Round(value, 2)
             });
 
@@ -48,7 +56,7 @@ namespace GSSystemAnalyzer.Services
 
             minutes = Math.Clamp(minutes, 1, 60);
 
-            var cutoff = DateTime.UtcNow.AddMinutes(-minutes);
+            var cutoff = _timeProvider.GetUtcNow().UtcDateTime.AddMinutes(-minutes);
 
             List<TelemetryPoint> points;
 
@@ -91,14 +99,20 @@ namespace GSSystemAnalyzer.Services
         }
 
         /// <summary>
-        /// Removes entries older than 60 minutes from the front of the queue.
+        /// Removes entries older than 60 minutes from the front of the queue, or if queue exceeds max length.
         /// Safe to call concurrently — ConcurrentQueue.TryDequeue is atomic.
         /// </summary>
-        private static void Prune(ConcurrentQueue<TelemetryPoint> queue)
+        private void Prune(ConcurrentQueue<TelemetryPoint> queue)
         {
-            var horizon = DateTime.UtcNow - MaxRetention;
+            var horizon = _timeProvider.GetUtcNow().UtcDateTime - MaxRetention;
 
             while (queue.TryPeek(out var oldest) && oldest.Timestamp < horizon)
+            {
+                queue.TryDequeue(out _);
+            }
+
+            // Hard cap to prevent memory ballooning if interval is misconfigured
+            while (queue.Count > MaxQueueLength)
             {
                 queue.TryDequeue(out _);
             }

--- a/backend/Services/TelemetryHistoryBuffer.cs
+++ b/backend/Services/TelemetryHistoryBuffer.cs
@@ -1,0 +1,107 @@
+using System.Collections.Concurrent;
+using GSSystemAnalyzer.Interfaces;
+using GSSystemAnalyzer.Models;
+
+namespace GSSystemAnalyzer.Services
+{
+    public class TelemetryHistoryBuffer : ITelemetryHistoryBuffer
+    {
+        // Registry of supported metrics and their display units.
+        // Wired metrics are populated by background services.
+        // TODO metrics are registered but not yet wired — will return empty points until a provider is built.
+        private static readonly Dictionary<string, string> MetricUnits = new()
+        {
+            ["cpu"]                 = "%",
+            ["ram"]                 = "GB",
+            ["ram_percent"]         = "%",
+            ["thermal_cpu_package"] = "°C",
+            ["network_rx"]          = "MB/s",   // TODO: wire when Network provider is built
+            ["network_tx"]          = "MB/s",   // TODO: wire when Network provider is built
+            ["disk_io_read"]        = "MB/s",   // TODO: wire when Disk I/O provider is built
+            ["disk_io_write"]       = "MB/s",   // TODO: wire when Disk I/O provider is built
+        };
+
+        private readonly ConcurrentDictionary<string, ConcurrentQueue<TelemetryPoint>> _buffers = new();
+        private static readonly TimeSpan MaxRetention = TimeSpan.FromMinutes(60);
+
+        /// <inheritdoc />
+        public void Record(string metric, double value)
+        {
+            if (!MetricUnits.ContainsKey(metric)) return;
+
+            var queue = _buffers.GetOrAdd(metric, _ => new ConcurrentQueue<TelemetryPoint>());
+
+            queue.Enqueue(new TelemetryPoint
+            {
+                Timestamp = DateTime.UtcNow,
+                Value = Math.Round(value, 2)
+            });
+
+            Prune(queue);
+        }
+
+        /// <inheritdoc />
+        public TelemetryHistoryResponse? GetHistory(string metric, int minutes)
+        {
+            if (!MetricUnits.TryGetValue(metric, out var unit))
+                return null;
+
+            minutes = Math.Clamp(minutes, 1, 60);
+
+            var cutoff = DateTime.UtcNow.AddMinutes(-minutes);
+
+            List<TelemetryPoint> points;
+
+            if (_buffers.TryGetValue(metric, out var queue))
+            {
+                // Snapshot the queue and filter to the requested window
+                points = queue.ToArray()
+                    .Where(p => p.Timestamp >= cutoff)
+                    .OrderBy(p => p.Timestamp)
+                    .ToList();
+            }
+            else
+            {
+                points = new List<TelemetryPoint>();
+            }
+
+            var stats = new TelemetryStats();
+            if (points.Count > 0)
+            {
+                stats.Min     = Math.Round(points.Min(p => p.Value), 2);
+                stats.Max     = Math.Round(points.Max(p => p.Value), 2);
+                stats.Avg     = Math.Round(points.Average(p => p.Value), 2);
+                stats.Current = points[^1].Value;
+            }
+
+            return new TelemetryHistoryResponse
+            {
+                Metric  = metric,
+                Minutes = minutes,
+                Unit    = unit,
+                Points  = points,
+                Stats   = stats
+            };
+        }
+
+        /// <inheritdoc />
+        public IReadOnlyCollection<string> GetSupportedMetrics()
+        {
+            return MetricUnits.Keys.ToList().AsReadOnly();
+        }
+
+        /// <summary>
+        /// Removes entries older than 60 minutes from the front of the queue.
+        /// Safe to call concurrently — ConcurrentQueue.TryDequeue is atomic.
+        /// </summary>
+        private static void Prune(ConcurrentQueue<TelemetryPoint> queue)
+        {
+            var horizon = DateTime.UtcNow - MaxRetention;
+
+            while (queue.TryPeek(out var oldest) && oldest.Timestamp < horizon)
+            {
+                queue.TryDequeue(out _);
+            }
+        }
+    }
+}

--- a/frontend/gs_analyzer_ui/lib/models/telemetry_history_model.dart
+++ b/frontend/gs_analyzer_ui/lib/models/telemetry_history_model.dart
@@ -1,0 +1,67 @@
+class TelemetryPoint {
+  final DateTime timestamp;
+  final double value;
+
+  TelemetryPoint({required this.timestamp, required this.value});
+
+  factory TelemetryPoint.fromJson(Map<String, dynamic> json) {
+    return TelemetryPoint(
+      timestamp: DateTime.parse(json['timestamp']).toLocal(),
+      value: (json['value'] as num).toDouble(),
+    );
+  }
+}
+
+class TelemetryStats {
+  final double min;
+  final double max;
+  final double avg;
+  final double current;
+
+  TelemetryStats({
+    required this.min,
+    required this.max,
+    required this.avg,
+    required this.current,
+  });
+
+  factory TelemetryStats.fromJson(Map<String, dynamic> json) {
+    return TelemetryStats(
+      min: (json['min'] as num).toDouble(),
+      max: (json['max'] as num).toDouble(),
+      avg: (json['avg'] as num).toDouble(),
+      current: (json['current'] as num).toDouble(),
+    );
+  }
+}
+
+class TelemetryHistoryResponse {
+  final String metric;
+  final int minutes;
+  final String unit;
+  final List<TelemetryPoint> points;
+  final TelemetryStats stats;
+
+  TelemetryHistoryResponse({
+    required this.metric,
+    required this.minutes,
+    required this.unit,
+    required this.points,
+    required this.stats,
+  });
+
+  factory TelemetryHistoryResponse.fromJson(Map<String, dynamic> json) {
+    return TelemetryHistoryResponse(
+      metric: json['metric'] ?? '',
+      minutes: json['minutes'] ?? 5,
+      unit: json['unit'] ?? '',
+      points: (json['points'] as List<dynamic>?)
+              ?.map((p) => TelemetryPoint.fromJson(p))
+              .toList() ??
+          [],
+      stats: json['stats'] != null
+          ? TelemetryStats.fromJson(json['stats'])
+          : TelemetryStats(min: 0, max: 0, avg: 0, current: 0),
+    );
+  }
+}

--- a/frontend/gs_analyzer_ui/lib/providers/navigation_provider.dart
+++ b/frontend/gs_analyzer_ui/lib/providers/navigation_provider.dart
@@ -8,6 +8,7 @@ enum AppRoute {
   storage,
   network,
   thermal,
+  telemetryHistory,
   settings,
 }
 

--- a/frontend/gs_analyzer_ui/lib/providers/telemetry_history_provider.dart
+++ b/frontend/gs_analyzer_ui/lib/providers/telemetry_history_provider.dart
@@ -1,0 +1,90 @@
+import 'dart:async';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:gs_analyzer_ui/models/telemetry_history_model.dart';
+import 'package:gs_analyzer_ui/services/api_service.dart';
+
+final apiServiceProvider = Provider((ref) => ApiService());
+
+class TelemetryHistoryState {
+  final TelemetryHistoryResponse? response;
+  final bool isLoading;
+  final int minutes;
+  final String? error;
+
+  TelemetryHistoryState({
+    this.response,
+    this.isLoading = false,
+    this.minutes = 5,
+    this.error,
+  });
+
+  TelemetryHistoryState copyWith({
+    TelemetryHistoryResponse? response,
+    bool? isLoading,
+    int? minutes,
+    String? error,
+  }) {
+    return TelemetryHistoryState(
+      response: response ?? this.response,
+      isLoading: isLoading ?? this.isLoading,
+      minutes: minutes ?? this.minutes,
+      error: error, // null means clear error if not specified
+    );
+  }
+}
+
+class TelemetryHistoryNotifier extends StateNotifier<TelemetryHistoryState> {
+  final ApiService _apiService;
+  final String _metric;
+  Timer? _timer;
+
+  TelemetryHistoryNotifier(this._apiService, this._metric)
+      : super(TelemetryHistoryState()) {
+    _fetchHistory();
+    _startTimer();
+  }
+
+  void _startTimer() {
+    _timer?.cancel();
+    _timer = Timer.periodic(const Duration(seconds: 5), (_) {
+      _fetchHistory(silent: true);
+    });
+  }
+
+  Future<void> _fetchHistory({bool silent = false}) async {
+    if (!silent) {
+      state = state.copyWith(isLoading: true, error: null);
+    }
+    
+    try {
+      final response = await _apiService.fetchTelemetryHistory(_metric, state.minutes);
+      if (response != null) {
+        state = state.copyWith(isLoading: false, response: response, error: null);
+      } else {
+        state = state.copyWith(isLoading: false, error: 'Failed to fetch history for $_metric');
+      }
+    } catch (e) {
+      state = state.copyWith(isLoading: false, error: e.toString());
+    }
+  }
+
+  void setMinutes(int newMinutes) {
+    if (state.minutes != newMinutes) {
+      state = state.copyWith(minutes: newMinutes);
+      _fetchHistory(); // fetch immediately on change
+    }
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+}
+
+// We use FamilyStateNotifier from riverpod to pass the metric as an argument
+final telemetryHistoryProvider = StateNotifierProvider.family<TelemetryHistoryNotifier, TelemetryHistoryState, String>((ref, metric) {
+  final apiService = ref.watch(apiServiceProvider);
+  return TelemetryHistoryNotifier(apiService, metric);
+});

--- a/frontend/gs_analyzer_ui/lib/screen/cpu_metrics_screen.dart
+++ b/frontend/gs_analyzer_ui/lib/screen/cpu_metrics_screen.dart
@@ -43,7 +43,7 @@ class _CpuMetricsScreenState extends ConsumerState<CpuMetricsScreen> {
                 Container(
                   padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
                   decoration: BoxDecoration(
-                    color: HudTheme.accentRed.withOpacity(0.2),
+                    color: HudTheme.accentRed.withValues(alpha: 0.2),
                     border: Border.all(color: HudTheme.accentRed),
                     borderRadius: BorderRadius.circular(4),
                   ),
@@ -79,7 +79,7 @@ class _CpuMetricsScreenState extends ConsumerState<CpuMetricsScreen> {
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         decoration: BoxDecoration(
-          color: isSelected ? HudTheme.accentCyan.withOpacity(0.1) : Colors.transparent,
+          color: isSelected ? HudTheme.accentCyan.withValues(alpha: 0.1) : Colors.transparent,
           border: Border.all(color: isSelected ? HudTheme.accentCyan : Colors.white10),
         ),
         child: Text(

--- a/frontend/gs_analyzer_ui/lib/screen/cpu_metrics_screen.dart
+++ b/frontend/gs_analyzer_ui/lib/screen/cpu_metrics_screen.dart
@@ -4,12 +4,20 @@ import 'package:fl_chart/fl_chart.dart';
 import 'package:gs_analyzer_ui/providers/cpu_provider.dart';
 import 'package:gs_analyzer_ui/models/cpu_snapshot.dart';
 import 'package:gs_analyzer_ui/utils/hud_theme.dart';
+import 'package:gs_analyzer_ui/widgets/telemetry_history_chart.dart';
 
-class CpuMetricsScreen extends ConsumerWidget {
+class CpuMetricsScreen extends ConsumerStatefulWidget {
   const CpuMetricsScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<CpuMetricsScreen> createState() => _CpuMetricsScreenState();
+}
+
+class _CpuMetricsScreenState extends ConsumerState<CpuMetricsScreen> {
+  bool _showHistory = false;
+
+  @override
+  Widget build(BuildContext context) {
     final cpuState = ref.watch(cpuProvider);
     final snapshot = cpuState.snapshot;
 
@@ -22,11 +30,20 @@ class CpuMetricsScreen extends ConsumerWidget {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               const Text('CPU TELEMETRY MODULE', style: HudTheme.headerCyan),
-              if (cpuState.isCritical)
+              
+              // Custom Toggle Strip
+              Row(
+                children: [
+                  _buildToggleBtn('LIVE VIEW', !_showHistory),
+                  _buildToggleBtn('HISTORY', _showHistory),
+                ],
+              ),
+              
+              if (cpuState.isCritical && !_showHistory)
                 Container(
                   padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
                   decoration: BoxDecoration(
-                    color: HudTheme.accentRed.withValues(alpha: 0.2),
+                    color: HudTheme.accentRed.withOpacity(0.2),
                     border: Border.all(color: HudTheme.accentRed),
                     borderRadius: BorderRadius.circular(4),
                   ),
@@ -35,7 +52,9 @@ class CpuMetricsScreen extends ConsumerWidget {
             ],
           ),
           const SizedBox(height: 24),
-          if(snapshot == null)
+          if (_showHistory)
+            const Expanded(child: TelemetryHistoryChart(metricKey: 'cpu'))
+          else if(snapshot == null)
             const Expanded(
               child: Center(
                 child: CircularProgressIndicator(color: HudTheme.primaryBorder),
@@ -47,6 +66,32 @@ class CpuMetricsScreen extends ConsumerWidget {
             )
         ],
       )
+    );
+  }
+
+  Widget _buildToggleBtn(String label, bool isSelected) {
+    return InkWell(
+      onTap: () {
+        setState(() {
+          _showHistory = label == 'HISTORY';
+        });
+      },
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        decoration: BoxDecoration(
+          color: isSelected ? HudTheme.accentCyan.withOpacity(0.1) : Colors.transparent,
+          border: Border.all(color: isSelected ? HudTheme.accentCyan : Colors.white10),
+        ),
+        child: Text(
+          label,
+          style: TextStyle(
+            fontFamily: HudTheme.fontCore,
+            color: isSelected ? HudTheme.accentCyan : HudTheme.textDim,
+            fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+            letterSpacing: 1,
+          ),
+        ),
+      ),
     );
   }
 

--- a/frontend/gs_analyzer_ui/lib/screen/master_layout.dart
+++ b/frontend/gs_analyzer_ui/lib/screen/master_layout.dart
@@ -11,6 +11,7 @@ import 'package:gs_analyzer_ui/screen/storage_screen.dart';
 import 'package:gs_analyzer_ui/providers/storage_view_provider.dart';
 import 'package:gs_analyzer_ui/providers/telemetry_provider.dart';
 import 'package:gs_analyzer_ui/screen/process_explorer_screen.dart';
+import 'package:gs_analyzer_ui/screen/telemetry_history_screen.dart';
 import 'cpu_metrics_screen.dart';
 
 class MasterLayout extends ConsumerWidget {
@@ -55,6 +56,9 @@ class MasterLayout extends ConsumerWidget {
 
       case AppRoute.thermal:
         return const ThermalModuleScreen();
+        
+      case AppRoute.telemetryHistory:
+        return const TelemetryHistoryScreen();
 
       case AppRoute.process:
         return const ProcessExplorerScreen();

--- a/frontend/gs_analyzer_ui/lib/screen/ram_scannner_screen.dart
+++ b/frontend/gs_analyzer_ui/lib/screen/ram_scannner_screen.dart
@@ -3,22 +3,31 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gs_analyzer_ui/providers/ram_provider.dart';
 import 'package:gs_analyzer_ui/utils/hud_theme.dart';
 import 'package:gs_analyzer_ui/utils/hud_label.dart';
+import 'package:gs_analyzer_ui/widgets/telemetry_history_chart.dart';
 
-class RamScannerScreen extends ConsumerWidget {
+class RamScannerScreen extends ConsumerStatefulWidget {
   const RamScannerScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<RamScannerScreen> createState() => _RamScannerScreenState();
+}
+
+class _RamScannerScreenState extends ConsumerState<RamScannerScreen> {
+  bool _showHistory = false;
+
+  @override
+  Widget build(BuildContext context) {
     final ramState = ref.watch(ramProvider);
 
     return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         // Critical banner
-        if (ramState.isCritical)
+        if (ramState.isCritical && !_showHistory)
           Container(
             width: double.infinity,
             padding: const EdgeInsets.symmetric(vertical: 8),
-            color: HudTheme.accentRed.withValues(alpha: 0.2),
+            color: HudTheme.accentRed.withOpacity(0.2),
             child: const Center(
               child: Text(
                 'RAM CRITICAL ALERT: REDUCE SYSTEM LOAD',
@@ -26,39 +35,63 @@ class RamScannerScreen extends ConsumerWidget {
               ),
             ),
           ),
-
-        // Allocation cards
-        Container(
-          padding: const EdgeInsets.all(24),
-          decoration: const BoxDecoration(
-            border: Border(bottom: BorderSide(color: Colors.white10)),
-          ),
+          
+        Padding(
+          padding: const EdgeInsets.fromLTRB(24, 24, 24, 0),
           child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Expanded(
-                child: _buildAllocationCard(
-                  'ACTIVE MEMORY',
-                  '${ramState.activeGb.toStringAsFixed(1)} GB',
-                  HudTheme.accentCyan,
-                  ramState.totalGb > 0 ? ramState.activeGb / ramState.totalGb : 0.0,
-                ),
+              const Text('MEMORY SCANNER MODULE', style: HudTheme.headerCyan),
+              Row(
+                children: [
+                  _buildToggleBtn('LIVE VIEW', !_showHistory),
+                  _buildToggleBtn('HISTORY', _showHistory),
+                ],
               ),
-              Expanded(
-                child: _buildAllocationCard(
-                  'CACHE (STANDBY)',
-                  '${ramState.cacheGb.toStringAsFixed(1)} GB',
-                  HudTheme.accentGreen,
-                  ramState.totalGb > 0 ? ramState.cacheGb / ramState.totalGb : 0.0,
+            ],
+          ),
+        ),
+
+        if (_showHistory)
+          const Expanded(
+            child: Padding(
+              padding: EdgeInsets.all(24.0),
+              child: TelemetryHistoryChart(metricKey: 'ram'),
+            ),
+          )
+        else ...[
+          // Allocation cards
+          Container(
+            padding: const EdgeInsets.all(24),
+            decoration: const BoxDecoration(
+              border: Border(bottom: BorderSide(color: Colors.white10)),
+            ),
+            child: Row(
+              children: [
+                Expanded(
+                  child: _buildAllocationCard(
+                    'ACTIVE MEMORY',
+                    '${ramState.activeGb.toStringAsFixed(1)} GB',
+                    HudTheme.accentCyan,
+                    ramState.totalGb > 0 ? ramState.activeGb / ramState.totalGb : 0.0,
+                  ),
                 ),
-              ),
-              Expanded(
-                child: _buildAllocationCard(
-                  'SWAP / PAGEFILE',
-                  '${ramState.swapGb.toStringAsFixed(1)} GB',
-                  HudTheme.accentAmber,
-                  ramState.totalGb > 0 ? ramState.swapGb / (ramState.totalGb * 2) : 0.0,
+                Expanded(
+                  child: _buildAllocationCard(
+                    'CACHE (STANDBY)',
+                    '${ramState.cacheGb.toStringAsFixed(1)} GB',
+                    HudTheme.accentGreen,
+                    ramState.totalGb > 0 ? ramState.cacheGb / ramState.totalGb : 0.0,
+                  ),
                 ),
-              ),
+                Expanded(
+                  child: _buildAllocationCard(
+                    'SWAP / PAGEFILE',
+                    '${ramState.swapGb.toStringAsFixed(1)} GB',
+                    HudTheme.accentAmber,
+                    ramState.totalGb > 0 ? ramState.swapGb / (ramState.totalGb * 2) : 0.0,
+                  ),
+                ),
             ],
           ),
         ),
@@ -155,8 +188,35 @@ class RamScannerScreen extends ConsumerWidget {
                   },
                 ),
               ),
-            ],
-          );
+        ],
+      ],
+    );
+  }
+
+  Widget _buildToggleBtn(String label, bool isSelected) {
+    return InkWell(
+      onTap: () {
+        setState(() {
+          _showHistory = label == 'HISTORY';
+        });
+      },
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        decoration: BoxDecoration(
+          color: isSelected ? HudTheme.accentCyan.withOpacity(0.1) : Colors.transparent,
+          border: Border.all(color: isSelected ? HudTheme.accentCyan : Colors.white10),
+        ),
+        child: Text(
+          label,
+          style: TextStyle(
+            fontFamily: HudTheme.fontCore,
+            color: isSelected ? HudTheme.accentCyan : HudTheme.textDim,
+            fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+            letterSpacing: 1,
+          ),
+        ),
+      ),
+    );
   }
 
   Widget _buildTableHeader() {

--- a/frontend/gs_analyzer_ui/lib/screen/ram_scannner_screen.dart
+++ b/frontend/gs_analyzer_ui/lib/screen/ram_scannner_screen.dart
@@ -27,7 +27,7 @@ class _RamScannerScreenState extends ConsumerState<RamScannerScreen> {
           Container(
             width: double.infinity,
             padding: const EdgeInsets.symmetric(vertical: 8),
-            color: HudTheme.accentRed.withOpacity(0.2),
+            color: HudTheme.accentRed.withValues(alpha: 0.2),
             child: const Center(
               child: Text(
                 'RAM CRITICAL ALERT: REDUCE SYSTEM LOAD',
@@ -203,7 +203,7 @@ class _RamScannerScreenState extends ConsumerState<RamScannerScreen> {
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         decoration: BoxDecoration(
-          color: isSelected ? HudTheme.accentCyan.withOpacity(0.1) : Colors.transparent,
+          color: isSelected ? HudTheme.accentCyan.withValues(alpha: 0.1) : Colors.transparent,
           border: Border.all(color: isSelected ? HudTheme.accentCyan : Colors.white10),
         ),
         child: Text(

--- a/frontend/gs_analyzer_ui/lib/screen/telemetry_history_screen.dart
+++ b/frontend/gs_analyzer_ui/lib/screen/telemetry_history_screen.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:gs_analyzer_ui/widgets/telemetry_history_chart.dart';
+import 'package:gs_analyzer_ui/utils/hud_theme.dart';
+
+class TelemetryHistoryScreen extends StatelessWidget {
+  const TelemetryHistoryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: HudTheme.bgBase,
+      body: Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'TELEMETRY HISTORY',
+              style: TextStyle(
+                fontFamily: HudTheme.fontCore,
+                color: HudTheme.primaryBorder,
+                fontSize: 24,
+                fontWeight: FontWeight.bold,
+                letterSpacing: 3,
+              ),
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'SYSTEM-WIDE METRIC TRENDS',
+              style: HudTheme.labelMuted,
+            ),
+            const SizedBox(height: 24),
+            Expanded(
+              child: ListView(
+                children: const [
+                  SizedBox(
+                    height: 400,
+                    child: TelemetryHistoryChart(metricKey: 'cpu'),
+                  ),
+                  SizedBox(height: 24),
+                  SizedBox(
+                    height: 400,
+                    child: TelemetryHistoryChart(metricKey: 'ram'),
+                  ),
+                  SizedBox(height: 24),
+                  SizedBox(
+                    height: 400,
+                    child: TelemetryHistoryChart(metricKey: 'thermal_cpu_package'),
+                  ),
+                  SizedBox(height: 48), // Padding at bottom
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/gs_analyzer_ui/lib/screen/thermal_module_screen.dart
+++ b/frontend/gs_analyzer_ui/lib/screen/thermal_module_screen.dart
@@ -49,7 +49,7 @@ class _ThermalModuleScreenState extends ConsumerState<ThermalModuleScreen> {
                 Container(
                   padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
                   decoration: BoxDecoration(
-                    color: HudTheme.accentRed.withOpacity(0.2),
+                    color: HudTheme.accentRed.withValues(alpha: 0.2),
                     border: Border.all(color: HudTheme.accentRed),
                     borderRadius: BorderRadius.circular(4),
                   ),
@@ -112,7 +112,7 @@ class _ThermalModuleScreenState extends ConsumerState<ThermalModuleScreen> {
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         decoration: BoxDecoration(
-          color: isSelected ? HudTheme.accentCyan.withOpacity(0.1) : Colors.transparent,
+          color: isSelected ? HudTheme.accentCyan.withValues(alpha: 0.1) : Colors.transparent,
           border: Border.all(color: isSelected ? HudTheme.accentCyan : Colors.white10),
         ),
         child: Text(

--- a/frontend/gs_analyzer_ui/lib/screen/thermal_module_screen.dart
+++ b/frontend/gs_analyzer_ui/lib/screen/thermal_module_screen.dart
@@ -7,6 +7,7 @@ import 'package:gs_analyzer_ui/providers/thermal_provider.dart';
 import 'package:gs_analyzer_ui/models/thermal_telemetry.dart';
 import 'package:gs_analyzer_ui/utils/hud_theme.dart';
 import 'package:gs_analyzer_ui/utils/hud_label.dart';
+import 'package:gs_analyzer_ui/widgets/telemetry_history_chart.dart';
 
 class ThermalModuleScreen extends ConsumerStatefulWidget {
   const ThermalModuleScreen({super.key});
@@ -17,6 +18,7 @@ class ThermalModuleScreen extends ConsumerStatefulWidget {
 
 class _ThermalModuleScreenState extends ConsumerState<ThermalModuleScreen> {
   bool _isAdvancedExpanded = false;
+  bool _showHistory = false;
 
   @override
   Widget build(BuildContext context) {
@@ -35,11 +37,19 @@ class _ThermalModuleScreenState extends ConsumerState<ThermalModuleScreen> {
               const Text(
                 'THERMAL RADAR MODULE', style: HudTheme.headerCyan
               ),
-              if (thermalState.isCritical)
+              
+              Row(
+                children: [
+                  _buildToggleBtn('LIVE VIEW', !_showHistory),
+                  _buildToggleBtn('HISTORY', _showHistory),
+                ],
+              ),
+              
+              if (thermalState.isCritical && !_showHistory)
                 Container(
                   padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
                   decoration: BoxDecoration(
-                    color: HudTheme.accentRed.withValues(alpha: 0.2),
+                    color: HudTheme.accentRed.withOpacity(0.2),
                     border: Border.all(color: HudTheme.accentRed),
                     borderRadius: BorderRadius.circular(4),
                   ),
@@ -49,7 +59,9 @@ class _ThermalModuleScreenState extends ConsumerState<ThermalModuleScreen> {
           ),
           const SizedBox(height: 24),
 
-          if (telemetry == null)
+          if (_showHistory)
+            const Expanded(child: TelemetryHistoryChart(metricKey: 'thermal_cpu_package'))
+          else if (telemetry == null)
             const Expanded(
               child: Center(
                 child: CircularProgressIndicator(color: HudTheme.accentAmber),
@@ -87,6 +99,32 @@ class _ThermalModuleScreenState extends ConsumerState<ThermalModuleScreen> {
           ),
         ],
       )
+    );
+  }
+
+  Widget _buildToggleBtn(String label, bool isSelected) {
+    return InkWell(
+      onTap: () {
+        setState(() {
+          _showHistory = label == 'HISTORY';
+        });
+      },
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        decoration: BoxDecoration(
+          color: isSelected ? HudTheme.accentCyan.withOpacity(0.1) : Colors.transparent,
+          border: Border.all(color: isSelected ? HudTheme.accentCyan : Colors.white10),
+        ),
+        child: Text(
+          label,
+          style: TextStyle(
+            fontFamily: HudTheme.fontCore,
+            color: isSelected ? HudTheme.accentCyan : HudTheme.textDim,
+            fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+            letterSpacing: 1,
+          ),
+        ),
+      ),
     );
   }
 

--- a/frontend/gs_analyzer_ui/lib/services/api_service.dart
+++ b/frontend/gs_analyzer_ui/lib/services/api_service.dart
@@ -11,6 +11,7 @@ import 'package:gs_analyzer_ui/models/extension_breakdown_model.dart';
 import 'package:gs_analyzer_ui/providers/age_heatmap_provider.dart';
 import 'package:gs_analyzer_ui/providers/file_type_provider.dart';
 import 'package:gs_analyzer_ui/models/permission_audit_models.dart';
+import 'package:gs_analyzer_ui/models/telemetry_history_model.dart';
 
 class ApiService {
   final http.Client _client;
@@ -23,6 +24,25 @@ class ApiService {
   static const String settingsUrl = 'http://localhost:5200/api/settings';
   static const String driveUrl = 'http://localhost:5200/api/drives';
   static const String auditUrl = 'http://localhost:5200/api/audit';
+  static const String telemetryHistoryUrl = 'http://localhost:5200/api/telemetry/history';
+
+  Future<TelemetryHistoryResponse?> fetchTelemetryHistory(String metric, int minutes) async {
+    final uri = Uri.parse(telemetryHistoryUrl).replace(queryParameters: {
+      'metric': metric,
+      'minutes': minutes.toString(),
+    });
+    
+    print('MATRIX BRIDGE FIRING TO: \$uri');
+    final response = await _client.get(uri);
+
+    if (response.statusCode == 200) {
+      final jsonBody = jsonDecode(response.body);
+      return TelemetryHistoryResponse.fromJson(jsonBody);
+    } else {
+      print('Failed to fetch telemetry history: \${response.statusCode} - \${response.body}');
+      return null;
+    }
+  }
 
 
   Future<List<StorageNode>> scanDirectory(String path) async {

--- a/frontend/gs_analyzer_ui/lib/services/api_service.dart
+++ b/frontend/gs_analyzer_ui/lib/services/api_service.dart
@@ -32,7 +32,7 @@ class ApiService {
       'minutes': minutes.toString(),
     });
     
-    print('MATRIX BRIDGE FIRING TO: \$uri');
+    // print('MATRIX BRIDGE FIRING TO: \$uri');
     final response = await _client.get(uri);
 
     if (response.statusCode == 200) {

--- a/frontend/gs_analyzer_ui/lib/widgets/global_sidebar_widget.dart
+++ b/frontend/gs_analyzer_ui/lib/widgets/global_sidebar_widget.dart
@@ -49,15 +49,22 @@ class GlobalSidebarWidget extends ConsumerWidget {
           const Divider(color: Colors.white10, height: 1,),
           const SizedBox(height: 16),
 
-          _buildNavItem(ref, AppRoute.dashboard, 'DASHBOARD', Icons.dashboard_outlined, currentRoute),
-          _buildNavItem(ref, AppRoute.process, 'PROCESS EXPLORER', Icons.monitor_heart_outlined, currentRoute),
-          _buildNavItem(ref, AppRoute.cpuMetics, 'CPU METRICS', Icons.memory_outlined, currentRoute),
-          _buildNavItem(ref, AppRoute.memory, 'MEMORY', Icons.bar_chart_outlined, currentRoute),
-          _buildNavItem(ref, AppRoute.storage, 'STORAGE', Icons.storage_outlined, currentRoute),
-          _buildNavItem(ref, AppRoute.network, 'NETWORK', Icons.account_tree_outlined, currentRoute),
-          _buildNavItem(ref, AppRoute.thermal, 'THERMAL', Icons.thermostat_outlined, currentRoute),
-
-          const Spacer(),
+          Expanded(
+            child: SingleChildScrollView(
+              child: Column(
+                children: [
+                  _buildNavItem(ref, AppRoute.dashboard, 'DASHBOARD', Icons.dashboard_outlined, currentRoute),
+                  _buildNavItem(ref, AppRoute.process, 'PROCESS EXPLORER', Icons.monitor_heart_outlined, currentRoute),
+                  _buildNavItem(ref, AppRoute.cpuMetics, 'CPU METRICS', Icons.memory_outlined, currentRoute),
+                  _buildNavItem(ref, AppRoute.memory, 'MEMORY', Icons.bar_chart_outlined, currentRoute),
+                  _buildNavItem(ref, AppRoute.storage, 'STORAGE', Icons.storage_outlined, currentRoute),
+                  _buildNavItem(ref, AppRoute.network, 'NETWORK', Icons.account_tree_outlined, currentRoute),
+                  _buildNavItem(ref, AppRoute.thermal, 'THERMAL', Icons.thermostat_outlined, currentRoute),
+                  _buildNavItem(ref, AppRoute.telemetryHistory, 'TELEMETRY HISTORY', Icons.history_outlined, currentRoute),
+                ],
+              ),
+            ),
+          ),
 
           _buildSettingsNavItem(context, ref),
 

--- a/frontend/gs_analyzer_ui/lib/widgets/telemetry_history_chart.dart
+++ b/frontend/gs_analyzer_ui/lib/widgets/telemetry_history_chart.dart
@@ -1,0 +1,284 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:gs_analyzer_ui/providers/telemetry_history_provider.dart';
+import 'package:gs_analyzer_ui/utils/hud_theme.dart';
+import 'package:intl/intl.dart';
+
+class TelemetryHistoryChart extends ConsumerStatefulWidget {
+  final String metricKey;
+
+  const TelemetryHistoryChart({super.key, required this.metricKey});
+
+  @override
+  ConsumerState<TelemetryHistoryChart> createState() => _TelemetryHistoryChartState();
+}
+
+class _TelemetryHistoryChartState extends ConsumerState<TelemetryHistoryChart> {
+  late String _currentMetricKey;
+
+  @override
+  void initState() {
+    super.initState();
+    _currentMetricKey = widget.metricKey;
+  }
+
+  @override
+  void didUpdateWidget(covariant TelemetryHistoryChart oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.metricKey != widget.metricKey && !widget.metricKey.startsWith('ram')) {
+      _currentMetricKey = widget.metricKey;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(telemetryHistoryProvider(_currentMetricKey));
+    final notifier = ref.read(telemetryHistoryProvider(_currentMetricKey).notifier);
+
+    return Container(
+      decoration: BoxDecoration(
+        color: HudTheme.bgPanel,
+        border: Border.all(color: Colors.white10),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // Header & Controls
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                _buildHeaderTitle(),
+                Row(
+                  children: [
+                    if (widget.metricKey.startsWith('ram')) _buildRamToggle(),
+                    const SizedBox(width: 16),
+                    _buildTimeRangeSelector(state.minutes, notifier.setMinutes),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          
+          const Divider(height: 1, color: Colors.white10),
+          
+          // Chart Area
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.all(24.0),
+              child: _buildChartContent(state),
+            ),
+          ),
+          
+          const Divider(height: 1, color: Colors.white10),
+          
+          // Stats Strip
+          if (state.response != null)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceAround,
+                children: [
+                  _buildStatChip('MIN', state.response!.stats.min, state.response!.unit),
+                  _buildStatChip('AVG', state.response!.stats.avg, state.response!.unit),
+                  _buildStatChip('MAX', state.response!.stats.max, state.response!.unit),
+                  _buildStatChip('NOW', state.response!.stats.current, state.response!.unit),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHeaderTitle() {
+    String title = _currentMetricKey.toUpperCase().replaceAll('_', ' ');
+    return Text(
+      title,
+      style: HudTheme.headerCyan,
+    );
+  }
+
+  Widget _buildRamToggle() {
+    final isPercent = _currentMetricKey == 'ram_percent';
+    return Row(
+      children: [
+        Text('GB', style: isPercent ? HudTheme.labelMuted : HudTheme.statCyan),
+        Switch(
+          value: isPercent,
+          activeColor: HudTheme.accentCyan,
+          onChanged: (val) {
+            setState(() {
+              _currentMetricKey = val ? 'ram_percent' : 'ram';
+            });
+          },
+        ),
+        Text('%', style: isPercent ? HudTheme.statCyan : HudTheme.labelMuted),
+      ],
+    );
+  }
+
+  Widget _buildTimeRangeSelector(int currentMinutes, Function(int) onSelect) {
+    return Row(
+      children: [5, 15, 30, 60].map((mins) {
+        final isSelected = currentMinutes == mins;
+        final label = mins == 60 ? '1H' : '${mins}M';
+        return InkWell(
+          onTap: () => onSelect(mins),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+            decoration: BoxDecoration(
+              border: Border.all(color: isSelected ? HudTheme.accentCyan : Colors.white10),
+              color: isSelected ? HudTheme.accentCyan.withOpacity(0.1) : Colors.transparent,
+            ),
+            child: Text(
+              label,
+              style: TextStyle(
+                fontFamily: HudTheme.fontCore,
+                color: isSelected ? HudTheme.accentCyan : HudTheme.textDim,
+                fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+              ),
+            ),
+          ),
+        );
+      }).toList(),
+    );
+  }
+
+  Widget _buildStatChip(String label, double value, String unit) {
+    return Row(
+      children: [
+        Text('$label: ', style: HudTheme.labelMuted),
+        Text('$value $unit', style: HudTheme.statGreen),
+      ],
+    );
+  }
+
+  Widget _buildChartContent(TelemetryHistoryState state) {
+    if (state.isLoading && (state.response == null || state.response!.points.isEmpty)) {
+      return const Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            CircularProgressIndicator(color: HudTheme.accentCyan),
+            SizedBox(height: 16),
+            Text('LOADING HISTORY...', style: HudTheme.labelMuted),
+          ],
+        ),
+      );
+    }
+
+    if (state.response == null || state.response!.points.isEmpty) {
+      return const Center(
+        child: Text('COLLECTING DATA — CHECK BACK IN A MOMENT', style: HudTheme.labelMuted),
+      );
+    }
+
+    final points = state.response!.points;
+    final unit = state.response!.unit;
+    final isPercent = unit == '%' || _currentMetricKey.contains('percent');
+
+    final spots = points.map((p) {
+      return FlSpot(p.timestamp.millisecondsSinceEpoch.toDouble(), p.value);
+    }).toList();
+
+    final double maxX = spots.last.x;
+    final double minX = maxX - (state.minutes * 60 * 1000);
+
+    return LineChart(
+      LineChartData(
+        minX: minX,
+        maxX: maxX,
+        minY: isPercent ? 0 : null,
+        maxY: isPercent ? 100 : null,
+        gridData: FlGridData(
+          show: true,
+          drawVerticalLine: true,
+          drawHorizontalLine: true,
+          horizontalInterval: isPercent ? 25 : null,
+          getDrawingHorizontalLine: (value) {
+            return FlLine(
+              color: Colors.white10,
+              strokeWidth: 1,
+              dashArray: [4, 4],
+            );
+          },
+          getDrawingVerticalLine: (value) {
+            return FlLine(color: Colors.white10, strokeWidth: 1);
+          },
+        ),
+        titlesData: FlTitlesData(
+          show: true,
+          topTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+          rightTitles: const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+          leftTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: true,
+              reservedSize: 40,
+              getTitlesWidget: (value, meta) {
+                return Text(
+                  isPercent ? value.toInt().toString() : value.toStringAsFixed(1),
+                  style: HudTheme.labelMuted.copyWith(fontSize: 10),
+                  textAlign: TextAlign.right,
+                );
+              },
+            ),
+          ),
+          bottomTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: true,
+              reservedSize: 22,
+              interval: (maxX - minX) / 5, // 5 evenly spaced ticks
+              getTitlesWidget: (value, meta) {
+                if (value == minX || value == maxX) return const SizedBox();
+                final date = DateTime.fromMillisecondsSinceEpoch(value.toInt());
+                return Padding(
+                  padding: const EdgeInsets.only(top: 8.0),
+                  child: Text(
+                    DateFormat('HH:mm').format(date),
+                    style: HudTheme.labelMuted.copyWith(fontSize: 10),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+        borderData: FlBorderData(
+          show: true,
+          border: Border.all(color: Colors.white10),
+        ),
+        lineTouchData: LineTouchData(
+          touchTooltipData: LineTouchTooltipData(
+            getTooltipColor: (touchedSpot) => HudTheme.bgPanel,
+            getTooltipItems: (touchedSpots) {
+              return touchedSpots.map((spot) {
+                final date = DateTime.fromMillisecondsSinceEpoch(spot.x.toInt());
+                final timeStr = DateFormat('HH:mm:ss').format(date);
+                return LineTooltipItem(
+                  '$timeStr\n${spot.y} $unit',
+                  const TextStyle(color: HudTheme.accentCyan, fontFamily: HudTheme.fontCore, fontSize: 12),
+                );
+              }).toList();
+            },
+          ),
+        ),
+        lineBarsData: [
+          LineChartBarData(
+            spots: spots,
+            isCurved: true,
+            color: HudTheme.accentCyan,
+            barWidth: 2,
+            isStrokeCapRound: true,
+            dotData: const FlDotData(show: false),
+            belowBarData: BarAreaData(
+              show: true,
+              color: HudTheme.accentCyan.withOpacity(0.08),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/gs_analyzer_ui/lib/widgets/telemetry_history_chart.dart
+++ b/frontend/gs_analyzer_ui/lib/widgets/telemetry_history_chart.dart
@@ -131,7 +131,7 @@ class _TelemetryHistoryChartState extends ConsumerState<TelemetryHistoryChart> {
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
             decoration: BoxDecoration(
               border: Border.all(color: isSelected ? HudTheme.accentCyan : Colors.white10),
-              color: isSelected ? HudTheme.accentCyan.withOpacity(0.1) : Colors.transparent,
+              color: isSelected ? HudTheme.accentCyan.withValues(alpha: 0.1) : Colors.transparent,
             ),
             child: Text(
               label,
@@ -151,7 +151,7 @@ class _TelemetryHistoryChartState extends ConsumerState<TelemetryHistoryChart> {
     return Row(
       children: [
         Text('$label: ', style: HudTheme.labelMuted),
-        Text('$value $unit', style: HudTheme.statGreen),
+        Text('${value.toStringAsFixed(1)} $unit', style: HudTheme.statGreen),
       ],
     );
   }
@@ -274,7 +274,7 @@ class _TelemetryHistoryChartState extends ConsumerState<TelemetryHistoryChart> {
             dotData: const FlDotData(show: false),
             belowBarData: BarAreaData(
               show: true,
-              color: HudTheme.accentCyan.withOpacity(0.08),
+              color: HudTheme.accentCyan.withValues(alpha: 0.08),
             ),
           ),
         ],

--- a/frontend/gs_analyzer_ui/test/models/telemetry_history_model_test.dart
+++ b/frontend/gs_analyzer_ui/test/models/telemetry_history_model_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gs_analyzer_ui/models/telemetry_history_model.dart';
+
+void main() {
+  group('TelemetryHistoryModel', () {
+    test('TelemetryPoint fromJson parses correctly', () {
+      final json = {
+        'timestamp': '2023-10-01T12:00:00Z',
+        'value': 42.5,
+      };
+
+      final point = TelemetryPoint.fromJson(json);
+
+      expect(point.timestamp, DateTime.parse('2023-10-01T12:00:00Z').toLocal());
+      expect(point.value, 42.5);
+    });
+
+    test('TelemetryStats fromJson parses correctly', () {
+      final json = {
+        'min': 10.0,
+        'max': 90.0,
+        'avg': 50.0,
+        'current': 60.0,
+      };
+
+      final stats = TelemetryStats.fromJson(json);
+
+      expect(stats.min, 10.0);
+      expect(stats.max, 90.0);
+      expect(stats.avg, 50.0);
+      expect(stats.current, 60.0);
+    });
+
+    test('TelemetryHistoryResponse fromJson parses correctly', () {
+      final json = {
+        'metric': 'cpu',
+        'minutes': 15,
+        'unit': '%',
+        'points': [
+          {'timestamp': '2023-10-01T12:00:00Z', 'value': 20.0},
+          {'timestamp': '2023-10-01T12:01:00Z', 'value': 30.0},
+        ],
+        'stats': {
+          'min': 20.0,
+          'max': 30.0,
+          'avg': 25.0,
+          'current': 30.0,
+        }
+      };
+
+      final response = TelemetryHistoryResponse.fromJson(json);
+
+      expect(response.metric, 'cpu');
+      expect(response.minutes, 15);
+      expect(response.unit, '%');
+      expect(response.points.length, 2);
+      expect(response.points.first.value, 20.0);
+      expect(response.stats.min, 20.0);
+      expect(response.stats.max, 30.0);
+    });
+  });
+}

--- a/frontend/gs_analyzer_ui/test/provider/telemetry_history_provider_test.dart
+++ b/frontend/gs_analyzer_ui/test/provider/telemetry_history_provider_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gs_analyzer_ui/models/telemetry_history_model.dart';
+import 'package:gs_analyzer_ui/providers/telemetry_history_provider.dart';
+import 'package:gs_analyzer_ui/services/api_service.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockApiService extends Mock implements ApiService {}
+
+void main() {
+  group('TelemetryHistoryProvider', () {
+    late ProviderContainer container;
+    late MockApiService mockApiService;
+
+    setUp(() {
+      mockApiService = MockApiService();
+      container = ProviderContainer(
+        overrides: [
+          apiServiceProvider.overrideWithValue(mockApiService),
+        ],
+      );
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    test('initial state is loading with default 5 minutes', () {
+      when(() => mockApiService.fetchTelemetryHistory('cpu', 5))
+          .thenAnswer((_) async {
+        await Future.delayed(const Duration(seconds: 1));
+        return null;
+      });
+
+      final state = container.read(telemetryHistoryProvider('cpu'));
+      
+      expect(state.isLoading, true);
+      expect(state.minutes, 5);
+      expect(state.response, null);
+    });
+
+    test('fetchData success updates state correctly', () async {
+      final mockResponse = TelemetryHistoryResponse(
+        metric: 'cpu',
+        minutes: 5,
+        unit: '%',
+        points: [],
+        stats: TelemetryStats(min: 0, max: 0, avg: 0, current: 0),
+      );
+
+      when(() => mockApiService.fetchTelemetryHistory('cpu', 5))
+          .thenAnswer((_) async => mockResponse);
+
+      final notifier = container.read(telemetryHistoryProvider('cpu').notifier);
+      await Future.delayed(Duration.zero);
+
+      final state = container.read(telemetryHistoryProvider('cpu'));
+      expect(state.isLoading, false);
+      expect(state.response, mockResponse);
+      verify(() => mockApiService.fetchTelemetryHistory('cpu', 5)).called(1);
+    });
+
+    test('setTimeRange updates minutes and triggers refetch', () async {
+      final mockResponse = TelemetryHistoryResponse(
+        metric: 'cpu',
+        minutes: 30,
+        unit: '%',
+        points: [],
+        stats: TelemetryStats(min: 0, max: 0, avg: 0, current: 0),
+      );
+
+      when(() => mockApiService.fetchTelemetryHistory('cpu', 30))
+          .thenAnswer((_) async => mockResponse);
+
+      final notifier = container.read(telemetryHistoryProvider('cpu').notifier);
+      
+      notifier.setMinutes(30);
+
+      await Future.delayed(Duration.zero);
+
+      final state = container.read(telemetryHistoryProvider('cpu'));
+      expect(state.minutes, 30);
+      expect(state.isLoading, false);
+      expect(state.response, mockResponse);
+      verify(() => mockApiService.fetchTelemetryHistory('cpu', 30)).called(1);
+    });
+  });
+}

--- a/frontend/gs_analyzer_ui/test/widgets/telemetry_history_chart_test.dart
+++ b/frontend/gs_analyzer_ui/test/widgets/telemetry_history_chart_test.dart
@@ -1,0 +1,88 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gs_analyzer_ui/models/telemetry_history_model.dart';
+import 'package:gs_analyzer_ui/widgets/telemetry_history_chart.dart';
+import 'package:gs_analyzer_ui/services/api_service.dart';
+import 'package:gs_analyzer_ui/providers/telemetry_history_provider.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockApiService extends Mock implements ApiService {}
+
+void main() {
+  group('TelemetryHistoryChart Widget', () {
+    testWidgets('shows loading indicator initially', (WidgetTester tester) async {
+      final mockApiService = MockApiService();
+
+      // Return null or delay to keep it in loading state
+      final completer = Completer<TelemetryHistoryResponse?>();
+      when(() => mockApiService.fetchTelemetryHistory('cpu', 5))
+          .thenAnswer((_) => completer.future);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            apiServiceProvider.overrideWithValue(mockApiService),
+          ],
+          child: const MaterialApp(
+            home: Scaffold(
+              body: TelemetryHistoryChart(metricKey: 'cpu'),
+            ),
+          ),
+        ),
+      );
+
+      // Verify loading indicator is present
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.text('CPU'), findsOneWidget); // title
+    });
+
+    testWidgets('renders chart and stats when data is loaded', (WidgetTester tester) async {
+      final mockApiService = MockApiService();
+      final now = DateTime.now();
+
+      final mockResponse = TelemetryHistoryResponse(
+        metric: 'cpu',
+        minutes: 15,
+        unit: '%',
+        points: [
+          TelemetryPoint(timestamp: now.subtract(const Duration(minutes: 5)), value: 25.0),
+          TelemetryPoint(timestamp: now, value: 50.0),
+        ],
+        stats: TelemetryStats(min: 25.0, max: 50.0, avg: 37.5, current: 50.0),
+      );
+
+      when(() => mockApiService.fetchTelemetryHistory('cpu', 5))
+          .thenAnswer((_) async => mockResponse);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            apiServiceProvider.overrideWithValue(mockApiService),
+          ],
+          child: const MaterialApp(
+            home: Scaffold(
+              body: TelemetryHistoryChart(metricKey: 'cpu'),
+            ),
+          ),
+        ),
+      );
+
+      // Wait for provider to fetch
+      await tester.pumpAndSettle();
+
+      // Should show the title
+      expect(find.text('CPU'), findsOneWidget);
+      
+      // Should show the stat strips
+      expect(find.text('MIN: '), findsOneWidget);
+      expect(find.text('25.0 %'), findsOneWidget);
+      expect(find.text('MAX: '), findsOneWidget);
+      expect(find.text('50.0 %'), findsNWidgets(2)); // matches both MAX and NOW
+      
+      // Should NOT have loading indicator
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Adds **Historical Telemetry Charts** — an in-memory ring buffer that retains the
last 60 minutes of telemetry, a query endpoint, and Flutter line charts with
selectable time ranges. Live telemetry is unaffected; recording is a non-blocking
append inside the existing SignalR loops (PRD FR-X4).

MVP scope per the Beta doc: **in-memory only**. Persistent history (SQLite /
time-series) remains **Phase 2** and is intentionally not included here.

## Backend
- **`TelemetryHistoryBuffer`** (`ITelemetryHistoryBuffer`) — thread-safe
  `ConcurrentDictionary<string, ConcurrentQueue<TelemetryPoint>>`; 60-min
  time-based prune + hard cap (`MaxQueueLength = 10000`) as a safety net.
  Clock is injected via `TimeProvider` for testability.
- **`GET /api/telemetry/history?metric=<m>&minutes=<n>`** — `minutes` clamped
  1–60; metric normalized (trim + lowercase); unknown/empty metric → `400` with
  `supportedMetrics`. Returns `{ metric, minutes, unit, points[], stats }`.
- **`GET /api/telemetry/history/metrics`** — lists supported metrics.
- Wired recorders: `cpu` (CpuSamplerEngine), `ram` + `ram_percent`
  (RamMonitoringEngine), `thermal_cpu_package` (ThermalMonitoringEngine).
- Replaced the anonymous RAM payload with a typed `GlobalMemoryMetrics` model
  (removes `dynamic` access).
- Registered as a singleton in `Program.cs` so engines and the controller share
  one buffer.

## Frontend
- `TelemetryHistoryChart` (fl_chart) with 5M / 15M / 30M / 1H range selector,
  stats strip (min/avg/max/now), and a RAM GB↔% toggle.
- LIVE/HISTORY toggle on the CPU, RAM, and Thermal screens.
- Dedicated **TELEMETRY HISTORY** screen (CPU + RAM + thermal) with sidebar nav.
- `fetchTelemetryHistory` in `ApiService` parses the raw response body and keys
  off HTTP status (consistent with the backend envelope).

## Tests
- Backend: `TelemetryHistoryBufferTests` (record, window exclusion, 60-min prune,
  stats, rounding, clamp, concurrency, supported-metrics) + controller tests
  (valid/unknown/empty metric, default + clamped minutes, case-insensitivity,
  metrics list). Existing engine tests updated for the new ctor param.
- Frontend: model `fromJson` tests, provider tests (initial/success/setMinutes),
  widget tests (loading + loaded states).

## Notes / follow-ups
- `network_*` and `disk_io_*` metrics are intentionally **not** registered until
  their providers exist (avoids advertising empty series).
- Thermal history depends on elevated access; the chart handles an empty series
  gracefully.

## Out of scope (Phase 2)
- Persistent telemetry history (SQLite / time-series).