### PR TITLE
feat: Compact Mode + adaptive window sizing with overflow-safe panels

### DIFF
--- a/frontend/gs_analyzer_ui/lib/main.dart
+++ b/frontend/gs_analyzer_ui/lib/main.dart
@@ -4,16 +4,71 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gs_analyzer_ui/providers/settings_provider.dart';
 import 'package:gs_analyzer_ui/screen/master_layout.dart';
 import 'package:gs_analyzer_ui/utils/hud_theme.dart';
+import 'package:gs_analyzer_ui/providers/window_provider.dart';
+import 'package:window_manager/window_manager.dart';
 
-void main() {
+const kCompactSize = Size(900, 640);
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await windowManager.ensureInitialized();
+
+  const opts = WindowOptions(
+    size: kCompactSize,
+    minimumSize: Size(720, 520),
+    center: true,
+    titleBarStyle: TitleBarStyle.normal,
+  );
+  windowManager.waitUntilReadyToShow(opts, () async {
+    await windowManager.setSize(kCompactSize);
+    await windowManager.center();
+    await windowManager.show();
+    await windowManager.focus();
+  });
+
   runApp(const ProviderScope(child: GSAnalyzerApp()));
 }
 
-class GSAnalyzerApp extends ConsumerWidget {
+class GSAnalyzerApp extends ConsumerStatefulWidget {
   const GSAnalyzerApp({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<GSAnalyzerApp> createState() => _GSAnalyzerAppState();
+}
+
+class _GSAnalyzerAppState extends ConsumerState<GSAnalyzerApp> with WindowListener {
+  @override
+  void initState() {
+    super.initState();
+    windowManager.addListener(this);
+    _checkInitialState();
+  }
+
+  Future<void> _checkInitialState() async {
+    final isMax = await windowManager.isMaximized();
+    ref.read(windowMaximizedProvider.notifier).state = isMax;
+  }
+
+  @override
+  void dispose() {
+    windowManager.removeListener(this);
+    super.dispose();
+  }
+
+  @override
+  void onWindowMaximize() {
+    ref.read(windowMaximizedProvider.notifier).state = true;
+  }
+
+  @override
+  void onWindowUnmaximize() {
+    ref.read(windowMaximizedProvider.notifier).state = false;
+    windowManager.setSize(kCompactSize);
+    windowManager.center();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final appearance = ref.watch(
       settingsProvider.select((s) => s.currentSettings?.appearance),
     );

--- a/frontend/gs_analyzer_ui/lib/models/app_settings.dart
+++ b/frontend/gs_analyzer_ui/lib/models/app_settings.dart
@@ -98,8 +98,8 @@ class AppSettings {
   class AppearanceSettings {
   String theme, accentColor;
   bool compactMode, showAnimations;
-  AppearanceSettings({this.theme = 'cyber_dark', this.accentColor = 'cyan', this.compactMode = false, this.showAnimations = true});
-  factory AppearanceSettings.fromJson(Map<String, dynamic> json) => AppearanceSettings(theme: json['theme'] ?? 'cyber_dark', accentColor: json['accentColor'] ?? 'cyan', compactMode: json['compactMode'] ?? false, showAnimations: json['showAnimations'] ?? true);
+  AppearanceSettings({this.theme = 'cyber_dark', this.accentColor = 'cyan', this.compactMode = true, this.showAnimations = true});
+  factory AppearanceSettings.fromJson(Map<String, dynamic> json) => AppearanceSettings(theme: json['theme'] ?? 'cyber_dark', accentColor: json['accentColor'] ?? 'cyan', compactMode: json['compactMode'] ?? true, showAnimations: json['showAnimations'] ?? true);
   Map<String, dynamic> toJson() => {'theme': theme, 'accentColor': accentColor, 'compactMode': compactMode, 'showAnimations': showAnimations};
   }
 

--- a/frontend/gs_analyzer_ui/lib/providers/hud_density_provider.dart
+++ b/frontend/gs_analyzer_ui/lib/providers/hud_density_provider.dart
@@ -6,11 +6,17 @@ class HudDensity {
   final double gap;
   final double panelPad;
   final double rowHeight;
+  final double titleSize;
+  final double valueSize;
+  final bool isMax;
 
   const HudDensity({
     required this.gap,
     required this.panelPad,
     required this.rowHeight,
+    required this.titleSize,
+    required this.valueSize,
+    required this.isMax,
   });
 }
 
@@ -22,16 +28,22 @@ final hudDensityProvider = Provider<HudDensity>((ref) {
   final isCompact = isMax ? false : savedCompact;
   
   if (isCompact) {
-    return const HudDensity(
+    return HudDensity(
       gap: 8.0,
       panelPad: 12.0,
       rowHeight: 32.0,
+      titleSize: 12.0,
+      valueSize: 32.0,
+      isMax: isMax,
     );
   } else {
-    return const HudDensity(
+    return HudDensity(
       gap: 16.0,
       panelPad: 24.0,
       rowHeight: 48.0,
+      titleSize: 16.0,
+      valueSize: 48.0,
+      isMax: isMax,
     );
   }
 });

--- a/frontend/gs_analyzer_ui/lib/providers/hud_density_provider.dart
+++ b/frontend/gs_analyzer_ui/lib/providers/hud_density_provider.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gs_analyzer_ui/providers/settings_provider.dart';
+
+class HudDensity {
+  final double gap;
+  final double panelPad;
+  final double rowHeight;
+
+  const HudDensity({
+    required this.gap,
+    required this.panelPad,
+    required this.rowHeight,
+  });
+}
+
+final hudDensityProvider = Provider<HudDensity>((ref) {
+  final settings = ref.watch(settingsProvider);
+  final isCompact = settings.currentSettings?.appearance.compactMode ?? true;
+  
+  if (isCompact) {
+    return const HudDensity(
+      gap: 8.0,
+      panelPad: 12.0,
+      rowHeight: 32.0,
+    );
+  } else {
+    return const HudDensity(
+      gap: 16.0,
+      panelPad: 24.0,
+      rowHeight: 48.0,
+    );
+  }
+});

--- a/frontend/gs_analyzer_ui/lib/providers/hud_density_provider.dart
+++ b/frontend/gs_analyzer_ui/lib/providers/hud_density_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gs_analyzer_ui/providers/settings_provider.dart';
+import 'package:gs_analyzer_ui/providers/window_provider.dart';
 
 class HudDensity {
   final double gap;
@@ -15,7 +16,10 @@ class HudDensity {
 
 final hudDensityProvider = Provider<HudDensity>((ref) {
   final settings = ref.watch(settingsProvider);
-  final isCompact = settings.currentSettings?.appearance.compactMode ?? true;
+  final isMax = ref.watch(windowMaximizedProvider);
+  final savedCompact = settings.currentSettings?.appearance.compactMode ?? true;
+  
+  final isCompact = isMax ? false : savedCompact;
   
   if (isCompact) {
     return const HudDensity(

--- a/frontend/gs_analyzer_ui/lib/providers/window_provider.dart
+++ b/frontend/gs_analyzer_ui/lib/providers/window_provider.dart
@@ -1,0 +1,3 @@
+import 'package:flutter_riverpod/legacy.dart';
+
+final windowMaximizedProvider = StateProvider<bool>((ref) => false);

--- a/frontend/gs_analyzer_ui/lib/screen/cpu_metrics_screen.dart
+++ b/frontend/gs_analyzer_ui/lib/screen/cpu_metrics_screen.dart
@@ -5,6 +5,7 @@ import 'package:gs_analyzer_ui/providers/cpu_provider.dart';
 import 'package:gs_analyzer_ui/models/cpu_snapshot.dart';
 import 'package:gs_analyzer_ui/utils/hud_theme.dart';
 import 'package:gs_analyzer_ui/widgets/telemetry_history_chart.dart';
+import 'package:gs_analyzer_ui/providers/hud_density_provider.dart';
 
 class CpuMetricsScreen extends ConsumerStatefulWidget {
   const CpuMetricsScreen({super.key});
@@ -20,9 +21,11 @@ class _CpuMetricsScreenState extends ConsumerState<CpuMetricsScreen> {
   Widget build(BuildContext context) {
     final cpuState = ref.watch(cpuProvider);
     final snapshot = cpuState.snapshot;
+    final d = ref.watch(hudDensityProvider);
 
-    return Padding(
-      padding: const EdgeInsets.all(24.0),
+    return SingleChildScrollView(
+      child: Padding(
+        padding: EdgeInsets.all(d.panelPad),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -51,21 +54,24 @@ class _CpuMetricsScreenState extends ConsumerState<CpuMetricsScreen> {
                 ),
             ],
           ),
-          const SizedBox(height: 24),
+          SizedBox(height: d.gap * 2),
           if (_showHistory)
-            const Expanded(child: TelemetryHistoryChart(metricKey: 'cpu'))
+            const SizedBox(height: 500, child: TelemetryHistoryChart(metricKey: 'cpu'))
           else if(snapshot == null)
-            const Expanded(
+            const SizedBox(
+              height: 500,
               child: Center(
                 child: CircularProgressIndicator(color: HudTheme.primaryBorder),
               ),
             )
           else
-            Expanded(
-              child: _buildDashBoard(context, snapshot),
+            SizedBox(
+              height: 500,
+              child: _buildDashBoard(context, snapshot, d),
             )
         ],
-      )
+      ),
+      ),
     );
   }
 
@@ -95,9 +101,9 @@ class _CpuMetricsScreenState extends ConsumerState<CpuMetricsScreen> {
     );
   }
 
-  Widget _buildDashBoard(BuildContext context, CpuSnapshot snapshot) {
+  Widget _buildDashBoard(BuildContext context, CpuSnapshot snapshot, HudDensity d) {
     return Container(
-      padding: const EdgeInsets.all(24),
+      padding: EdgeInsets.all(d.panelPad),
       decoration: HudTheme.hudPanelDecoration,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -117,7 +123,7 @@ class _CpuMetricsScreenState extends ConsumerState<CpuMetricsScreen> {
               Text('${snapshot.averageLoad.toStringAsFixed(1)}%', style: const TextStyle(color: HudTheme.accentCyan, fontSize: 48, fontWeight: FontWeight.bold, fontFamily: HudTheme.fontCore)),
             ],
           ),
-          const SizedBox(height: 16),
+          SizedBox(height: d.gap),
           FittedBox(
             fit: BoxFit.scaleDown,
             child: Text(
@@ -125,17 +131,17 @@ class _CpuMetricsScreenState extends ConsumerState<CpuMetricsScreen> {
               style: HudTheme.bodyText,
             ),
           ),
-          const SizedBox(height: 16),
-          Row(
+          SizedBox(height: d.gap),
+          Wrap(
+            spacing: d.gap,
+            runSpacing: d.gap,
             children: [
               _buildCacheChip('L1', snapshot.l1Cache),
-              const SizedBox(width: 8),
               _buildCacheChip('L2', snapshot.l2Cache),
-              const SizedBox(width: 8),
               _buildCacheChip('L3', snapshot.l3Cache),
             ],
           ),
-          const SizedBox(height: 32),
+          SizedBox(height: d.gap * 2),
           Expanded(child: _buildCoreCharts(snapshot.coreGroups)),
         ],
       ),

--- a/frontend/gs_analyzer_ui/lib/screen/cpu_metrics_screen.dart
+++ b/frontend/gs_analyzer_ui/lib/screen/cpu_metrics_screen.dart
@@ -23,9 +23,8 @@ class _CpuMetricsScreenState extends ConsumerState<CpuMetricsScreen> {
     final snapshot = cpuState.snapshot;
     final d = ref.watch(hudDensityProvider);
 
-    return SingleChildScrollView(
-      child: Padding(
-        padding: EdgeInsets.all(d.panelPad),
+    return Padding(
+      padding: EdgeInsets.all(d.panelPad),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -56,21 +55,20 @@ class _CpuMetricsScreenState extends ConsumerState<CpuMetricsScreen> {
           ),
           SizedBox(height: d.gap * 2),
           if (_showHistory)
-            const SizedBox(height: 500, child: TelemetryHistoryChart(metricKey: 'cpu'))
+            const Expanded(child: TelemetryHistoryChart(metricKey: 'cpu'))
           else if(snapshot == null)
-            const SizedBox(
-              height: 500,
+            const Expanded(
               child: Center(
                 child: CircularProgressIndicator(color: HudTheme.primaryBorder),
               ),
             )
           else
-            SizedBox(
-              height: 500,
-              child: _buildDashBoard(context, snapshot, d),
+            Expanded(
+              child: SingleChildScrollView(
+                child: _buildDashBoard(context, snapshot, d),
+              ),
             )
         ],
-      ),
       ),
     );
   }
@@ -142,7 +140,7 @@ class _CpuMetricsScreenState extends ConsumerState<CpuMetricsScreen> {
             ],
           ),
           SizedBox(height: d.gap * 2),
-          Expanded(child: _buildCoreCharts(snapshot.coreGroups)),
+          SizedBox(height: 300, child: _buildCoreCharts(snapshot.coreGroups)),
         ],
       ),
     );

--- a/frontend/gs_analyzer_ui/lib/screen/cpu_metrics_screen.dart
+++ b/frontend/gs_analyzer_ui/lib/screen/cpu_metrics_screen.dart
@@ -63,11 +63,13 @@ class _CpuMetricsScreenState extends ConsumerState<CpuMetricsScreen> {
               ),
             )
           else
-            Expanded(
-              child: SingleChildScrollView(
-                child: _buildDashBoard(context, snapshot, d),
-              ),
-            )
+            d.isMax
+                ? Expanded(child: _buildDashBoard(context, snapshot, d))
+                : Expanded(
+                    child: SingleChildScrollView(
+                      child: _buildDashBoard(context, snapshot, d),
+                    ),
+                  )
         ],
       ),
     );
@@ -118,7 +120,7 @@ class _CpuMetricsScreenState extends ConsumerState<CpuMetricsScreen> {
             crossAxisAlignment: CrossAxisAlignment.baseline,
             textBaseline: TextBaseline.alphabetic,
             children: [
-              Text('${snapshot.averageLoad.toStringAsFixed(1)}%', style: const TextStyle(color: HudTheme.accentCyan, fontSize: 48, fontWeight: FontWeight.bold, fontFamily: HudTheme.fontCore)),
+              Text('${snapshot.averageLoad.toStringAsFixed(1)}%', style: TextStyle(color: HudTheme.accentCyan, fontSize: d.valueSize, fontWeight: FontWeight.bold, fontFamily: HudTheme.fontCore)),
             ],
           ),
           SizedBox(height: d.gap),
@@ -140,7 +142,7 @@ class _CpuMetricsScreenState extends ConsumerState<CpuMetricsScreen> {
             ],
           ),
           SizedBox(height: d.gap * 2),
-          SizedBox(height: 300, child: _buildCoreCharts(snapshot.coreGroups)),
+          d.isMax ? Expanded(child: _buildCoreCharts(snapshot.coreGroups)) : SizedBox(height: 300, child: _buildCoreCharts(snapshot.coreGroups)),
         ],
       ),
     );

--- a/frontend/gs_analyzer_ui/lib/screen/process_explorer_screen.dart
+++ b/frontend/gs_analyzer_ui/lib/screen/process_explorer_screen.dart
@@ -91,15 +91,34 @@ class _SystemLoadBar extends ConsumerWidget {
       padding: EdgeInsets.symmetric(horizontal: d.panelPad, vertical: d.gap),
       decoration: const BoxDecoration(
           border: Border(bottom: BorderSide(color: Colors.white10))),
-      child: Wrap(
-        spacing: d.gap * 2,
-        runSpacing: d.gap,
-        crossAxisAlignment: WrapCrossAlignment.center,
-        children: [
-          SizedBox(width: 200, child: _LoadMetric('CPU', cpuText, cpuPct.clamp(0.0, 1.0), HudTheme.accentCyan)),
-          SizedBox(width: 200, child: _LoadMetric('RAM', '${(ramPct * 100).toStringAsFixed(1)}%', ramPct.clamp(0.0, 1.0), HudTheme.accentGreen)),
-          HudLabel('PROCS: ${ramState.groupedProcesses.length}'),
-        ],
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final wide = constraints.maxWidth > 520;
+          final cpu = _LoadMetric('CPU', cpuText, cpuPct.clamp(0.0, 1.0), HudTheme.accentCyan);
+          final ram = _LoadMetric('RAM', '${(ramPct * 100).toStringAsFixed(1)}%', ramPct.clamp(0.0, 1.0), HudTheme.accentGreen);
+          
+          if (wide) {
+            return Row(
+              children: [
+                Expanded(child: cpu),
+                SizedBox(width: d.gap),
+                Expanded(child: ram),
+                SizedBox(width: d.gap * 1.5),
+                HudLabel('PROCS: ${ramState.groupedProcesses.length}'),
+              ],
+            );
+          }
+          return Wrap(
+            spacing: d.gap * 2,
+            runSpacing: d.gap,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              SizedBox(width: 200, child: cpu),
+              SizedBox(width: 200, child: ram),
+              HudLabel('PROCS: ${ramState.groupedProcesses.length}'),
+            ],
+          );
+        },
       ),
     );
   }

--- a/frontend/gs_analyzer_ui/lib/screen/process_explorer_screen.dart
+++ b/frontend/gs_analyzer_ui/lib/screen/process_explorer_screen.dart
@@ -8,6 +8,7 @@ import 'package:gs_analyzer_ui/providers/ram_provider.dart';
 import 'package:gs_analyzer_ui/providers/settings_provider.dart';
 import 'package:gs_analyzer_ui/utils/hud_theme.dart';
 import 'package:gs_analyzer_ui/utils/hud_label.dart';
+import 'package:gs_analyzer_ui/providers/hud_density_provider.dart';
 
 class ProcessExplorerScreen extends ConsumerWidget {
   const ProcessExplorerScreen({super.key});
@@ -21,6 +22,7 @@ class ProcessExplorerScreen extends ConsumerWidget {
     final selectedPid = ref.watch(selectedProcessPidProvider);
     final showAll = ref.watch(showAllProcessesProvider);
     final totalCount = ramState.groupedProcesses.length;
+    final d = ref.watch(hudDensityProvider);
 
     return Column(
       children: [
@@ -47,6 +49,7 @@ class ProcessExplorerScreen extends ConsumerWidget {
                           return _ProcessRow(
                             group: group,
                             isSelected: isSelected,
+                            d: d,
                             onTap: () {
                               final current = ref.read(selectedProcessPidProvider);
                               ref.read(selectedProcessPidProvider.notifier).state =
@@ -68,14 +71,15 @@ class ProcessExplorerScreen extends ConsumerWidget {
 }
 
 //  System Load Bar
-class _SystemLoadBar extends StatelessWidget {
+class _SystemLoadBar extends ConsumerWidget {
   final RamState ramState;
   final CpuState cpuState;
 
   const _SystemLoadBar({required this.ramState, required this.cpuState});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final d = ref.watch(hudDensityProvider);
     final load    = cpuState.snapshot?.averageLoad ?? 0.0;
     final cpuPct  = load / 100.0;
     final ramPct  = ramState.totalGb > 0 ? ramState.activeGb / ramState.totalGb : 0.0;
@@ -84,22 +88,16 @@ class _SystemLoadBar extends StatelessWidget {
         : '--';
 
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 14),
+      padding: EdgeInsets.symmetric(horizontal: d.panelPad, vertical: d.gap),
       decoration: const BoxDecoration(
           border: Border(bottom: BorderSide(color: Colors.white10))),
-      child: Row(
+      child: Wrap(
+        spacing: d.gap * 2,
+        runSpacing: d.gap,
+        crossAxisAlignment: WrapCrossAlignment.center,
         children: [
-          Expanded(child: _LoadMetric(
-            'CPU', cpuText, cpuPct.clamp(0.0, 1.0), HudTheme.accentCyan,
-          )),
-          const SizedBox(width: 16),
-          Expanded(child: _LoadMetric(
-            'RAM',
-            '${(ramPct * 100).toStringAsFixed(1)}%',
-            ramPct.clamp(0.0, 1.0),
-            HudTheme.accentGreen,
-          )),
-          const SizedBox(width: 24),
+          SizedBox(width: 200, child: _LoadMetric('CPU', cpuText, cpuPct.clamp(0.0, 1.0), HudTheme.accentCyan)),
+          SizedBox(width: 200, child: _LoadMetric('RAM', '${(ramPct * 100).toStringAsFixed(1)}%', ramPct.clamp(0.0, 1.0), HudTheme.accentGreen)),
           HudLabel('PROCS: ${ramState.groupedProcesses.length}'),
         ],
       ),
@@ -251,11 +249,13 @@ class _ToolbarChip extends StatelessWidget {
 }
 
 // Table Header
-class _TableHeader extends StatelessWidget {
+class _TableHeader extends ConsumerWidget {
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final d = ref.watch(hudDensityProvider);
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 10),
+      padding: EdgeInsets.symmetric(horizontal: d.panelPad, vertical: 8),
+      height: d.rowHeight + 16,
       decoration: BoxDecoration(
           color: HudTheme.bgPanel,
           border: const Border(bottom: BorderSide(color: Colors.white10))),
@@ -277,11 +277,13 @@ class _ProcessRow extends ConsumerWidget {
   final ProcessGroup group;
   final bool isSelected;
   final VoidCallback onTap;
+  final HudDensity d;
 
   const _ProcessRow({
     required this.group,
     required this.isSelected,
     required this.onTap,
+    required this.d,
   });
 
   @override
@@ -305,7 +307,8 @@ class _ProcessRow extends ConsumerWidget {
           onTap: onTap,
           hoverColor: Colors.white.withValues(alpha: 0.03),
           child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 11),
+            height: d.rowHeight + 16,
+            padding: EdgeInsets.symmetric(horizontal: d.panelPad, vertical: 8),
             decoration: BoxDecoration(
               color: rowColor,
               border: Border(
@@ -356,7 +359,7 @@ class _ProcessRow extends ConsumerWidget {
         ),
 
         // ── Expanded detail drawer
-        if (isSelected) _DetailDrawer(group: group),
+        if (isSelected) _DetailDrawer(group: group, d: d),
       ],
     );
   }
@@ -399,14 +402,15 @@ class _ProcessRow extends ConsumerWidget {
 // Expanded Detail Drawer
 class _DetailDrawer extends ConsumerWidget {
   final ProcessGroup group;
-  const _DetailDrawer({required this.group});
+  final HudDensity d;
+  const _DetailDrawer({required this.group, required this.d});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return AnimatedContainer(
       duration: const Duration(milliseconds: 180),
       curve: Curves.easeOut,
-      padding: const EdgeInsets.symmetric(horizontal: 28, vertical: 14),
+      padding: EdgeInsets.symmetric(horizontal: d.panelPad, vertical: d.gap),
       decoration: BoxDecoration(
         color: HudTheme.accentCyan.withValues(alpha: 0.04),
         border: const Border(
@@ -414,18 +418,18 @@ class _DetailDrawer extends ConsumerWidget {
           bottom: BorderSide(color: Colors.white10),
         ),
       ),
-      child: Row(
-        children: [
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Row(
+          children: [
           // Stats
-          Expanded(
-            child: Wrap(spacing: 32, runSpacing: 8, children: [
-              _DrawerStat('PID',          group.count > 1 ? 'GROUPED (${group.count})' : group.primaryPid.toString()),
-              _DrawerStat('WORKING SET',  '${group.totalRamMb.toStringAsFixed(1)} MB'),
-              _DrawerStat('% CPU',        '${group.totalCpuPercent.toStringAsFixed(2)}%'),
-              _DrawerStat('STATUS',       group.dominantStatus),
-              _DrawerStat('USER',         group.primaryUser),
-            ]),
-          ),
+          Wrap(spacing: 32, runSpacing: 8, children: [
+            _DrawerStat('PID',          group.count > 1 ? 'GROUPED (${group.count})' : group.primaryPid.toString()),
+            _DrawerStat('WORKING SET',  '${group.totalRamMb.toStringAsFixed(1)} MB'),
+            _DrawerStat('% CPU',        '${group.totalCpuPercent.toStringAsFixed(2)}%'),
+            _DrawerStat('STATUS',       group.dominantStatus),
+            _DrawerStat('USER',         group.primaryUser),
+          ]),
           const SizedBox(width: 24),
           // Actions
           Row(children: [
@@ -444,6 +448,7 @@ class _DetailDrawer extends ConsumerWidget {
             ),
           ]),
         ],
+      ),
       ),
     );
   }

--- a/frontend/gs_analyzer_ui/lib/screen/ram_scannner_screen.dart
+++ b/frontend/gs_analyzer_ui/lib/screen/ram_scannner_screen.dart
@@ -21,9 +21,8 @@ class _RamScannerScreenState extends ConsumerState<RamScannerScreen> {
     final ramState = ref.watch(ramProvider);
     final d = ref.watch(hudDensityProvider);
 
-    return SingleChildScrollView(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
         // Critical banner
         if (ramState.isCritical && !_showHistory)
@@ -56,11 +55,10 @@ class _RamScannerScreenState extends ConsumerState<RamScannerScreen> {
         ),
 
         if (_showHistory)
-          Padding(
-            padding: EdgeInsets.all(d.panelPad),
-            child: const SizedBox(
-              height: 400,
-              child: TelemetryHistoryChart(metricKey: 'ram'),
+          Expanded(
+            child: Padding(
+              padding: EdgeInsets.all(d.panelPad),
+              child: const TelemetryHistoryChart(metricKey: 'ram'),
             ),
           )
         else ...[
@@ -122,10 +120,9 @@ class _RamScannerScreenState extends ConsumerState<RamScannerScreen> {
                     child: CircularProgressIndicator(color: HudTheme.primaryBorder),
                   ),
                 )
-              : ListView.builder(
-                  shrinkWrap: true,
-                  physics: const NeverScrollableScrollPhysics(),
-                  itemCount: ramState.groupedProcesses.length + 1,
+              : Expanded(
+                  child: ListView.builder(
+                    itemCount: ramState.groupedProcesses.length + 1,
                   itemBuilder: (context, index) {
                     if (index == 0) return _buildTableHeader(d);
 
@@ -210,9 +207,9 @@ class _RamScannerScreenState extends ConsumerState<RamScannerScreen> {
                     );
                   },
                 ),
+              ),
         ],
       ],
-      ),
     );
   }
 

--- a/frontend/gs_analyzer_ui/lib/screen/ram_scannner_screen.dart
+++ b/frontend/gs_analyzer_ui/lib/screen/ram_scannner_screen.dart
@@ -4,6 +4,7 @@ import 'package:gs_analyzer_ui/providers/ram_provider.dart';
 import 'package:gs_analyzer_ui/utils/hud_theme.dart';
 import 'package:gs_analyzer_ui/utils/hud_label.dart';
 import 'package:gs_analyzer_ui/widgets/telemetry_history_chart.dart';
+import 'package:gs_analyzer_ui/providers/hud_density_provider.dart';
 
 class RamScannerScreen extends ConsumerStatefulWidget {
   const RamScannerScreen({super.key});
@@ -18,10 +19,12 @@ class _RamScannerScreenState extends ConsumerState<RamScannerScreen> {
   @override
   Widget build(BuildContext context) {
     final ramState = ref.watch(ramProvider);
+    final d = ref.watch(hudDensityProvider);
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
         // Critical banner
         if (ramState.isCritical && !_showHistory)
           Container(
@@ -53,59 +56,78 @@ class _RamScannerScreenState extends ConsumerState<RamScannerScreen> {
         ),
 
         if (_showHistory)
-          const Expanded(
-            child: Padding(
-              padding: EdgeInsets.all(24.0),
+          Padding(
+            padding: EdgeInsets.all(d.panelPad),
+            child: const SizedBox(
+              height: 400,
               child: TelemetryHistoryChart(metricKey: 'ram'),
             ),
           )
         else ...[
           // Allocation cards
           Container(
-            padding: const EdgeInsets.all(24),
+            padding: EdgeInsets.all(d.panelPad),
             decoration: const BoxDecoration(
               border: Border(bottom: BorderSide(color: Colors.white10)),
             ),
-            child: Row(
-              children: [
-                Expanded(
-                  child: _buildAllocationCard(
-                    'ACTIVE MEMORY',
-                    '${ramState.activeGb.toStringAsFixed(1)} / ${ramState.totalGb.toStringAsFixed(1)} GB',
-                    HudTheme.accentCyan,
-                    ramState.totalGb > 0 ? ramState.activeGb / ramState.totalGb : 0.0,
-                  ),
-                ),
-                Expanded(
-                  child: _buildAllocationCard(
-                    'CACHE (STANDBY)',
-                    '${ramState.cacheGb.toStringAsFixed(1)} / ${ramState.totalGb.toStringAsFixed(1)} GB',
-                    HudTheme.accentGreen,
-                    ramState.totalGb > 0 ? ramState.cacheGb / ramState.totalGb : 0.0,
-                  ),
-                ),
-                Expanded(
-                  child: _buildAllocationCard(
-                    'SWAP / PAGEFILE',
-                    '${ramState.swapGb.toStringAsFixed(1)} / ${ramState.totalSwapGb.toStringAsFixed(1)} GB',
-                    HudTheme.accentAmber,
-                    ramState.totalSwapGb > 0 ? ramState.swapGb / ramState.totalSwapGb : 0.0,
-                  ),
-                ),
-            ],
+            child: LayoutBuilder(
+              builder: (ctx, c) {
+                final row = c.maxWidth > 640;
+                return Flex(
+                  direction: row ? Axis.horizontal : Axis.vertical,
+                  children: [
+                    Flexible(
+                      fit: row ? FlexFit.tight : FlexFit.loose,
+                      child: _buildAllocationCard(
+                        'ACTIVE MEMORY',
+                        '${ramState.activeGb.toStringAsFixed(1)} / ${ramState.totalGb.toStringAsFixed(1)} GB',
+                        HudTheme.accentCyan,
+                        ramState.totalGb > 0 ? ramState.activeGb / ramState.totalGb : 0.0,
+                        d,
+                      ),
+                    ),
+                    SizedBox(width: d.gap, height: d.gap),
+                    Flexible(
+                      fit: row ? FlexFit.tight : FlexFit.loose,
+                      child: _buildAllocationCard(
+                        'CACHE (STANDBY)',
+                        '${ramState.cacheGb.toStringAsFixed(1)} / ${ramState.totalGb.toStringAsFixed(1)} GB',
+                        HudTheme.accentGreen,
+                        ramState.totalGb > 0 ? ramState.cacheGb / ramState.totalGb : 0.0,
+                        d,
+                      ),
+                    ),
+                    SizedBox(width: d.gap, height: d.gap),
+                    Flexible(
+                      fit: row ? FlexFit.tight : FlexFit.loose,
+                      child: _buildAllocationCard(
+                        'SWAP / PAGEFILE',
+                        '${ramState.swapGb.toStringAsFixed(1)} / ${ramState.totalSwapGb.toStringAsFixed(1)} GB',
+                        HudTheme.accentAmber,
+                        ramState.totalSwapGb > 0 ? ramState.swapGb / ramState.totalSwapGb : 0.0,
+                        d,
+                      ),
+                    ),
+                  ],
+                );
+              },
+            ),
           ),
-        ),
 
-        // Process table
-        Expanded(
-          child: ramState.isLoading && ramState.groupedProcesses.isEmpty
+          // Process table
+          ramState.isLoading && ramState.groupedProcesses.isEmpty
               ? const Center(
-                  child: CircularProgressIndicator(color: HudTheme.primaryBorder),
+                  child: Padding(
+                    padding: EdgeInsets.all(32.0),
+                    child: CircularProgressIndicator(color: HudTheme.primaryBorder),
+                  ),
                 )
               : ListView.builder(
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
                   itemCount: ramState.groupedProcesses.length + 1,
                   itemBuilder: (context, index) {
-                    if (index == 0) return _buildTableHeader();
+                    if (index == 0) return _buildTableHeader(d);
 
                     final group = ramState.groupedProcesses[index - 1];
                     final isMemHot = group.totalPercentMem > 10.0;
@@ -116,7 +138,8 @@ class _RamScannerScreenState extends ConsumerState<RamScannerScreen> {
                         : group.name;
 
                     return Container(
-                      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+                      height: d.rowHeight + 16,
+                      padding: EdgeInsets.symmetric(horizontal: d.panelPad, vertical: 8),
                       decoration: BoxDecoration(
                         color: isHot
                             ? HudTheme.accentAmber.withValues(alpha: 0.05)
@@ -187,9 +210,9 @@ class _RamScannerScreenState extends ConsumerState<RamScannerScreen> {
                     );
                   },
                 ),
-              ),
         ],
       ],
+      ),
     );
   }
 
@@ -219,12 +242,13 @@ class _RamScannerScreenState extends ConsumerState<RamScannerScreen> {
     );
   }
 
-  Widget _buildTableHeader() {
+  Widget _buildTableHeader(HudDensity d) {
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
-      decoration: BoxDecoration(
+      padding: EdgeInsets.symmetric(horizontal: d.panelPad, vertical: 8),
+      height: d.rowHeight + 16,
+      decoration: const BoxDecoration(
         color: HudTheme.bgPanel,
-        border: const Border(bottom: BorderSide(color: Colors.white10)),
+        border: Border(bottom: BorderSide(color: Colors.white10)),
       ),
       child: const Row(
         children: [
@@ -244,25 +268,29 @@ class _RamScannerScreenState extends ConsumerState<RamScannerScreen> {
     String subtitle,
     Color accentColor,
     double percentage,
+    HudDensity d,
   ) {
     return Container(
-      padding: const EdgeInsets.all(16),
+      padding: EdgeInsets.all(d.panelPad),
       decoration: HudTheme.hudPanelDecoration,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           HudLabel(title),
-          const SizedBox(height: 8),
-          Text(
-            subtitle,
-            style: TextStyle(
-              color: accentColor,
-              fontSize: 16,
-              fontWeight: FontWeight.bold,
-              fontFamily: HudTheme.fontCore,
+          SizedBox(height: d.gap),
+          FittedBox(
+            fit: BoxFit.scaleDown,
+            child: Text(
+              subtitle,
+              style: TextStyle(
+                color: accentColor,
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+                fontFamily: HudTheme.fontCore,
+              ),
             ),
           ),
-          const SizedBox(height: 12),
+          SizedBox(height: d.gap),
           LinearProgressIndicator(
             value: percentage.clamp(0.0, 1.0),
             color: accentColor,

--- a/frontend/gs_analyzer_ui/lib/screen/ram_scannner_screen.dart
+++ b/frontend/gs_analyzer_ui/lib/screen/ram_scannner_screen.dart
@@ -281,7 +281,7 @@ class _RamScannerScreenState extends ConsumerState<RamScannerScreen> {
               subtitle,
               style: TextStyle(
                 color: accentColor,
-                fontSize: 16,
+                fontSize: d.titleSize,
                 fontWeight: FontWeight.bold,
                 fontFamily: HudTheme.fontCore,
               ),

--- a/frontend/gs_analyzer_ui/lib/screen/storage_screen.dart
+++ b/frontend/gs_analyzer_ui/lib/screen/storage_screen.dart
@@ -9,6 +9,7 @@ import 'package:gs_analyzer_ui/providers/storage_view_provider.dart';
 import 'package:gs_analyzer_ui/providers/storage_mode_provider.dart';
 import 'package:gs_analyzer_ui/widgets/file_type_analyzer_panel.dart';
 import 'package:gs_analyzer_ui/widgets/undo_history_panel.dart';
+import 'package:gs_analyzer_ui/providers/hud_density_provider.dart';
 
 class StorageScreen extends ConsumerWidget {
   const StorageScreen({Key? key}) : super(key: key);
@@ -16,8 +17,8 @@ class StorageScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final currentDrive = ref.watch(currentDriveProvider);
-
     final drives = ref.watch(drivesProvider);
+    final d = ref.watch(hudDensityProvider);
 
     Widget buildBody() {
       if (drives.isEmpty) {
@@ -38,30 +39,33 @@ class StorageScreen extends ConsumerWidget {
             child: ListView(
               children: [
                 Padding(
-                  padding: const EdgeInsets.all(16.0),
-                  child: _DriveDetailCard(drive: currentDrive),
+                  padding: EdgeInsets.all(d.panelPad),
+                  child: _DriveDetailCard(drive: currentDrive, d: d),
                 ),
                 FileTypeAnalyzerPanel(driveName: currentDrive.name),
                 Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                  padding: EdgeInsets.symmetric(horizontal: d.panelPad),
                   child: Column(
                     children: [
                       _ScanLaunchTile(
                         title: 'DIRECTORY SCANNER',
                         subtitle: 'Index every sector on ${currentDrive.name}',
                         icon: Icons.account_tree_outlined,
+                        d: d,
                         onLaunch: () => _enterAnalyzer(ref, currentDrive, StorageMode.diskAnalyzer),
                       ),
                       _ScanLaunchTile(
                         title: 'DUPLICATE HUNTER',
                         subtitle: 'Scan for duplicate files on ${currentDrive.name}',
                         icon: Icons.copy_all_outlined,
+                        d: d,
                         onLaunch: () => _enterAnalyzer(ref, currentDrive, StorageMode.duplicateScanner),
                       ),
                       _ScanLaunchTile(
                         title: 'PERMISSION AUDIT',
                         subtitle: 'Detect world-writable paths and orphaned files',
                         icon: Icons.security_outlined,
+                        d: d,
                         onLaunch: () => _enterAnalyzer(ref, currentDrive, StorageMode.permissionAudit),
                       ),
                     ],
@@ -104,25 +108,27 @@ class _ScanLaunchTile extends StatelessWidget {
   final String subtitle;
   final IconData icon;
   final VoidCallback onLaunch;
+  final HudDensity d;
 
   const _ScanLaunchTile({
     required this.title,
     required this.subtitle,
     required this.icon,
     required this.onLaunch,
+    required this.d,
   });
 
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.only(bottom: 16),
+      padding: EdgeInsets.only(bottom: d.gap),
       child: Material(
         color: Colors.transparent,
         child: InkWell(
           onTap: onLaunch,
           borderRadius: BorderRadius.circular(8),
           child: Container(
-            padding: const EdgeInsets.all(16),
+            padding: EdgeInsets.all(d.panelPad),
             decoration: HudTheme.hudPanelDecoration,
             child: Row(
               children: [
@@ -245,8 +251,9 @@ class _DriveTab extends ConsumerWidget {
 
 class _DriveDetailCard extends ConsumerWidget {
   final DriveInfo drive;
+  final HudDensity d;
 
-  const _DriveDetailCard({required this.drive});
+  const _DriveDetailCard({required this.drive, required this.d});
 
   String _formatGB(int bytes) => (bytes / (1024 * 1024 * 1024)).toStringAsFixed(1);
 
@@ -260,7 +267,7 @@ class _DriveDetailCard extends ConsumerWidget {
         : (drive.percentageUsed >= redThreshold - 10 ? Colors.amber : HudTheme.accentCyan);
 
     return Container(
-      padding: const EdgeInsets.all(16),
+      padding: EdgeInsets.all(d.panelPad),
       decoration: HudTheme.hudPanelDecoration,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -274,18 +281,18 @@ class _DriveDetailCard extends ConsumerWidget {
                 Text('● CRITICAL SPACE', style: HudTheme.bodyText.copyWith(color: Colors.redAccent, fontWeight: FontWeight.bold)),
             ],
           ),
-          const Divider(color: Colors.white10, height: 24, thickness: 1),
+          Divider(color: Colors.white10, height: d.gap * 3, thickness: 1),
 
-          Row(
+          Wrap(
+            spacing: d.gap * 3,
+            runSpacing: d.gap,
             children: [
               _buildMetaTag('TYPE', drive.type.toUpperCase()),
-              const SizedBox(width: 24),
               _buildMetaTag('FORMAT', drive.format.toUpperCase()),
-              const SizedBox(width: 24),
               _buildMetaTag('MOUNT', drive.name.toUpperCase()),
             ],
           ),
-          const SizedBox(height: 16),
+          SizedBox(height: d.gap * 2),
 
           Row(
             children: [
@@ -304,10 +311,12 @@ class _DriveDetailCard extends ConsumerWidget {
               Text('${drive.percentageUsed.toStringAsFixed(1)}%', style: HudTheme.bodyText),
             ],
           ),
-          const SizedBox(height: 12),
+          SizedBox(height: d.gap * 2),
 
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          Wrap(
+            spacing: d.gap * 3,
+            runSpacing: d.gap,
+            alignment: WrapAlignment.spaceBetween,
             children: [
               Text('USED: ${_formatGB(drive.usedBytes)} GB', style: HudTheme.bodyText.copyWith(color: statusColor)),
               Text('FREE: ${_formatGB(drive.freeBytes)} GB', style: HudTheme.bodyText),

--- a/frontend/gs_analyzer_ui/lib/screen/storage_screen.dart
+++ b/frontend/gs_analyzer_ui/lib/screen/storage_screen.dart
@@ -313,15 +313,30 @@ class _DriveDetailCard extends ConsumerWidget {
           ),
           SizedBox(height: d.gap * 2),
 
-          Wrap(
-            spacing: d.gap * 3,
-            runSpacing: d.gap,
-            alignment: WrapAlignment.spaceBetween,
-            children: [
-              Text('USED: ${_formatGB(drive.usedBytes)} GB', style: HudTheme.bodyText.copyWith(color: statusColor)),
-              Text('FREE: ${_formatGB(drive.freeBytes)} GB', style: HudTheme.bodyText),
-              Text('TOTAL: ${_formatGB(drive.totalBytes)} GB', style: HudTheme.bodyText.copyWith(color: HudTheme.textDim)),
-            ],
+          LayoutBuilder(
+            builder: (context, constraints) {
+              final wide = constraints.maxWidth > 520;
+              final used = Text('USED: ${_formatGB(drive.usedBytes)} GB', style: HudTheme.bodyText.copyWith(color: statusColor));
+              final free = Text('FREE: ${_formatGB(drive.freeBytes)} GB', style: HudTheme.bodyText);
+              final total = Text('TOTAL: ${_formatGB(drive.totalBytes)} GB', style: HudTheme.bodyText.copyWith(color: HudTheme.textDim));
+
+              if (wide) {
+                return Row(
+                  children: [
+                    Expanded(child: used),
+                    Expanded(child: free),
+                    Expanded(child: total),
+                  ],
+                );
+              }
+              
+              return Wrap(
+                spacing: d.gap * 3,
+                runSpacing: d.gap,
+                alignment: WrapAlignment.spaceBetween,
+                children: [used, free, total],
+              );
+            },
           ),
         ],
       ),

--- a/frontend/gs_analyzer_ui/lib/screen/telemetry_history_screen.dart
+++ b/frontend/gs_analyzer_ui/lib/screen/telemetry_history_screen.dart
@@ -1,16 +1,19 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gs_analyzer_ui/widgets/telemetry_history_chart.dart';
 import 'package:gs_analyzer_ui/utils/hud_theme.dart';
+import 'package:gs_analyzer_ui/providers/hud_density_provider.dart';
 
-class TelemetryHistoryScreen extends StatelessWidget {
+class TelemetryHistoryScreen extends ConsumerWidget {
   const TelemetryHistoryScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final d = ref.watch(hudDensityProvider);
     return Scaffold(
       backgroundColor: HudTheme.bgBase,
       body: Padding(
-        padding: const EdgeInsets.all(24.0),
+        padding: EdgeInsets.all(d.panelPad),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -32,17 +35,17 @@ class TelemetryHistoryScreen extends StatelessWidget {
             const SizedBox(height: 24),
             Expanded(
               child: ListView(
-                children: const [
+                children: [
                   SizedBox(
                     height: 400,
                     child: TelemetryHistoryChart(metricKey: 'cpu'),
                   ),
-                  SizedBox(height: 24),
+                  SizedBox(height: d.gap * 2),
                   SizedBox(
                     height: 400,
                     child: TelemetryHistoryChart(metricKey: 'ram'),
                   ),
-                  SizedBox(height: 24),
+                  SizedBox(height: d.gap * 2),
                   SizedBox(
                     height: 400,
                     child: TelemetryHistoryChart(metricKey: 'thermal_cpu_package'),

--- a/frontend/gs_analyzer_ui/lib/screen/thermal_module_screen.dart
+++ b/frontend/gs_analyzer_ui/lib/screen/thermal_module_screen.dart
@@ -8,6 +8,7 @@ import 'package:gs_analyzer_ui/models/thermal_telemetry.dart';
 import 'package:gs_analyzer_ui/utils/hud_theme.dart';
 import 'package:gs_analyzer_ui/utils/hud_label.dart';
 import 'package:gs_analyzer_ui/widgets/telemetry_history_chart.dart';
+import 'package:gs_analyzer_ui/providers/hud_density_provider.dart';
 
 class ThermalModuleScreen extends ConsumerStatefulWidget {
   const ThermalModuleScreen({super.key});
@@ -25,9 +26,10 @@ class _ThermalModuleScreenState extends ConsumerState<ThermalModuleScreen> {
     final thermalState = ref.watch(thermalProvider);
     final telemetry = thermalState.telemetry;
     final cpuState = ref.watch(cpuProvider).snapshot;
+    final d = ref.watch(hudDensityProvider);
 
     return Padding(
-      padding: const EdgeInsets.all(24.0),
+      padding: EdgeInsets.all(d.panelPad),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -73,26 +75,26 @@ class _ThermalModuleScreenState extends ConsumerState<ThermalModuleScreen> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  _buildCpuSection(telemetry, cpuState),
-                  const SizedBox(height: 16),
+                  _buildCpuSection(telemetry, cpuState, d),
+                  SizedBox(height: d.gap),
 
                   if (telemetry.motherBoardCelsius != null || telemetry.chipsetCelsius != null || telemetry.ramCelsius != null || telemetry.ambientCelsius != null) ... [
-                    _buildBoardSection(telemetry),
-                    const SizedBox(height: 16,)
+                    _buildBoardSection(telemetry, d),
+                    SizedBox(height: d.gap)
                   ],
 
                   if (telemetry.nvmeCelsius != null) ...[
-                    _buildStorageSection(telemetry),
-                    const SizedBox(height: 16),
+                    _buildStorageSection(telemetry, d),
+                    SizedBox(height: d.gap),
                   ],
 
                   if (_hasActiveFans(telemetry)) ...[
-                    _buildFansSection(telemetry),
-                    const SizedBox(height: 16),
+                    _buildFansSection(telemetry, d),
+                    SizedBox(height: d.gap),
                   ],
 
-                  _buildAdvancedSection(),
-                  const SizedBox(height: 24),
+                  _buildAdvancedSection(d),
+                  SizedBox(height: d.gap * 2),
                 ],
               ),
             )
@@ -132,10 +134,11 @@ class _ThermalModuleScreenState extends ConsumerState<ThermalModuleScreen> {
     return (t.cpuFanRpm ?? 0) > 0 || (t.chassisFan1Rpm ?? 0) > 0 || (t.chassisFan2Rpm ?? 0) > 0 || (t.pumpRpm ?? 0) > 0;
   }
 
-  Widget _buildCpuSection(ThermalTelemetry telemetry, dynamic cpuState) {
+  Widget _buildCpuSection(ThermalTelemetry telemetry, dynamic cpuState, HudDensity d) {
     return _ThermalSection(
       title: 'CPU',
       icon: Icons.memory_outlined,
+      d: d,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -164,7 +167,7 @@ class _ThermalModuleScreenState extends ConsumerState<ThermalModuleScreen> {
           ),
 
           if (telemetry.coreCelsius.isNotEmpty) ... [
-            const SizedBox(height: 16),
+            SizedBox(height: d.gap),
             SingleChildScrollView(
               scrollDirection: Axis.horizontal,
               child: Row(
@@ -182,13 +185,14 @@ class _ThermalModuleScreenState extends ConsumerState<ThermalModuleScreen> {
     );
   }
 
-  Widget _buildBoardSection(ThermalTelemetry telemetry) {
+  Widget _buildBoardSection(ThermalTelemetry telemetry, HudDensity d) {
     return _ThermalSection(
       title: 'SYSTEM ENVIRONMENT',
       icon: Icons.developer_board_outlined,
+      d: d,
       child: Wrap(
         spacing: 32,
-        runSpacing: 16,
+        runSpacing: d.gap,
         children: [
           if (telemetry.motherBoardCelsius != null)
             _buildEnvironmentRow('MOBO', telemetry.motherBoardCelsius!),
@@ -216,10 +220,11 @@ class _ThermalModuleScreenState extends ConsumerState<ThermalModuleScreen> {
     );
   }
 
-  Widget _buildStorageSection(ThermalTelemetry telemetry) {
+  Widget _buildStorageSection(ThermalTelemetry telemetry, HudDensity d) {
     return _ThermalSection(
       title: 'STORAGE',
       icon: Icons.storage_outlined,
+      d: d,
       child: Text(
         'NAME: ${telemetry.nvmeCelsius}°C',
         style: HudTheme.bodyText.copyWith(color: HudTheme.textMain, fontSize: 16),
@@ -227,13 +232,14 @@ class _ThermalModuleScreenState extends ConsumerState<ThermalModuleScreen> {
     );
   }
 
-  Widget _buildFansSection(ThermalTelemetry telemetry) {
+  Widget _buildFansSection(ThermalTelemetry telemetry, HudDensity d) {
     return _ThermalSection(
       title: 'FANS',
       icon: Icons.air_outlined,
+      d: d,
       child: Wrap(
         spacing: 24,
-        runSpacing: 12,
+        runSpacing: d.gap,
         children: [
           if ((telemetry.cpuFanRpm ?? 0) > 0) _buildFanRow('CPU_FAN', telemetry.cpuFanRpm!),
           if((telemetry.chassisFan1Rpm ?? 0) > 0) _buildFanRow('CHA_FAN1', telemetry.chassisFan1Rpm!),
@@ -258,7 +264,7 @@ class _ThermalModuleScreenState extends ConsumerState<ThermalModuleScreen> {
     );
   }
 
-  Widget _buildAdvancedSection() {
+  Widget _buildAdvancedSection(HudDensity d) {
     return Container(
       decoration: HudTheme.hudPanelDecoration,
       child: Theme(
@@ -277,10 +283,10 @@ class _ThermalModuleScreenState extends ConsumerState<ThermalModuleScreen> {
           ),
           children: [
             Padding(
-              padding: const EdgeInsets.only(left: 24, right: 24, bottom: 24, top: 8),
+              padding: EdgeInsets.only(left: d.panelPad, right: d.panelPad, bottom: d.panelPad, top: 8),
               child: Wrap(
                 spacing: 32,
-                runSpacing: 16,
+                runSpacing: d.gap,
                 children: [
                   _buildAdvancedRow('GPU_CORE', 'N/A'),
                   _buildAdvancedRow('GPU_HOTSPOT', 'N/A'),
@@ -351,13 +357,14 @@ class _ThermalSection extends StatelessWidget {
   final String title;
   final IconData icon;
   final Widget child;
+  final HudDensity d;
 
-  const _ThermalSection({required this.title, required this.icon, required this.child});
+  const _ThermalSection({required this.title, required this.icon, required this.child, required this.d});
 
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.all(24),
+      padding: EdgeInsets.all(d.panelPad),
       decoration: HudTheme.hudPanelDecoration,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -369,7 +376,7 @@ class _ThermalSection extends StatelessWidget {
               HudLabel(title)
             ],
           ),
-          const SizedBox(height: 16),
+          SizedBox(height: d.gap),
           child,
         ],
       ),

--- a/frontend/gs_analyzer_ui/linux/flutter/generated_plugin_registrant.cc
+++ b/frontend/gs_analyzer_ui/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,14 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <screen_retriever_linux/screen_retriever_linux_plugin.h>
+#include <window_manager/window_manager_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) screen_retriever_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverLinuxPlugin");
+  screen_retriever_linux_plugin_register_with_registrar(screen_retriever_linux_registrar);
+  g_autoptr(FlPluginRegistrar) window_manager_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "WindowManagerPlugin");
+  window_manager_plugin_register_with_registrar(window_manager_registrar);
 }

--- a/frontend/gs_analyzer_ui/linux/flutter/generated_plugins.cmake
+++ b/frontend/gs_analyzer_ui/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,8 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  screen_retriever_linux
+  window_manager
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/frontend/gs_analyzer_ui/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/frontend/gs_analyzer_ui/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,12 @@
 import FlutterMacOS
 import Foundation
 
+import screen_retriever_macos
 import shared_preferences_foundation
+import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))
 }

--- a/frontend/gs_analyzer_ui/pubspec.lock
+++ b/frontend/gs_analyzer_ui/pubspec.lock
@@ -255,6 +255,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  json_annotation:
+    dependency: transitive
+    description:
+      name: json_annotation
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.12.0"
   leak_tracker:
     dependency: transitive
     description:
@@ -463,6 +471,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
+  screen_retriever:
+    dependency: transitive
+    description:
+      name: screen_retriever
+      sha256: "42cc3b402a0f67d2455a0d067553d0f13453f6a008d98eababf8b63958d506bd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
+  screen_retriever_linux:
+    dependency: transitive
+    description:
+      name: screen_retriever_linux
+      sha256: "2a476f1a5538065bc5badf376cfdc83d6ecf07d77eb2391b9c2bff5a76970048"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
+  screen_retriever_macos:
+    dependency: transitive
+    description:
+      name: screen_retriever_macos
+      sha256: b5abb900fcb86614ff10b738b34e37b9e1d03b0447280668e2bc8a98bdc7bd59
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
+  screen_retriever_platform_interface:
+    dependency: transitive
+    description:
+      name: screen_retriever_platform_interface
+      sha256: "3af22d926bedf20c2caa308eea376776451a3af125919ce072e56525fded8901"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
+  screen_retriever_windows:
+    dependency: transitive
+    description:
+      name: screen_retriever_windows
+      sha256: c44b38a4c4bab34af259180a70a4eee1e29384e7b82e627c9faa68afcdab2e73
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -764,6 +812,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
+  window_manager:
+    dependency: "direct main"
+    description:
+      name: window_manager
+      sha256: "7eb6d6c4164ec08e1bf978d6e733f3cebe792e2a23fb07cbca25c2872bfdbdcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.1"
   xdg_directories:
     dependency: transitive
     description:

--- a/frontend/gs_analyzer_ui/pubspec.yaml
+++ b/frontend/gs_analyzer_ui/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   fl_chart: ^1.2.0
   intl: ^0.20.2
   logger: ^2.7.0
+  window_manager: ^0.5.1
 
 dev_dependencies:
   flutter_test:

--- a/frontend/gs_analyzer_ui/test/models/app_settings_test.dart
+++ b/frontend/gs_analyzer_ui/test/models/app_settings_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gs_analyzer_ui/models/app_settings.dart';
+
+void main() {
+  group('AppearanceSettings serialization', () {
+    test('compactMode defaults to true when parsing empty json', () {
+      final settings = AppearanceSettings.fromJson({});
+      expect(settings.compactMode, isTrue, reason: 'Compact Mode must default to true to match native Task Manager feel');
+    });
+
+    test('fromJson and toJson round-trips correctly', () {
+      final jsonPayload = {
+        'theme': 'light',
+        'accentColor': 'green',
+        'compactMode': false,
+        'showAnimations': true,
+      };
+
+      final settings = AppearanceSettings.fromJson(jsonPayload);
+      
+      expect(settings.theme, 'light');
+      expect(settings.accentColor, 'green');
+      expect(settings.compactMode, isFalse);
+      expect(settings.showAnimations, isTrue);
+
+      final outJson = settings.toJson();
+      
+      expect(outJson['theme'], 'light');
+      expect(outJson['accentColor'], 'green');
+      expect(outJson['compactMode'], false);
+      expect(outJson['showAnimations'], true);
+    });
+  });
+}

--- a/frontend/gs_analyzer_ui/test/provider/hud_density_provider_test.dart
+++ b/frontend/gs_analyzer_ui/test/provider/hud_density_provider_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:gs_analyzer_ui/providers/hud_density_provider.dart';
+import 'package:gs_analyzer_ui/providers/settings_provider.dart';
+import 'package:gs_analyzer_ui/providers/window_provider.dart';
+import 'package:gs_analyzer_ui/models/app_settings.dart';
+
+class MockSettingsNotifier extends StateNotifier<SettingsState> implements SettingsNotifier {
+  MockSettingsNotifier(SettingsState state) : super(state);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  group('HudDensityProvider Tests', () {
+    test('maximized + savedCompact=true -> Standard density', () {
+      final container = ProviderContainer(
+        overrides: [
+          windowMaximizedProvider.overrideWith((ref) => true),
+          settingsProvider.overrideWith((ref) => MockSettingsNotifier(
+                SettingsState(
+                  currentSettings: AppSettings.fromjson({
+                    'appearance': {'compactMode': true}
+                  }),
+                ),
+              )),
+        ],
+      );
+
+      final d = container.read(hudDensityProvider);
+      
+      // Standard: maximized ignores compact setting
+      expect(d.isMax, isTrue);
+      expect(d.gap, 16.0);
+      expect(d.panelPad, 24.0);
+    });
+
+    test('not maximized + savedCompact=true -> Compact density', () {
+      final container = ProviderContainer(
+        overrides: [
+          windowMaximizedProvider.overrideWith((ref) => false),
+          settingsProvider.overrideWith((ref) => MockSettingsNotifier(
+                SettingsState(
+                  currentSettings: AppSettings.fromjson({
+                    'appearance': {'compactMode': true}
+                  }),
+                ),
+              )),
+        ],
+      );
+
+      final d = container.read(hudDensityProvider);
+      
+      // Compact
+      expect(d.isMax, isFalse);
+      expect(d.gap, 8.0);
+      expect(d.panelPad, 12.0);
+    });
+
+    test('not maximized + savedCompact=false -> Standard density', () {
+      final container = ProviderContainer(
+        overrides: [
+          windowMaximizedProvider.overrideWith((ref) => false),
+          settingsProvider.overrideWith((ref) => MockSettingsNotifier(
+                SettingsState(
+                  currentSettings: AppSettings.fromjson({
+                    'appearance': {'compactMode': false}
+                  }),
+                ),
+              )),
+        ],
+      );
+
+      final d = container.read(hudDensityProvider);
+      
+      // Standard
+      expect(d.isMax, isFalse);
+      expect(d.gap, 16.0);
+      expect(d.panelPad, 24.0);
+    });
+  });
+}

--- a/frontend/gs_analyzer_ui/windows/flutter/generated_plugin_registrant.cc
+++ b/frontend/gs_analyzer_ui/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,12 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
+#include <window_manager/window_manager_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  ScreenRetrieverWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ScreenRetrieverWindowsPluginCApi"));
+  WindowManagerPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("WindowManagerPlugin"));
 }

--- a/frontend/gs_analyzer_ui/windows/flutter/generated_plugins.cmake
+++ b/frontend/gs_analyzer_ui/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,8 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  screen_retriever_windows
+  window_manager
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
## Summary

Implements **Compact Mode** (PRD §4.8 / Beta §4.3): a UI density that keeps the
HUD legible and overflow-free on smaller windows, plus Task-Manager-style window
behavior where the app starts as a small centered window and maximizing reveals
the full Standard view.

Density is driven by window state — **maximized = Standard (full view), restored =
Compact** — so the full view stays structurally identical to the original layout
while Compact only tightens spacing.

## Motivation

- Panels threw `RenderFlex overflowed by N px` at smaller window sizes.
- We wanted a compact default (like Task Manager) without redesigning the full view.
- Fix: separate **density** (spacing values) from **overflow safety** (structural,
  latent) so the Standard/full view is unchanged and only engages fallbacks when
  the window is actually small.

## What changed

**Density system**
- New `HudDensity` helper + `hudDensityProvider` — single source of truth for
  `gap` / `panelPad` / `rowHeight`. Panels read these instead of hardcoded values.
- `AppearanceSettings.compactMode` now defaults to `true` (persists via existing
  settings pipeline).
- Density resolves as `isCompact = isMaximized ? false : savedCompact`.

**Window behavior (`window_manager` ^0.5.1)**
- App opens at `900×640`, centered (`minimumSize 720×520`).
- New `windowMaximizedProvider` tracks window state via a `WindowListener`.
- `onWindowUnmaximize` re-centers and resizes back to the compact window.
- Plugin registrations added for Windows / macOS / Linux.

**Overflow-safe panels** (latent — only engage when space runs out)
- Restored `Expanded` fills; scroll moved *inside* `Expanded` (CPU dashboard).
- `LayoutBuilder` width breakpoints: `Row`+`Expanded` when wide, `Wrap` when narrow
  (Process `_SystemLoadBar`, Storage `_DriveDetailCard`, RAM allocation cards).
- Process table `ListView` restored to a real scrolling list inside `Expanded`.
- `FittedBox` / `TextOverflow.ellipsis` on large readouts and labels.

## Testing

- **Unit:** `hudDensityProvider` resolution — maximized→Standard, restored+saved
  compact→Compact, restored+saved standard→Standard.
- **Unit:** `AppearanceSettings` default (`compactMode == true`) + JSON round-trip.
- **Manual smoke test:** launch → compact + centered; maximize → full Standard view;
  restore → snaps back to centered compact window. Verified zero `RenderFlex`
  overflow at `720×520` (min) and maximized, in both densities.

## Notes

- v2.0 Compact Mode is **spacing only** — no panel reflow/hiding (deferred, per FR-A3).
- Window-state density slightly overlaps the manual Settings → Appearance toggle;
  the saved preference governs density while not maximized.

## Related

- PRD §4.8 Display Density (Compact Mode) — FR-A1…FR-A7
- Beta Technical Documentation §4.3 Display Density (Compact Mode)