### PR TITLE
Enhance .editorconfig with file type-specific settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,26 @@ root = true
 [*]
 end_of_line = lf
 insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
 
+# Windows batch scripts keep CRLF
 [*.{bat,cmd}]
 end_of_line = crlf
+
+# C# — 4 spaces (.NET convention)
+[*.cs]
+indent_size = 4
+
+# Dart — 2 spaces (official Dart style)
+[*.dart]
+indent_size = 2
+
+# Config / markup — 2 spaces
+[*.{json,jsonc,yml,yaml,xml,csproj,props,targets}]
+indent_size = 2
+
+# Markdown — don't trim trailing spaces (they're meaningful for line breaks)
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
This pull request updates the repository's line ending and formatting configuration by replacing the `.gitattributes` file with a more comprehensive `.editorconfig`-style configuration. The new configuration standardizes code style across different file types and platforms, ensuring consistency and preventing common formatting issues.

Formatting and line ending standardization:

* Replaces the previous `.gitattributes` settings with a new configuration that enforces LF line endings, UTF-8 encoding, final newlines, and trimming of trailing whitespace for most files.
* Specifies CRLF line endings for Windows batch scripts (`*.bat`, `*.cmd`) to maintain compatibility.

Language-specific formatting rules:

* Sets indentation to 4 spaces for C# files (`*.cs`) and 2 spaces for Dart files (`*.dart`), following language conventions.
* Applies 2-space indentation to common config and markup files (e.g., JSON, YAML, XML).
* Disables trimming of trailing whitespace in Markdown files to preserve intentional line breaks.