### PR TITLE
chore: refactor the scan to use a unique random IDIntroduce ScanSession: per-scan cancellation isolation + scanId-correlated progress and directory streaming

### DIFF
--- a/backend/Controllers/StorageController.cs
+++ b/backend/Controllers/StorageController.cs
@@ -24,12 +24,12 @@ namespace GSSystemAnalyzer.Controllers
         }
 
         [HttpPost("stream-sector")]
-        public IActionResult StreamDirectorySection([FromServices] IHubContext<SystemHub> hubContext, [FromServices] IDriveDetectionService driveService, [FromQuery] string path)
+        public IActionResult StreamDirectorySection([FromServices] IHubContext<SystemHub> hubContext, [FromServices] IDriveDetectionService driveService, [FromQuery] string path, [FromQuery] Guid? scanId)
         {
             var validationResult = ValidateDriveAndDirectory(path, driveService);
             if (validationResult != null) return validationResult;
             
-            var cancelToken = _diskService.BeginScan();
+            var id = _diskService.BeginScan(scanId);
 
             _ = Task.Run(async () =>
             {
@@ -37,12 +37,19 @@ namespace GSSystemAnalyzer.Controllers
                 var scopedDiskService = scope.ServiceProvider.GetRequiredService<IDiskOperationService>();
                 try
                 {
-                    var allNodes = scopedDiskService.ScanDirectory(path).ToList();
+                    var allNodes = scopedDiskService.ScanDirectory(path, id).ToList();
                     
                     var chunkSize = 100;
                     for (var i = 0; i < allNodes.Count; i += chunkSize)
                     {
-                        if (cancelToken.IsCancellationRequested) break;
+                        // To allow cancellation, we need the token from the singleton engine for this session
+                        // Since we are in a background thread and the scoped disk service doesn't easily expose it here, 
+                        // we can let the scoped service retrieve it, or we skip checking here since CalculateMissingSizesAsync 
+                        // handles its own cancellation. But wait, `cancelToken` was used here before.
+                        // Let's resolve the engine directly to check cancellation if we want.
+                        // Actually, I can just resolve the engine from scope.
+                        var engine = scope.ServiceProvider.GetRequiredService<GSSystemAnalyzer.Interfaces.IDiskScannerEngine>();
+                        if (engine.GetScanToken(id).IsCancellationRequested) break;
 
                         var chunk = allNodes.Skip(i).Take(chunkSize).ToList();
                         await hubContext.Clients.All.SendAsync("DirectoryChunk", new
@@ -83,8 +90,8 @@ namespace GSSystemAnalyzer.Controllers
                 var validationResult = ValidateDriveAndDirectory(targetPath, driveService);
                 if (validationResult != null) return validationResult;
 
-                _diskService.BeginScan();
-                var result = await Task.Run(() => _diskService.ScanDirectory(targetPath));
+                var id = _diskService.BeginScan(request.ScanId);
+                var result = await Task.Run(() => _diskService.ScanDirectory(targetPath, id));
 
                 var response = new ApiResponse<IEnumerable<StorageNode>>
                 {
@@ -147,9 +154,9 @@ namespace GSSystemAnalyzer.Controllers
 
 
         [HttpPost("abort-scan")]
-        public IActionResult AbortScan()
+        public IActionResult AbortScan([FromQuery] Guid? scanId = null)
         {
-            _diskService.TriggerScanAbort();
+            _diskService.TriggerScanAbort(scanId);
 
             return Ok(new ApiResponse<object>
             {
@@ -170,8 +177,8 @@ namespace GSSystemAnalyzer.Controllers
                 var validationResult = ValidateDriveAndDirectory(targetPath, driveService);
                 if (validationResult != null) return validationResult;
 
-                var cancelToken = _diskService.BeginScan();
-                var duplicateGroups = await _duplicateFileDetector.FindDuplicatesAsync(targetPath, cancelToken);
+                var id = _diskService.BeginScan(request.ScanId);
+                var duplicateGroups = await _duplicateFileDetector.FindDuplicatesAsync(targetPath, id);
 
                 return Ok(new ApiResponse<IEnumerable<DuplicateGroup>>
                 {

--- a/backend/Controllers/StorageController.cs
+++ b/backend/Controllers/StorageController.cs
@@ -42,19 +42,13 @@ namespace GSSystemAnalyzer.Controllers
                     var chunkSize = 100;
                     for (var i = 0; i < allNodes.Count; i += chunkSize)
                     {
-                        // To allow cancellation, we need the token from the singleton engine for this session
-                        // Since we are in a background thread and the scoped disk service doesn't easily expose it here, 
-                        // we can let the scoped service retrieve it, or we skip checking here since CalculateMissingSizesAsync 
-                        // handles its own cancellation. But wait, `cancelToken` was used here before.
-                        // Let's resolve the engine directly to check cancellation if we want.
-                        // Actually, I can just resolve the engine from scope.
                         var engine = scope.ServiceProvider.GetRequiredService<GSSystemAnalyzer.Interfaces.IDiskScannerEngine>();
                         if (engine.GetScanToken(id).IsCancellationRequested) break;
 
                         var chunk = allNodes.Skip(i).Take(chunkSize).ToList();
                         await hubContext.Clients.All.SendAsync("DirectoryChunk", new
                         {
-                            path = path, chunk = chunk
+                            scanId = id, path = path, chunk = chunk
                         });
 
                         await Task.Delay(10);
@@ -63,11 +57,11 @@ namespace GSSystemAnalyzer.Controllers
                 catch (Exception ex)
                 {
                     await hubContext.Clients.All.SendAsync("DirectoryStreamError",
-                        new { path = path, error = ex.Message });
+                        new { scanId = id, path = path, error = ex.Message });
                 }
                 finally
                 {
-                    await hubContext.Clients.All.SendAsync("DirectoryStreamComplete", path);
+                    await hubContext.Clients.All.SendAsync("DirectoryStreamComplete", new { scanId = id, path = path });
                 }
             });
 

--- a/backend/Engine/DiskScannerEngine.cs
+++ b/backend/Engine/DiskScannerEngine.cs
@@ -20,8 +20,7 @@ public class DiskScannerEngine : IDiskScannerEngine
 {
     public ConcurrentDictionary<string, CacheEntry> DirectorySizeCache = new(StringComparer.OrdinalIgnoreCase);
     private CancellationTokenSource? _nukeCts;
-    private CancellationTokenSource? _scanCts;
-    private readonly object _scanCtsLock = new();
+    private readonly ConcurrentDictionary<Guid, ScanSession> _activeSessions = new();
     private readonly SemaphoreSlim _scanLock = new SemaphoreSlim(1, 1);
     private readonly object _fileWriteLock = new object();
     private int _deepScanThrottle = 0;
@@ -85,7 +84,7 @@ public class DiskScannerEngine : IDiskScannerEngine
         return items;
     }
 
-    public async Task CalculateMissingSizesAsync(List<FileSystemInfo> items)
+    public async Task CalculateMissingSizesAsync(List<FileSystemInfo> items, Guid scanId)
     {
         await _scanLock.WaitAsync();
         try
@@ -102,10 +101,10 @@ public class DiskScannerEngine : IDiskScannerEngine
                 _deepScanThrottle = 0;
                 _scannedFilesCount = 0;
 
-                // Fix: scanToken is read directly from _scanCts outside _scanCtsLock, which can lead to a scan without a cancellation token.
-                var scanToken = _scanCts?.Token ?? CancellationToken.None;
+                // Retrieve the specific session's token
+                var scanToken = _activeSessions.TryGetValue(scanId, out var session) ? session.Cts.Token : CancellationToken.None;
 
-                await _hub.Clients.All.SendAsync("ScanProgress", new { status = "INITIALIZING", count = 0, currentTarget = "Walking up the Engine...." });
+                await _hub.Clients.All.SendAsync("ScanProgress", new { scanId = scanId, status = "INITIALIZING", count = 0, currentTarget = "Walking up the Engine...." });
 
                 var options = new ParallelOptions
                 {
@@ -137,6 +136,7 @@ public class DiskScannerEngine : IDiskScannerEngine
 
                     _ = _hub.Clients.All.SendAsync("ScanProgress", new
                     {
+                        scanId = scanId,
                         completed = completed,
                         total = totalNodes,
                         percentageComplete = percentage,
@@ -147,7 +147,7 @@ public class DiskScannerEngine : IDiskScannerEngine
                 SaveMemoryToDisk();
             }
             
-            await _hub.Clients.All.SendAsync("ScanProgress", new { status = "COMPLETED", count = _scannedFilesCount, currentTarget = "Scan completed" });
+            await _hub.Clients.All.SendAsync("ScanProgress", new { scanId = scanId, status = "COMPLETED", count = _scannedFilesCount, currentTarget = "Scan completed" });
         }
         finally
         {
@@ -393,20 +393,52 @@ public class DiskScannerEngine : IDiskScannerEngine
         _nukeCts?.Cancel();
     }
 
-    public CancellationToken ScanToken()
+    public Guid BeginScanSession(Guid? scanId = null)
     {
-        lock (_scanCtsLock)
+        var id = scanId ?? Guid.NewGuid();
+
+        if (_activeSessions.TryRemove(id, out var existingSession))
         {
-            _scanCts?.Cancel();
-            _scanCts = new CancellationTokenSource();
-            return _scanCts.Token;
+            existingSession.Dispose();
+        }
+
+        var newSession = new ScanSession(id);
+        _activeSessions[id] = newSession;
+
+        return id;
+    }
+
+    public CancellationToken GetScanToken(Guid scanId)
+    {
+        return _activeSessions.TryGetValue(scanId, out var session) ? session.Cts.Token : CancellationToken.None;
+    }
+
+    public void EndScanSession(Guid scanId)
+    {
+        if (_activeSessions.TryRemove(scanId, out var session))
+        {
+            session.Dispose();
         }
     }
 
-    public void TriggerScanAbort()
+    public void TriggerScanAbort(Guid? scanId = null)
     {
-        lock (_scanCtsLock) { _scanCts?.Cancel(); }
-        _logger.LogInformation("Scan abort signal received");
+        if (scanId.HasValue)
+        {
+            if (_activeSessions.TryGetValue(scanId.Value, out var session))
+            {
+                session.Cts.Cancel();
+                _logger.LogInformation("Scan abort signal received for specific scanId: {ScanId}", scanId.Value);
+            }
+        }
+        else
+        {
+            foreach (var session in _activeSessions.Values)
+            {
+                session.Cts.Cancel();
+            }
+            _logger.LogInformation("Global scan abort signal received, all active scans canceled");
+        }
     }
 
     public void PruneStaleCacheEntries()

--- a/backend/GSSystemAnalyzer.Tests/Controllers/StorageControllerCancellationTests.cs
+++ b/backend/GSSystemAnalyzer.Tests/Controllers/StorageControllerCancellationTests.cs
@@ -52,8 +52,9 @@ namespace GSSystemAnalyzer.Tests.Controllers
         public async Task ScanDirectory_ReturnsOk_WhenScanSucceeds()
         {
             var disk = new Mock<IDiskOperationService>();
-            disk.Setup(s => s.BeginScan()).Returns(CancellationToken.None);
-            disk.Setup(s => s.ScanDirectory(It.IsAny<string>())).Returns(new List<StorageNode>());
+            var id = Guid.NewGuid();
+            disk.Setup(s => s.BeginScan(It.IsAny<Guid?>())).Returns(id);
+            disk.Setup(s => s.ScanDirectory(It.IsAny<string>(), id)).Returns(new List<StorageNode>());
 
             var controller = BuildController(disk.Object);
 
@@ -67,8 +68,9 @@ namespace GSSystemAnalyzer.Tests.Controllers
         public async Task ScanDirectory_Returns499_WhenScanIsCanceled()
         {
             var disk = new Mock<IDiskOperationService>();
-            disk.Setup(s => s.BeginScan()).Returns(CancellationToken.None);
-            disk.Setup(s => s.ScanDirectory(It.IsAny<string>()))
+            var id = Guid.NewGuid();
+            disk.Setup(s => s.BeginScan(It.IsAny<Guid?>())).Returns(id);
+            disk.Setup(s => s.ScanDirectory(It.IsAny<string>(), id))
                 .Throws<OperationCanceledException>();
 
             var controller = BuildController(disk.Object);
@@ -86,12 +88,13 @@ namespace GSSystemAnalyzer.Tests.Controllers
             // Regression guard for the bug this PR fixes: scan must call BeginScan()
             // BEFORE ScanDirectory, otherwise it runs with a stale/None token.
             var callOrder = new List<string>();
+            var id = Guid.NewGuid();
 
             var disk = new Mock<IDiskOperationService>();
-            disk.Setup(s => s.BeginScan())
+            disk.Setup(s => s.BeginScan(It.IsAny<Guid?>()))
                 .Callback(() => callOrder.Add("BeginScan"))
-                .Returns(CancellationToken.None);
-            disk.Setup(s => s.ScanDirectory(It.IsAny<string>()))
+                .Returns(id);
+            disk.Setup(s => s.ScanDirectory(It.IsAny<string>(), id))
                 .Callback(() => callOrder.Add("ScanDirectory"))
                 .Returns(new List<StorageNode>());
 
@@ -116,7 +119,7 @@ namespace GSSystemAnalyzer.Tests.Controllers
                 new ScanRequest { Root = TempDir }, drive.Object);
 
             Assert.IsType<BadRequestObjectResult>(result);
-            disk.Verify(s => s.BeginScan(), Times.Never); // must not start a scan on bad input
+            disk.Verify(s => s.BeginScan(It.IsAny<Guid?>()), Times.Never); // must not start a scan on bad input
         }
 
         [Fact]
@@ -128,27 +131,29 @@ namespace GSSystemAnalyzer.Tests.Controllers
             var result = controller.AbortScan();
 
             Assert.IsType<OkObjectResult>(result);
-            disk.Verify(s => s.TriggerScanAbort(), Times.Once);
+            disk.Verify(s => s.TriggerScanAbort(null), Times.Once);
         }
 
         [Fact]
         public void StreamSector_ReturnsInitiated_AndBeginsScanSynchronously()
         {
             var disk = new Mock<IDiskOperationService>();
-            disk.Setup(s => s.BeginScan()).Returns(CancellationToken.None);
-            disk.Setup(s => s.ScanDirectory(It.IsAny<string>())).Returns(new List<StorageNode>());
+            var id = Guid.NewGuid();
+            disk.Setup(s => s.BeginScan(It.IsAny<Guid?>())).Returns(id);
+            disk.Setup(s => s.ScanDirectory(It.IsAny<string>(), id)).Returns(new List<StorageNode>());
 
             var controller = BuildController(disk.Object, ScopeFactoryFor(disk.Object).Object);
 
             var result = controller.StreamDirectorySection(
                 Mock.Of<IHubContext<SystemHub>>(),
                 DriveServiceWithReadyRoot().Object,
-                TempDir);
+                TempDir,
+                null);
 
             var ok = Assert.IsType<OkObjectResult>(result);
             var payload = Assert.IsType<ApiResponse<object>>(ok.Value);
             Assert.True(payload.Success);
-            disk.Verify(s => s.BeginScan(), Times.Once); // token established before returning
+            disk.Verify(s => s.BeginScan(It.IsAny<Guid?>()), Times.Once); // token established before returning
         }
     }
 }

--- a/backend/GSSystemAnalyzer.Tests/Engine/DiskScannerEngineTokenTests.cs
+++ b/backend/GSSystemAnalyzer.Tests/Engine/DiskScannerEngineTokenTests.cs
@@ -25,30 +25,41 @@ namespace GSSystemAnalyzer.Tests.Engine
         }
 
         [Fact]
-        public void ScanToken_ReturnsLiveToken()
+        public void BeginScanSession_ReturnsLiveToken()
         {
-            var token = _engine.ScanToken();
+            var id = _engine.BeginScanSession();
+            var token = _engine.GetScanToken(id);
             Assert.False(token.IsCancellationRequested);
         }
 
         [Fact]
-        public void TriggerScanAbort_CancelsToken()
+        public void TriggerScanAbort_SpecificId_CancelsOnlyThatToken()
         {
-            var token = _engine.ScanToken();
-            _engine.TriggerScanAbort();
-            Assert.True(token.IsCancellationRequested);
-        }
+            var id1 = _engine.BeginScanSession();
+            var id2 = _engine.BeginScanSession();
+            
+            var token1 = _engine.GetScanToken(id1);
+            var token2 = _engine.GetScanToken(id2);
 
-        [Fact]
-        public void ScanToken_SuccessiveCalls_CancelPreviousToken()
-        {
-            var token1 = _engine.ScanToken();
-            Assert.False(token1.IsCancellationRequested);
-
-            var token2 = _engine.ScanToken();
+            _engine.TriggerScanAbort(id1);
             
             Assert.True(token1.IsCancellationRequested);
             Assert.False(token2.IsCancellationRequested);
+        }
+
+        [Fact]
+        public void TriggerScanAbort_NullId_CancelsAllTokens()
+        {
+            var id1 = _engine.BeginScanSession();
+            var id2 = _engine.BeginScanSession();
+            
+            var token1 = _engine.GetScanToken(id1);
+            var token2 = _engine.GetScanToken(id2);
+
+            _engine.TriggerScanAbort(null);
+            
+            Assert.True(token1.IsCancellationRequested);
+            Assert.True(token2.IsCancellationRequested);
         }
     }
 }

--- a/backend/GSSystemAnalyzer.Tests/Services/DuplicateFileDetectorTests.cs
+++ b/backend/GSSystemAnalyzer.Tests/Services/DuplicateFileDetectorTests.cs
@@ -25,7 +25,10 @@ namespace GSSystemAnalyzer.Tests.Services
             mockSettings.Setup(s => s.Current)
                 .Returns(AppSettingDto.GetFactoryDefaults());
 
-            _detector = new DuplicateFileDetector(mockSettings.Object);
+            var mockScanner = new Mock<IDiskScannerEngine>();
+            mockScanner.Setup(s => s.GetScanToken(It.IsAny<Guid>())).Returns(CancellationToken.None);
+
+            _detector = new DuplicateFileDetector(mockSettings.Object, mockScanner.Object);
         }
 
         public void Dispose()
@@ -48,7 +51,7 @@ namespace GSSystemAnalyzer.Tests.Services
             CreateTestFile("beta_copy.log", "MATRIX_CORE_DATA");
             CreateTestFile("unique_file.txt", "ISOLATED_DATA");
 
-            var results = await _detector.FindDuplicatesAsync(_testBaseDir);
+            var results = await _detector.FindDuplicatesAsync(_testBaseDir, Guid.NewGuid());
 
             Assert.Single(results); // Only one group of duplicates should exist
             var group = results.First();
@@ -65,7 +68,7 @@ namespace GSSystemAnalyzer.Tests.Services
             CreateTestFile("valid1.txt", "REAL_DATA");
             CreateTestFile("valid2.txt", "REAL_DATA");
 
-            var results = await _detector.FindDuplicatesAsync(_testBaseDir);
+            var results = await _detector.FindDuplicatesAsync(_testBaseDir, Guid.NewGuid());
 
             Assert.Single(results);
             Assert.DoesNotContain(results.First().FilePaths, p => p.Contains("empty1.txt"));
@@ -82,8 +85,8 @@ namespace GSSystemAnalyzer.Tests.Services
 
             using (var lockedStream = new FileStream(lockedPath, FileMode.Open, FileAccess.Read, FileShare.None))
             {
-                var exception = await Record.ExceptionAsync(async () => await _detector.FindDuplicatesAsync(_testBaseDir));
-                var results = await _detector.FindDuplicatesAsync(_testBaseDir);
+                var exception = await Record.ExceptionAsync(async () => await _detector.FindDuplicatesAsync(_testBaseDir, Guid.NewGuid()));
+                var results = await _detector.FindDuplicatesAsync(_testBaseDir, Guid.NewGuid());
 
                 Assert.Null(exception);
                 Assert.Single(results);
@@ -99,7 +102,7 @@ namespace GSSystemAnalyzer.Tests.Services
             CreateTestFile("fileB.txt", content);
             CreateTestFile("fileC.txt", content); // 3 copies = 1 original + 2 wasted
 
-            var results = await _detector.FindDuplicatesAsync(_testBaseDir);
+            var results = await _detector.FindDuplicatesAsync(_testBaseDir, Guid.NewGuid());
 
             var group = results.First();
             Assert.Equal(10, group.FileSizeBytes);
@@ -118,7 +121,7 @@ namespace GSSystemAnalyzer.Tests.Services
             CreateTestFile("large1.txt", "123456789012345");
             CreateTestFile("large2.txt", "123456789012345");
 
-            var results = await _detector.FindDuplicatesAsync(_testBaseDir);
+            var results = await _detector.FindDuplicatesAsync(_testBaseDir, Guid.NewGuid());
 
             Assert.Equal(2, results.Count);
 
@@ -134,8 +137,18 @@ namespace GSSystemAnalyzer.Tests.Services
 
             using var cts = new CancellationTokenSource(0);
             
+            var mockSettings = new Mock<ISettingService>();
+            mockSettings.Setup(s => s.Current)
+                .Returns(AppSettingDto.GetFactoryDefaults());
+
+            var mockScanner = new Mock<IDiskScannerEngine>();
+            var scanId = Guid.NewGuid();
+            mockScanner.Setup(s => s.GetScanToken(scanId)).Returns(cts.Token);
+
+            var detector = new DuplicateFileDetector(mockSettings.Object, mockScanner.Object);
+
             await Assert.ThrowsAsync<OperationCanceledException>(
-                async () => await _detector.FindDuplicatesAsync(_testBaseDir, cts.Token)
+                async () => await detector.FindDuplicatesAsync(_testBaseDir, scanId)
             );
         }
     }

--- a/backend/Interfaces/IDiskOperationService.cs
+++ b/backend/Interfaces/IDiskOperationService.cs
@@ -5,13 +5,13 @@ namespace GSSystemAnalyzer.Interfaces;
 public interface IDiskOperationService
 {
     DriveTelemetryDto GetDriveTelemetry(string driveLetter);
-    IEnumerable<StorageNode> ScanDirectory(string path);
+    IEnumerable<StorageNode> ScanDirectory(string path, Guid scanId);
 
     /// <summary>
     /// Begins a new scan session: cancels any in-flight scan and returns the
     /// cancellation token that ScanDirectory / duplicate detection will observe.
     /// </summary>
-    CancellationToken BeginScan();
+    Guid BeginScan(Guid? scanId = null);
 
-    void TriggerScanAbort();
+    void TriggerScanAbort(Guid? scanId = null);
 }

--- a/backend/Interfaces/IDiskScannerEngine.cs
+++ b/backend/Interfaces/IDiskScannerEngine.cs
@@ -9,5 +9,9 @@ namespace GSSystemAnalyzer.Interfaces
         CancellationToken NukeToken();
         void TriggerNukeAbort();
         void InvalidatePaths(IEnumerable<string> paths);
+        Guid BeginScanSession(Guid? scanId = null);
+        CancellationToken GetScanToken(Guid scanId);
+        void EndScanSession(Guid scanId);
+        void TriggerScanAbort(Guid? scanId = null);
     }
 }

--- a/backend/Interfaces/IDuplicateFileDetector.cs
+++ b/backend/Interfaces/IDuplicateFileDetector.cs
@@ -4,6 +4,6 @@ namespace GSSystemAnalyzer.Interfaces
 {
     public interface IDuplicateFileDetector
     {
-        Task<List<DuplicateGroup>> FindDuplicatesAsync(string rootPath, CancellationToken cancellationToken = default);
+        Task<List<DuplicateGroup>> FindDuplicatesAsync(string rootPath, Guid scanId);
     }
 }

--- a/backend/Models/ScanRequestDto.cs
+++ b/backend/Models/ScanRequestDto.cs
@@ -1,7 +1,10 @@
+using System;
+
 namespace GSSystemAnalyzer.Models
 {
     public class ScanRequest
     {
         public string Root { get; set; } = string.Empty;
+        public Guid? ScanId { get; set; }
     }
 }

--- a/backend/Models/ScanSession.cs
+++ b/backend/Models/ScanSession.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Threading;
+
+namespace GSSystemAnalyzer.Models
+{
+    public class ScanSession : IDisposable
+    {
+        public Guid ScanId { get; }
+        public CancellationTokenSource Cts { get; }
+
+        public ScanSession(Guid scanId)
+        {
+            ScanId = scanId;
+            Cts = new CancellationTokenSource();
+        }
+
+        public void Dispose()
+        {
+            Cts?.Dispose();
+        }
+    }
+}

--- a/backend/Services/DiskOperationsService.cs
+++ b/backend/Services/DiskOperationsService.cs
@@ -38,11 +38,13 @@ namespace GSSystemAnalyzer.Services
             };
         }
 
-        public IEnumerable<StorageNode> ScanDirectory(string path)
+        public IEnumerable<StorageNode> ScanDirectory(string path, Guid scanId)
         {
-            var items = _scanner.LoadDirectoryItems(path);
-            PurgeDeadMemory(path, items);
-            _scanner.CalculateMissingSizesAsync(items).GetAwaiter().GetResult();
+            try
+            {
+                var items = _scanner.LoadDirectoryItems(path);
+                PurgeDeadMemory(path, items);
+                _scanner.CalculateMissingSizesAsync(items, scanId).GetAwaiter().GetResult();
 
             var nodes = items.Select(item =>
             {
@@ -89,6 +91,11 @@ namespace GSSystemAnalyzer.Services
             Task.Run(() => _scanner.SaveMemoryToDisk());
 
             return nodes;
+            }
+            finally
+            {
+                _scanner.EndScanSession(scanId);
+            }
         }
 
         private void PurgeDeadMemory(string currentPath, List<FileSystemInfo> actualItems)
@@ -123,11 +130,11 @@ namespace GSSystemAnalyzer.Services
             }
         }
 
-        public CancellationToken BeginScan() => _scanner.ScanToken();
+        public Guid BeginScan(Guid? scanId = null) => _scanner.BeginScanSession(scanId);
 
-        public void TriggerScanAbort()
+        public void TriggerScanAbort(Guid? scanId = null)
         {
-            _scanner.TriggerScanAbort();
+            _scanner.TriggerScanAbort(scanId);
         }
     }
 }

--- a/backend/Services/DuplicateFileDetector.cs
+++ b/backend/Services/DuplicateFileDetector.cs
@@ -13,19 +13,22 @@ namespace GSSystemAnalyzer.Services
     public class DuplicateFileDetector : IDuplicateFileDetector
     {
         private readonly ISettingService _settings;
+        private readonly IDiskScannerEngine _scanner;
 
-        public DuplicateFileDetector(ISettingService settings)
+        public DuplicateFileDetector(ISettingService settings, IDiskScannerEngine scanner)
         {
             _settings = settings;
+            _scanner = scanner;
         }
         /// Scans a root directory and returns a dictionary of duplicate files grouped by their SHA256 hash.
-        public async Task<List<DuplicateGroup>> FindDuplicatesAsync(string rootPath, CancellationToken cancellationToken = default)
+        public async Task<List<DuplicateGroup>> FindDuplicatesAsync(string rootPath, Guid scanId)
         {
-            // 1. Safely gather all files, ignoring protected system folders (This fixes the "Ghost Reading" crash)
-            var allFiles = SafeEnumerateFiles(rootPath, cancellationToken);
+            try
+            {
+                var cancellationToken = _scanner.GetScanToken(scanId);
 
-            // --- PASS 1: The O(n) Size Filter ---
-            // Group files by size. If a size group only has 1 file, throw it away.
+                // 1. Safely gather all files, ignoring protected system folders (This fixes the "Ghost Reading" crash)
+                var allFiles = SafeEnumerateFiles(rootPath, cancellationToken);
             var filesToHash = allFiles
                 .Where(f => f.Length > 0)
                 .GroupBy(f => f.Length)
@@ -91,6 +94,11 @@ namespace GSSystemAnalyzer.Services
                 })
                 .OrderByDescending(d => d.WastedBytes)
                 .ToList();
+            }
+            finally
+            {
+                _scanner.EndScanSession(scanId);
+            }
         }
 
         /// Helper method to traverse directories without crashing on UnauthorizedAccessException.

--- a/frontend/gs_analyzer_ui/lib/providers/directory_provider.dart
+++ b/frontend/gs_analyzer_ui/lib/providers/directory_provider.dart
@@ -208,7 +208,9 @@ class DirectoryNotifier extends StateNotifier<DirectoryState> {
     }
   }
 
-  void receiveStreamChunk(String path, List<dynamic> chunkData) {
+  void receiveStreamChunk(String? scanId, String path, List<dynamic> chunkData) {
+    if (scanId != null && scanId != _currentScanId) return;
+
     String incomingPath = path.replaceAll('\\', '/').toLowerCase();
     String currentPath = state.currentPath.replaceAll('\\', '/').toLowerCase();
     if (incomingPath.endsWith('/')) incomingPath = incomingPath.substring(0, incomingPath.length - 1);
@@ -228,7 +230,9 @@ class DirectoryNotifier extends StateNotifier<DirectoryState> {
     state = state.copyWith(allNodes: updatedList, displayNodes: updatedList);
   }
 
-  void finalizeStream(String path) async {
+  void finalizeStream(String? scanId, String path) async {
+    if (scanId != null && scanId != _currentScanId) return;
+
     String incomingPath = path.replaceAll('\\', '/').toLowerCase();
     String currentPath = state.currentPath.replaceAll('\\', '/').toLowerCase();
 

--- a/frontend/gs_analyzer_ui/lib/providers/directory_provider.dart
+++ b/frontend/gs_analyzer_ui/lib/providers/directory_provider.dart
@@ -3,6 +3,15 @@ import 'package:flutter_riverpod/legacy.dart';
 import 'package:gs_analyzer_ui/models/storage_node.dart';
 import 'package:gs_analyzer_ui/providers/settings_provider.dart';
 import 'package:gs_analyzer_ui/services/api_service.dart';
+import 'dart:math';
+
+String generateUuid() {
+  final random = Random();
+  final chars = '0123456789abcdef';
+  String randomString(int length) => String.fromCharCodes(Iterable.generate(
+      length, (_) => chars.codeUnitAt(random.nextInt(16))));
+  return '${randomString(8)}-${randomString(4)}-4${randomString(3)}-a${randomString(3)}-${randomString(12)}';
+}
 
 enum SortMethod {
   name,
@@ -155,9 +164,13 @@ class DirectoryNotifier extends StateNotifier<DirectoryState> {
 
   DateTime? _scanStartTime;
   bool _wasForceRefresh = false;
+  String? _currentScanId;
+  String? get currentScanId => _currentScanId;
 
   Future<void> scanDirectory(String targetPath, {bool forceRefresh = false}) async {
     String safePath = targetPath.replaceAll('\\', '/');
+    final scanId = generateUuid();
+    _currentScanId = scanId;
 
     if (!forceRefresh && _sectorCache.containsKey(safePath)) {
       _applyFiltersAndSort(nodes: _sectorCache[safePath]);
@@ -167,7 +180,7 @@ class DirectoryNotifier extends StateNotifier<DirectoryState> {
         errorMessage: null,
       );
 
-      _apiService.scanDirectory(safePath).then((freshNodes) {
+      _apiService.scanDirectory(safePath, scanId).then((freshNodes) {
         _sectorCache[safePath] = freshNodes;
         if (state.currentPath == safePath) _applyFiltersAndSort(nodes: freshNodes);
       }).catchError((_) {});
@@ -189,7 +202,7 @@ class DirectoryNotifier extends StateNotifier<DirectoryState> {
     state = state.copyWith(currentPath: safePath, isLoading: true, searchQuery: '', errorMessage: null, allNodes: [], displayNodes: []);
 
     try {
-      await _apiService.requestDirectoryStream(safePath);
+      await _apiService.requestDirectoryStream(safePath, scanId);
     } catch (e) {
       state = state.copyWith(isLoading: false, errorMessage: e.toString());
     }
@@ -243,7 +256,7 @@ class DirectoryNotifier extends StateNotifier<DirectoryState> {
     if (_sectorCache.containsKey(safePath)) {
       return _sectorCache[safePath]!;
     }
-    final nodes = await _apiService.scanDirectory(safePath);
+    final nodes = await _apiService.scanDirectory(safePath, generateUuid());
     _sectorCache[safePath] = nodes;
     return nodes;
   }

--- a/frontend/gs_analyzer_ui/lib/providers/duplicate_provider.dart
+++ b/frontend/gs_analyzer_ui/lib/providers/duplicate_provider.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/legacy.dart';
 import 'package:gs_analyzer_ui/models/duplicate_model.dart';
 import 'package:gs_analyzer_ui/providers/settings_provider.dart';
 import 'package:gs_analyzer_ui/services/api_service.dart';
+import 'package:gs_analyzer_ui/providers/directory_provider.dart';
 
 class DuplicateState {
   final bool isLoading;
@@ -73,7 +74,7 @@ class DuplicateNotifier extends StateNotifier<DuplicateState> {
 
     try {
       final apiService = ApiService();
-      final rawData = await apiService.scanForDuplicates(rootPath);
+      final rawData = await apiService.scanForDuplicates(rootPath, generateUuid());
 
       loadFromBackend(rawData);
     } catch (e) {

--- a/frontend/gs_analyzer_ui/lib/providers/root_tree_provider.dart
+++ b/frontend/gs_analyzer_ui/lib/providers/root_tree_provider.dart
@@ -1,7 +1,16 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gs_analyzer_ui/models/storage_node.dart';
 import 'package:gs_analyzer_ui/services/api_service.dart';
+import 'dart:math';
+
+String generateUuid() {
+  final random = Random();
+  final chars = '0123456789abcdef';
+  String randomString(int length) => String.fromCharCodes(Iterable.generate(
+      length, (_) => chars.codeUnitAt(random.nextInt(16))));
+  return '${randomString(8)}-${randomString(4)}-4${randomString(3)}-a${randomString(3)}-${randomString(12)}';
+}
 
 final rootTreeProvider = FutureProvider<List<StorageNode>>((ref) async {
-  return ApiService().scanDirectory('C:/');
+  return ApiService().scanDirectory('C:/', generateUuid());
 });

--- a/frontend/gs_analyzer_ui/lib/providers/telemetry_provider.dart
+++ b/frontend/gs_analyzer_ui/lib/providers/telemetry_provider.dart
@@ -16,6 +16,7 @@ class TelemetryState {
   final int total;
   final double percentComplete;
   final String target;
+  final String? currentScanId;
 
   const TelemetryState({
     this.status = 'IDLE',
@@ -23,6 +24,7 @@ class TelemetryState {
     this.total = 0,
     this.percentComplete = 0.0,
     this.target = '',
+    this.currentScanId,
   });
 
   TelemetryState copyWith({
@@ -31,6 +33,7 @@ class TelemetryState {
     int? total,
     double? percentComplete,
     String? target,
+    String? currentScanId,
   }) {
     return TelemetryState(
       status: status ?? this.status,
@@ -38,6 +41,7 @@ class TelemetryState {
       total: total ?? this.total,
       percentComplete: percentComplete ?? this.percentComplete,
       target: target ?? this.target,
+      currentScanId: currentScanId ?? this.currentScanId,
     );
   }
 }
@@ -64,14 +68,18 @@ class TelemetryNotifier extends StateNotifier<TelemetryState> {
       backendPort: backendPort,
       reconnectDelayMs: reconnectDelayMs,
       maxRetries: maxRetries,
-      onProgressUpdate: (status, completed, total, percentComplete, target) {
-        state = state.copyWith(
-          status: status,
-          completed: completed,
-          total: total,
-          percentComplete: percentComplete,
-          target: target,
-        );
+      onProgressUpdate: (scanId, status, completed, total, percentComplete, target) {
+        if (status == 'INITIALIZING' || state.currentScanId == null || state.currentScanId == scanId) {
+          final isDone = status == 'COMPLETED' || status == 'ABORTED' || status == 'FAILED';
+          state = state.copyWith(
+            status: status,
+            completed: completed,
+            total: total,
+            percentComplete: percentComplete,
+            target: target,
+            currentScanId: isDone ? null : scanId,
+          );
+        }
       },
     );
 

--- a/frontend/gs_analyzer_ui/lib/providers/telemetry_provider.dart
+++ b/frontend/gs_analyzer_ui/lib/providers/telemetry_provider.dart
@@ -91,12 +91,12 @@ class TelemetryNotifier extends StateNotifier<TelemetryState> {
       ref.read(cpuProvider.notifier).updateCpu(data);
     };
 
-    _telemetryService?.onDirectoryChunk = (path, chunk) {
-      ref.read(directoryProvider.notifier).receiveStreamChunk(path, chunk);
+    _telemetryService?.onDirectoryChunk = (scanId, path, chunk) {
+      ref.read(directoryProvider.notifier).receiveStreamChunk(scanId, path, chunk);
     };
 
-    _telemetryService?.onDirectoryStreamComplete = (path) {
-      ref.read(directoryProvider.notifier).finalizeStream(path);
+    _telemetryService?.onDirectoryStreamComplete = (scanId, path) {
+      ref.read(directoryProvider.notifier).finalizeStream(scanId, path);
     };
 
     _telemetryService?.onNukeProgress = (percentage, target, completed) {

--- a/frontend/gs_analyzer_ui/lib/screen/test_screen.dart
+++ b/frontend/gs_analyzer_ui/lib/screen/test_screen.dart
@@ -20,7 +20,7 @@ class TestScreen extends StatelessWidget {
             appLogger.i('INITIATING ANALYZER BRIDGE...');
             try {
               final service = ApiService();
-              final nodes = await service.scanDirectory('C:/');
+              final nodes = await service.scanDirectory('C:/', '00000000-0000-0000-0000-000000000000');
               
               appLogger.i('BRIDGE SUCCESS! found ${nodes.length} items in root.');
               appLogger.i("--------------------------------------------");

--- a/frontend/gs_analyzer_ui/lib/services/api_service.dart
+++ b/frontend/gs_analyzer_ui/lib/services/api_service.dart
@@ -46,14 +46,14 @@ class ApiService {
   }
 
 
-  Future<List<StorageNode>> scanDirectory(String path) async {
+  Future<List<StorageNode>> scanDirectory(String path, String scanId) async {
     final uri = Uri.parse('$storageUrl/scan');
-    appLogger.i('MATRIX BRIDGE FIRING TO: $uri (root: $path)');
+    appLogger.i('MATRIX BRIDGE FIRING TO: $uri (root: $path, scanId: $scanId)');
 
     final response = await _client.post(
       uri,
       headers: {'Content-Type': 'application/json'},
-      body: jsonEncode({'Root': path}),
+      body: jsonEncode({'Root': path, 'ScanId': scanId}),
     );
 
     if (response.statusCode == 200) {
@@ -198,10 +198,14 @@ class ApiService {
     }
   }
 
-  Future<void> abortScan() async {
+  Future<void> abortScan({String? scanId}) async {
     try {
-      appLogger.i('SENDING SCAN ABORT SIGNAL...');
-      await _client.post(Uri.parse('$storageUrl/abort-scan'));
+      appLogger.i('SENDING SCAN ABORT SIGNAL... (scanId: $scanId)');
+      var uri = Uri.parse('$storageUrl/abort-scan');
+      if (scanId != null) {
+        uri = uri.replace(queryParameters: {'scanId': scanId});
+      }
+      await _client.post(uri);
     } catch (e) {
       appLogger.i('Failed to send abort signal: $e');
     }
@@ -246,21 +250,22 @@ class ApiService {
     }
   }
 
-  Future<void> requestDirectoryStream(String path) async {
+  Future<void> requestDirectoryStream(String path, String scanId) async {
     final uri = Uri.parse('$storageUrl/stream-sector').replace(queryParameters: {
-      'path': path
+      'path': path,
+      'scanId': scanId
     });
     await _client.post(uri);
   }
 
-  Future<List<dynamic>> scanForDuplicates(String path) async {
+  Future<List<dynamic>> scanForDuplicates(String path, String scanId) async {
     final uri = Uri.parse('$storageUrl/duplicates');
-    appLogger.i('INITIATING DUPLICATE HUNTER ON: $uri (root: $path)');
+    appLogger.i('INITIATING DUPLICATE HUNTER ON: $uri (root: $path, scanId: $scanId)');
 
     final response = await _client.post(
       uri,
       headers: {'Content-Type': 'application/json'},
-      body: jsonEncode({'Root': path}),
+      body: jsonEncode({'Root': path, 'ScanId': scanId}),
     );
 
     if (response.statusCode == 200) {

--- a/frontend/gs_analyzer_ui/lib/services/telemetry_service.dart
+++ b/frontend/gs_analyzer_ui/lib/services/telemetry_service.dart
@@ -10,8 +10,8 @@ class TelemetryService {
   Function(double percentage, String target, int completed)? onNukeProgress;
   Function()? onNukeAborted;
   Function(Map<String, dynamic>)? onRamUpdate;
-  Function(String path, List<dynamic> chunk)? onDirectoryChunk;
-  Function(String path)? onDirectoryStreamComplete;
+  Function(String? scanId, String path, List<dynamic> chunk)? onDirectoryChunk;
+  Function(String? scanId, String path)? onDirectoryStreamComplete;
   Function(Map<String, dynamic>)? onCpuUpdate;
   Function(List<dynamic>)? onDriveUpdate;
   Function(Map<String, dynamic>)? onAuditProgress;
@@ -148,17 +148,14 @@ class TelemetryService {
     void _handleDirectoryChunk(List<Object?>? arguments) {
       if (arguments != null && arguments.isNotEmpty) {
         final data = arguments[0] as Map<String, dynamic>;
-        if (onDirectoryChunk != null) {
-          onDirectoryChunk!(data['path'], data['chunk']);
-        }
+        onDirectoryChunk?.call(data['scanId'] as String?, data['path'], data['chunk']);
       }
     }
 
     void _handleDirectoryStreamComplete(List<Object?>? arguments) {
       if (arguments != null && arguments.isNotEmpty) {
-        if (onDirectoryStreamComplete != null) {
-          onDirectoryStreamComplete!(arguments[0].toString());
-        }
+        final data = arguments[0] as Map<String, dynamic>;
+        onDirectoryStreamComplete?.call(data['scanId'] as String?, data['path'].toString());
       }
     }
 

--- a/frontend/gs_analyzer_ui/lib/services/telemetry_service.dart
+++ b/frontend/gs_analyzer_ui/lib/services/telemetry_service.dart
@@ -6,7 +6,7 @@ class TelemetryService {
   late HubConnection _hubConnection;
 
   Function(String)? onSectorChanged;
-  final Function(String? status, int? completed, int? total, double? percentComplete, String? target) onProgressUpdate;
+  final Function(String? scanId, String? status, int? completed, int? total, double? percentComplete, String? target) onProgressUpdate;
   Function(double percentage, String target, int completed)? onNukeProgress;
   Function()? onNukeAborted;
   Function(Map<String, dynamic>)? onRamUpdate;
@@ -77,6 +77,7 @@ class TelemetryService {
       if (arguments != null && arguments.isNotEmpty) {
         final data = arguments[0] as Map<String, dynamic>;
 
+        final scanId = data['scanId'] as String?;
         final status = data['status'] as String?;
         final completed = (data['completed'] as num?)?.toInt();
         final total = (data['total'] as num?)?.toInt();
@@ -84,7 +85,7 @@ class TelemetryService {
             ?.toDouble();
         final target = data['currentTarget'] as String?;
 
-        onProgressUpdate(status, completed, total, percentageComplete, target);
+        onProgressUpdate(scanId, status, completed, total, percentageComplete, target);
       }
     }
 

--- a/frontend/gs_analyzer_ui/test/directory_provider_test.dart
+++ b/frontend/gs_analyzer_ui/test/directory_provider_test.dart
@@ -21,9 +21,9 @@ void main() {
       fakeChunk[2] = MockFactory.createFakeNodeMap(name: 'medium_image.png', path: 'C:/medium_image.png', size: 250000);
       fakeChunk[3] = MockFactory.createFakeNodeMap(name: 'icon.png', path: 'C:/icon.png', size: 1050);
 
-      notifier.receiveStreamChunk('C:/', fakeChunk);
+      notifier.receiveStreamChunk(null, 'C:/', fakeChunk);
 
-      notifier.finalizeStream('C:/');
+      notifier.finalizeStream(null, 'C:/');
 
       notifier.setSortMethod(SortMethod.size);
 
@@ -45,7 +45,7 @@ void main() {
       final notifier = container.read(directoryProvider.notifier);
 
       await notifier.scanDirectory('C:/TestSector');
-      notifier.finalizeStream('C:/TestSector');
+      notifier.finalizeStream(null, 'C:/TestSector');
 
       expect(
           notifier.state.isLoading,
@@ -67,8 +67,8 @@ void main() {
       firstLoadChunk[1] = MockFactory.createFakeNodeMap(name: 'Siren-S1E3-1080.mp4', path: 'C:/Downloads/S3', size: 20000000);
       firstLoadChunk[2] = MockFactory.createFakeNodeMap(name: 'Siren-S1E4-1080.mp4', path: 'C:/Downloads/S4', size: 200000000);
 
-      notifier.receiveStreamChunk('c:/downloads', firstLoadChunk);
-      notifier.finalizeStream('c:/downloads');
+      notifier.receiveStreamChunk(null, 'c:/downloads', firstLoadChunk);
+      notifier.finalizeStream(null, 'c:/downloads');
 
       final loadedFile = notifier.state.displayNodes;
 
@@ -103,8 +103,8 @@ void main() {
       firstLoadChunk[0] = MockFactory.createFakeNodeMap(name: 'PCD_Report.pdf', path: 'C:/Documents/PCD_Report.pdf', size: 15000);
       firstLoadChunk[1] = MockFactory.createFakeNodeMap(name: 'small_file.txt', path: 'C:/Documents/small_file.txt', size: 150);
 
-      notifier.receiveStreamChunk('c:/documents', firstLoadChunk);
-      notifier.finalizeStream('c:/documents');
+      notifier.receiveStreamChunk(null, 'c:/documents', firstLoadChunk);
+      notifier.finalizeStream(null, 'c:/documents');
 
       expect(
           notifier.state.displayNodes.isNotEmpty,

--- a/frontend/gs_analyzer_ui/test/nuke_protocol_test.dart
+++ b/frontend/gs_analyzer_ui/test/nuke_protocol_test.dart
@@ -18,7 +18,7 @@ void main() {
 
      final nukeList = MockFactory.generateNukeTarget(10, 'C:/Downloads');
 
-     notifier.receiveStreamChunk('c:/Downloads', nukeList);
+     notifier.receiveStreamChunk(null, 'c:/Downloads', nukeList);
 
      final targetCount = notifier.state.displayNodes.where((node) => node.name.contains('target_item')).length;
 
@@ -36,7 +36,7 @@ void main() {
       final folderPath = 'C:/Downloads/OldProject';
       final rootFolder = MockFactory.createFakeNodeMap(name: 'OldProject', path: folderPath, isDirectory: true);
 
-      notifier.receiveStreamChunk('c:/Downloads', [rootFolder]);
+      notifier.receiveStreamChunk(null, 'c:/Downloads', [rootFolder]);
 
       final target = notifier.state.displayNodes.firstWhere((node) => node.name == 'OldProject');
 
@@ -60,7 +60,7 @@ void main() {
       MockFactory.createFakeNodeMap(name: 'Old_Cache_Folder', path: 'C:/Downloads/Old_Cache_Folder', isDirectory: true)
       ];
 
-      notifier.receiveStreamChunk('c:/downloads', mixedChunk);
+      notifier.receiveStreamChunk(null, 'c:/downloads', mixedChunk);
 
       notifier.toggleSelectionMode();
 


### PR DESCRIPTION
## Summary

Replaces the single shared `_scanCts` cancellation token with a proper per-scan
`ScanSession` abstraction, and threads a `scanId` end-to-end (backend → SignalR →
Flutter). This fixes three related bugs caused by overlapping background scans on
startup:

1. Concurrent scans cancelling each other's tokens (partial results / 499s).
2. The progress bar disappearing prematurely (~5s) on the first scan after a
   backend rebuild, because a fast cache-hit scan broadcast a global `COMPLETED`
   that hid a still-running scan's bar.
3. Directory rows rendered 2–3× on the first scan / after a refresh, because
   `DirectoryChunk` events were never scoped to the scan that produced them.

Root cause for all three: scans had no identity, and the old shared `_scanCts`
was accidentally masking (3) by cancelling overlapping scans. Isolating tokens
(the correct fix) exposed the unscoped directory stream, so this PR scopes it too.

## Changes

### Backend — scan sessions
- **[NEW] `Models/ScanSession.cs`** — bundles a `Guid ScanId` + its own
  `CancellationTokenSource`; `IDisposable`.
- **`Engine/DiskScannerEngine.cs`** — removed global `_scanCts`; added a
  `ConcurrentDictionary<Guid, ScanSession> _activeSessions`. New
  `BeginScanSession`, `GetScanToken`, `EndScanSession`, and
  `TriggerScanAbort(Guid?)` (specific id cancels one session; `null` cancels all).
  Every `ScanProgress` payload now carries `scanId`.
- **`Services/DiskOperationsService.cs`** — `BeginScan(Guid?)` returns the
  resolved id; `ScanDirectory(path, scanId)` threads it into
  `CalculateMissingSizesAsync`; session is disposed in a `finally`.
- **`Services/DuplicateFileDetector.cs`** — resolves its token via
  `GetScanToken(scanId)`; disposes the session in a `finally`.

### Backend — directory stream scoping
- **`Controllers/StorageController.cs`** — `stream-sector`, `scan`, `duplicates`,
  and `abort-scan` accept/forward a `scanId`. `DirectoryChunk` and
  `DirectoryStreamComplete` payloads now include `scanId`.
- **`Models/ScanRequestDto.cs`** — added `Guid? ScanId`.
- **Interfaces** updated (`IDiskOperationService`, `IDiskScannerEngine`,
  `IDuplicateFileDetector`).

### Frontend (Flutter)
- **`services/api_service.dart`** — `scanDirectory`, `requestDirectoryStream`,
  `scanForDuplicates`, and `abortScan` send a `scanId`.
- **`services/telemetry_service.dart`** — `onDirectoryChunk` /
  `onDirectoryStreamComplete` now surface `scanId`.
- **`providers/telemetry_provider.dart`** — tracks `currentScanId`; ignores
  `ScanProgress` events whose `scanId` doesn't match the active scan.
- **`providers/directory_provider.dart`** — generates a `scanId` per scan;
  `receiveStreamChunk` / `finalizeStream` drop chunks/completions from any
  scan other than the current one.
- **`providers/root_tree_provider.dart`**, **`duplicate_provider.dart`** —
  generate and pass a `scanId`.

## Cancellation semantics
- `POST /abort-scan?scanId=<guid>` cancels a specific scan.
- `POST /abort-scan` (no id) cancels **all** active scans (global stop).
- `TriggerScanAbort` is a no-op for unknown/completed ids.

## Tests
- `DiskScannerEngineTokenTests` rewritten to assert **isolation** — cancelling
  one session leaves others alive; `null` cancels all.
- `StorageControllerCancellationTests` updated to the `Guid`-based signatures.
- `DuplicateFileDetectorTests` updated to inject a mocked engine and pass a
  `scanId`.

## Verification
- `dotnet test backend/GSSystemAnalyzer.Tests` — green.
- Manual: rebuild backend → load app → root-tree + directory scans run without
  hiding each other's progress bar, and directory rows render exactly once.
- Clear cache → deep scan → trigger a second scan → confirm token/UI isolation.

## Follow-ups (out of scope)
- C:/ is still scanned redundantly on launch (constructor + root tree +
  settings-listener force-refresh). The `scanId` gate makes this correct, but a
  later PR should coordinate providers so startup scans C:/ once.