### PR TITLE
fix: propagate CancellationToken through duplicate scan so Abort kills the hash loop (#99)

### DIFF
--- a/backend/Controllers/StorageController.cs
+++ b/backend/Controllers/StorageController.cs
@@ -128,6 +128,14 @@ namespace GSSystemAnalyzer.Controllers
 
                 return Ok(response);
             }
+            catch (OperationCanceledException)
+            {
+                return StatusCode(499, new ApiResponse<object>
+                {
+                    Success = false,
+                    Message = "Directory Scan Aborted by User."
+                });
+            }
             catch (Exception ex)
             {
                 return BadRequest(new ApiResponse<object>
@@ -136,7 +144,6 @@ namespace GSSystemAnalyzer.Controllers
                     Message = $"Scan failed: {ex.Message}"
                 });
             }
-
 
         }
 
@@ -232,7 +239,7 @@ namespace GSSystemAnalyzer.Controllers
                 }
 
                 var cancelToken = engine.ScanToken();
-                var duplicateGroups = await _duplicateFileDetector.FindDuplicatesAsync(targetPath);
+                var duplicateGroups = await _duplicateFileDetector.FindDuplicatesAsync(targetPath, cancelToken);
 
                 return Ok(new ApiResponse<IEnumerable<DuplicateGroup>>
                 {

--- a/backend/Engine/DiskScannerEngine.cs
+++ b/backend/Engine/DiskScannerEngine.cs
@@ -21,6 +21,7 @@ public class DiskScannerEngine : IDiskScannerEngine
     public ConcurrentDictionary<string, CacheEntry> DirectorySizeCache = new(StringComparer.OrdinalIgnoreCase);
     private CancellationTokenSource? _nukeCts;
     private CancellationTokenSource? _scanCts;
+    private readonly object _scanCtsLock = new();
     private readonly SemaphoreSlim _scanLock = new SemaphoreSlim(1, 1);
     private readonly object _fileWriteLock = new object();
     private int _deepScanThrottle = 0;
@@ -100,16 +101,21 @@ public class DiskScannerEngine : IDiskScannerEngine
                 _deepScanThrottle = 0;
                 _scannedFilesCount = 0;
 
-                var token = _scanCts?.Token ?? CancellationToken.None;
+                var scanToken = _scanCts?.Token ?? CancellationToken.None;
 
                 await _hub.Clients.All.SendAsync("ScanProgress", new { status = "INITIALIZING", count = 0, currentTarget = "Walking up the Engine...." });
 
-                await Parallel.ForEachAsync(directoriesToScan, async (dir, token) =>
+                var options = new ParallelOptions
                 {
-                    if (token.IsCancellationRequested) return;
+                    CancellationToken = scanToken,
+                    MaxDegreeOfParallelism = Math.Max(1, Environment.ProcessorCount / 2)
+                };
+
+                await Parallel.ForEachAsync(directoriesToScan, options, async (dir, ct) =>
+                {
                     try
                     {
-                        var size = await Task.Run(() => GetDirectorySize(dir, token), token);
+                        var size = await Task.Run(() => GetDirectorySize(dir, ct), ct);
 
                         DirectorySizeCache.TryGetValue(dir.FullName, out var existingEntry);
                         DirectorySizeCache[dir.FullName] = new CacheEntry
@@ -382,14 +388,17 @@ public class DiskScannerEngine : IDiskScannerEngine
 
     public CancellationToken ScanToken()
     {
-        _scanCts?.Cancel();
-        _scanCts  = new CancellationTokenSource();
-        return _scanCts.Token;
+        lock (_scanCtsLock)
+        {
+            _scanCts?.Cancel();
+            _scanCts = new CancellationTokenSource();
+            return _scanCts.Token;
+        }
     }
 
     public void TriggerScanAbort()
     {
-        _scanCts?.Cancel();
+        lock (_scanCtsLock) { _scanCts?.Cancel(); }
         _logger.LogInformation("Scan abort signal received");
     }
 

--- a/backend/GSSystemAnalyzer.Tests/Controller/StorageControllerCancellationTests.cs
+++ b/backend/GSSystemAnalyzer.Tests/Controller/StorageControllerCancellationTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using GSSystemAnalyzer.Controllers;
+using GSSystemAnalyzer.Engine;
+using GSSystemAnalyzer.Hubs;
+using GSSystemAnalyzer.Interfaces;
+using GSSystemAnalyzer.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace GSSystemAnalyzer.Tests.Controller
+{
+    public class StorageControllerCancellationTests
+    {
+        [Fact]
+        public async Task ScanForDuplicates_WhenCanceled_Returns499StatusCode()
+        {
+            // Arrange
+            var mockDiskService = new Mock<IDiskOperationService>();
+            var mockDuplicateFileDetector = new Mock<IDuplicateFileDetector>();
+            var mockDriveService = new Mock<IDriveDetectionService>();
+
+            string tempPath = Path.GetTempPath();
+            string rootDrive = Path.GetPathRoot(tempPath);
+
+            // Mock ready drive so we pass validation
+            mockDriveService.Setup(d => d.GetReadyDrives())
+                .Returns(new System.Collections.Generic.List<DriveMetric> { new DriveMetric { Name = rootDrive } });
+
+            // Make duplicate detector throw OperationCanceledException
+            mockDuplicateFileDetector
+                .Setup(d => d.FindDuplicatesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new OperationCanceledException());
+
+            var hubMock = new Mock<IHubContext<SystemHub>>();
+            var settingsMock = new Mock<ISettingService>();
+            var loggerMock = new Mock<ILogger<DiskScannerEngine>>();
+            var engine = new DiskScannerEngine(hubMock.Object, settingsMock.Object, loggerMock.Object);
+
+            var controller = new StorageController(mockDiskService.Object, mockDuplicateFileDetector.Object);
+
+            var request = new ScanRequest { Root = tempPath };
+
+            // Act
+            var result = await controller.ScanForDuplicates(request, engine, mockDriveService.Object);
+
+            // Assert
+            var objectResult = Assert.IsType<ObjectResult>(result);
+            Assert.Equal(499, objectResult.StatusCode);
+
+            var response = Assert.IsType<ApiResponse<object>>(objectResult.Value);
+            Assert.False(response.Success);
+            Assert.Equal("Duplicate Scan Aborted by User.", response.Message);
+        }
+    }
+}

--- a/backend/GSSystemAnalyzer.Tests/Engine/DiskScannerEngineTokenTests.cs
+++ b/backend/GSSystemAnalyzer.Tests/Engine/DiskScannerEngineTokenTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using GSSystemAnalyzer.Engine;
+using GSSystemAnalyzer.Hubs;
+using GSSystemAnalyzer.Interfaces;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace GSSystemAnalyzer.Tests.Engine
+{
+    public class DiskScannerEngineTokenTests
+    {
+        private readonly DiskScannerEngine _engine;
+
+        public DiskScannerEngineTokenTests()
+        {
+            var hubMock = new Mock<IHubContext<SystemHub>>();
+            var settingsMock = new Mock<ISettingService>();
+            var loggerMock = new Mock<ILogger<DiskScannerEngine>>();
+
+            _engine = new DiskScannerEngine(hubMock.Object, settingsMock.Object, loggerMock.Object);
+        }
+
+        [Fact]
+        public void ScanToken_ReturnsLiveToken()
+        {
+            var token = _engine.ScanToken();
+            Assert.False(token.IsCancellationRequested);
+        }
+
+        [Fact]
+        public void TriggerScanAbort_CancelsToken()
+        {
+            var token = _engine.ScanToken();
+            _engine.TriggerScanAbort();
+            Assert.True(token.IsCancellationRequested);
+        }
+
+        [Fact]
+        public void ScanToken_SuccessiveCalls_CancelPreviousToken()
+        {
+            var token1 = _engine.ScanToken();
+            Assert.False(token1.IsCancellationRequested);
+
+            var token2 = _engine.ScanToken();
+            
+            Assert.True(token1.IsCancellationRequested);
+            Assert.False(token2.IsCancellationRequested);
+        }
+    }
+}

--- a/backend/GSSystemAnalyzer.Tests/Services/DuplicateFileDetectorTests.cs
+++ b/backend/GSSystemAnalyzer.Tests/Services/DuplicateFileDetectorTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using GSSystemAnalyzer.Interfaces;
 using GSSystemAnalyzer.Models.SettingDtos;
@@ -123,6 +124,19 @@ namespace GSSystemAnalyzer.Tests.Services
 
             Assert.Equal(20, results[0].WastedBytes);
             Assert.Equal(15, results[1].WastedBytes);
+        }
+
+        [Fact]
+        public async Task Detector_Cancellation_ThrowsOperationCanceledException()
+        {
+            CreateTestFile("cancel1.txt", "ABCDE");
+            CreateTestFile("cancel2.txt", "ABCDE");
+
+            using var cts = new CancellationTokenSource(0);
+            
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                async () => await _detector.FindDuplicatesAsync(_testBaseDir, cts.Token)
+            );
         }
     }
 }

--- a/backend/Services/DuplicateFileDetector.cs
+++ b/backend/Services/DuplicateFileDetector.cs
@@ -37,8 +37,14 @@ namespace GSSystemAnalyzer.Services
             // Thread-safe dictionary to handle multiple CPU cores writing at the same time
             var hashedFiles = new ConcurrentDictionary<string, ConcurrentBag<string>>();
 
+            var parallelOptions = new ParallelOptions
+            {
+                CancellationToken = cancellationToken,
+                MaxDegreeOfParallelism = Math.Max(1, Environment.ProcessorCount / 2)
+            };
+
             // Process the remaining files across all available CPU cores
-            await Parallel.ForEachAsync(filesToHash, async (file, ct) =>
+            await Parallel.ForEachAsync(filesToHash, parallelOptions, async (file, ct) =>
             {
                 try
                 {


### PR DESCRIPTION
Fixes #99.

## Root cause
Abort routing was fine (singleton DiskScannerEngine._scanCts is shared), but the
token was dropped in two layers:
1. StorageController.duplicates called FindDuplicatesAsync(path) — token never passed.
2. DuplicateFileDetector's Parallel.ForEachAsync had no ParallelOptions, so the body's
   `ct` was CancellationToken.None — the SHA-256 hashing pass (the CPU-burning phase)
   was uncancellable even once layer 1 was fixed.

## Changes
- StorageController: pass engine.ScanToken() into FindDuplicatesAsync.
- DuplicateFileDetector: add ParallelOptions { CancellationToken, MaxDegreeOfParallelism };
  OperationCanceledException bubbles → existing 499 handler.
- DiskScannerEngine.CalculateMissingSizesAsync: fix identical token-shadowing bug in the
  directory-scan parallel loop (+ 499 handling on /scan).
- DiskScannerEngine.ScanToken/TriggerScanAbort: lock around _scanCts to remove the race.

## Tests
- DuplicateFileDetector aborts on a cancelled token (temp-dir duplicates).
- Engine token lifecycle (ScanToken → TriggerScanAbort → IsCancellationRequested).
- Controller returns 499 on OperationCanceledException.

## Verification
- Init duplicate scan on a large dir → CPU spikes as expected.
- Click Abort → hashing halts within ~1s, CPU releases, no zombie thread on re-scan.