### PR TITLE
Fix Scan Cache Wipe on Restart & Implement Max Cached Scans

### DIFF
--- a/backend/Engine/DiskScannerEngine.cs
+++ b/backend/Engine/DiskScannerEngine.cs
@@ -11,7 +11,19 @@ namespace GSSystemAnalyzer.Engine;
 public class CacheEntry
 {
 	public long Size { get; set; }
+
+	// When the FOLDER's contents last changed on disk (dir.LastWriteTimeUtc).
+	// Used ONLY for content-staleness detection, never for TTL expiry.
 	public DateTime LastUpdated { get; set; }
+
+	// When WE last scanned/cached this folder. Used for TTL expiry and for
+	// grouping entries into scans. Distinct from LastUpdated.
+	public DateTime CachedAtUtc { get; set; }
+
+	// The top-level scan root (drive / browsed folder) this entry belongs to.
+	// Lets MaxCacheScans evict whole scans instead of individual folders.
+	public string? ScanRoot { get; set; }
+
 	public Dictionary<string, FileTypeEntry>? Extensions { get; set; }
 }
 
@@ -55,6 +67,7 @@ public class DiskScannerEngine : IDiskScannerEngine
 					_logger.LogInformation("Cache restored: {Count} folders loaded from disk", DirectorySizeCache.Count);
 
 					PruneStaleCacheEntries();
+					EnforceMaxCacheScans();
 				}
 			}
 			catch (Exception ex)
@@ -102,6 +115,14 @@ public class DiskScannerEngine : IDiskScannerEngine
 				_deepScanThrottle = 0;
 				_scannedFilesCount = 0;
 
+				// The top-level path being scanned (parent of the scanned items). Every
+				// folder cached during this scan is tagged with this root so MaxCacheScans
+				// can evict whole scans, not individual folders.
+				var scanRoot = directoriesToScan
+					.Select(d => d.Parent?.FullName)
+					.FirstOrDefault(p => !string.IsNullOrEmpty(p))
+					?? directoriesToScan[0].FullName;
+
 				// Retrieve the specific session's token
 				var scanToken = _activeSessions.TryGetValue(scanId, out var session) ? session.Cts.Token : CancellationToken.None;
 
@@ -117,13 +138,15 @@ public class DiskScannerEngine : IDiskScannerEngine
 				{
 					try
 					{
-						var size = await Task.Run(() => GetDirectorySize(dir, ct), ct);
+						var size = await Task.Run(() => GetDirectorySize(dir, ct, scanRoot), ct);
 
 						DirectorySizeCache.TryGetValue(dir.FullName, out var existingEntry);
 						DirectorySizeCache[dir.FullName] = new CacheEntry
 						{
 							Size = size,
 							LastUpdated = dir.LastWriteTimeUtc,
+							CachedAtUtc = DateTime.UtcNow,
+							ScanRoot = scanRoot,
 							Extensions = existingEntry?.Extensions
 						};
 					}
@@ -145,6 +168,10 @@ public class DiskScannerEngine : IDiskScannerEngine
 					});
 				});
 
+				// TTL expiry (now based on real scan time) + cap to N most-recent scans.
+				PruneStaleCacheEntries();
+				EnforceMaxCacheScans();
+
 				SaveMemoryToDisk();
 			}
 
@@ -157,7 +184,7 @@ public class DiskScannerEngine : IDiskScannerEngine
 
 	}
 
-	private long GetDirectorySize(DirectoryInfo dir, CancellationToken token, int currentDepth = 1)
+	private long GetDirectorySize(DirectoryInfo dir, CancellationToken token, string scanRoot, int currentDepth = 1)
 	{
 		if (token.IsCancellationRequested)
 			throw new OperationCanceledException("Scan aborted by user");
@@ -238,7 +265,7 @@ public class DiskScannerEngine : IDiskScannerEngine
 			foreach (var subDir in dir.GetDirectories("*", option))
 			{
 				// Pass depth + 1 so each recursive level is tracked
-				size += GetDirectorySize(subDir, token, currentDepth + 1);
+				size += GetDirectorySize(subDir, token, scanRoot, currentDepth + 1);
 			}
 		}
 		catch (OperationCanceledException) { throw; }
@@ -248,6 +275,8 @@ public class DiskScannerEngine : IDiskScannerEngine
 		{
 			Size = size,
 			LastUpdated = dir.LastWriteTimeUtc,
+			CachedAtUtc = DateTime.UtcNow,
+			ScanRoot = scanRoot,
 			Extensions = extMap
 		};
 
@@ -453,9 +482,11 @@ public class DiskScannerEngine : IDiskScannerEngine
 		var config = _settings.Current.Cache;
 		var cutoff = DateTime.UtcNow.AddMinutes(-config.ScanCacheTtlMinutes);
 
-		// Remove entries that are past their TTL
+		// Expire by WHEN WE SCANNED the folder (CachedAtUtc), not by the folder's own
+		// last-write time. Using LastUpdated here was the bug that wiped the whole
+		// cache on every restart, because folders are rarely modified within the TTL.
 		var stale = DirectorySizeCache
-			.Where(kvp => kvp.Value.LastUpdated < cutoff)
+			.Where(kvp => kvp.Value.CachedAtUtc < cutoff)
 			.Select(kvp => kvp.Key)
 			.ToList();
 
@@ -463,6 +494,43 @@ public class DiskScannerEngine : IDiskScannerEngine
 			DirectorySizeCache.TryRemove(key, out _);
 
 		_logger.LogDebug("Cache pruned: {Count} stale entries removed (TTL = {TtlMinutes} min)", stale.Count, config.ScanCacheTtlMinutes);
+	}
+
+	// Enforces CacheSettingDto.MaxCacheScans by keeping only the N most-recently
+	// scanned top-level roots (drive / browsed folder), evicting ALL folder entries
+	// that belong to older scans. This is "5 most-recent scans", not "5 folders".
+	// Previously MaxCacheScans was declared in settings but never read, so it did
+	// nothing.
+	public void EnforceMaxCacheScans()
+	{
+		var maxScans = _settings.Current.Cache.MaxCacheScans;
+		if (maxScans <= 0) return;
+
+		var rootsByRecency = DirectorySizeCache
+			.Where(kvp => !string.IsNullOrEmpty(kvp.Value.ScanRoot))
+			.GroupBy(kvp => kvp.Value.ScanRoot!, StringComparer.OrdinalIgnoreCase)
+			.Select(g => new { Root = g.Key, LastScan = g.Max(kvp => kvp.Value.CachedAtUtc) })
+			.OrderByDescending(x => x.LastScan)
+			.ToList();
+
+		if (rootsByRecency.Count <= maxScans) return;
+
+		var rootsToEvict = rootsByRecency
+			.Skip(maxScans)
+			.Select(x => x.Root)
+			.ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+		var keysToRemove = DirectorySizeCache
+			.Where(kvp => kvp.Value.ScanRoot != null && rootsToEvict.Contains(kvp.Value.ScanRoot))
+			.Select(kvp => kvp.Key)
+			.ToList();
+
+		foreach (var key in keysToRemove)
+			DirectorySizeCache.TryRemove(key, out _);
+
+		_logger.LogInformation(
+			"Cache trimmed to {MaxScans} most-recent scan roots: evicted {RootCount} older root(s), {EntryCount} folder entries",
+			maxScans, rootsToEvict.Count, keysToRemove.Count);
 	}
 
 	public void ClearCache()

--- a/backend/GSSystemAnalyzer.Tests/Engine/CacheTtlTests.cs
+++ b/backend/GSSystemAnalyzer.Tests/Engine/CacheTtlTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+using GSSystemAnalyzer.Engine;
+using GSSystemAnalyzer.Interfaces;
+using GSSystemAnalyzer.Models.SettingDtos;
+
+namespace GSSystemAnalyzer.Tests.Engine;
+
+public class CacheTtlTests
+{
+    private static DiskScannerEngine CreateEngine(int ttlMinutes, int maxScans)
+    {
+        var hub = new Mock<IHubContext<Hubs.SystemHub>>().Object;
+
+        var appSettings = AppSettingDto.GetFactoryDefaults();
+        appSettings.Cache = new CacheSettingDto
+        {
+            ScanCacheTtlMinutes = ttlMinutes,
+            MaxCacheScans = maxScans
+        };
+
+        var settings = new Mock<ISettingService>();
+        settings.SetupGet(s => s.Current).Returns(appSettings);
+
+        return new DiskScannerEngine(hub, settings.Object, NullLogger<DiskScannerEngine>.Instance);
+    }
+
+    [Fact]
+    public void Prune_keeps_entries_scanned_within_ttl_even_if_folder_is_old()
+    {
+        var engine = CreateEngine(ttlMinutes: 15, maxScans: 5);
+        engine.DirectorySizeCache.Clear();
+
+        engine.DirectorySizeCache["C:/fresh"] = new CacheEntry
+        {
+            Size = 100,
+            LastUpdated = DateTime.UtcNow.AddDays(-30),    // folder old on disk...
+            CachedAtUtc = DateTime.UtcNow.AddMinutes(-5),  // ...but scanned 5 min ago
+            ScanRoot = "C:/"
+        };
+        engine.DirectorySizeCache["C:/expired"] = new CacheEntry
+        {
+            Size = 200,
+            LastUpdated = DateTime.UtcNow.AddMinutes(-1),  // folder changed recently...
+            CachedAtUtc = DateTime.UtcNow.AddMinutes(-60), // ...but scan is 60 min old
+            ScanRoot = "C:/"
+        };
+
+        engine.PruneStaleCacheEntries();
+
+        Assert.True(engine.DirectorySizeCache.ContainsKey("C:/fresh"));
+        Assert.False(engine.DirectorySizeCache.ContainsKey("C:/expired"));
+    }
+
+    [Fact]
+    public void EnforceMaxCacheScans_keeps_only_n_most_recent_roots()
+    {
+        var engine = CreateEngine(ttlMinutes: 100000, maxScans: 2);
+        engine.DirectorySizeCache.Clear();
+
+        AddRoot(engine, "C:/", DateTime.UtcNow.AddMinutes(-30)); // oldest -> evicted
+        AddRoot(engine, "D:/", DateTime.UtcNow.AddMinutes(-20));
+        AddRoot(engine, "E:/", DateTime.UtcNow.AddMinutes(-10)); // newest
+
+        engine.EnforceMaxCacheScans();
+
+        Assert.DoesNotContain(engine.DirectorySizeCache.Keys, k => k.StartsWith("C:/"));
+        Assert.Contains(engine.DirectorySizeCache.Keys, k => k.StartsWith("D:/"));
+        Assert.Contains(engine.DirectorySizeCache.Keys, k => k.StartsWith("E:/"));
+    }
+
+    private static void AddRoot(DiskScannerEngine engine, string root, DateTime scannedAt)
+    {
+        for (var i = 0; i < 2; i++)
+        {
+            engine.DirectorySizeCache[$"{root}folder{i}"] = new CacheEntry
+            {
+                Size = 1,
+                LastUpdated = scannedAt,
+                CachedAtUtc = scannedAt,
+                ScanRoot = root
+            };
+        }
+    }
+}

--- a/backend/GSSystemAnalyzer.Tests/Soak/LeakTests.cs
+++ b/backend/GSSystemAnalyzer.Tests/Soak/LeakTests.cs
@@ -13,10 +13,6 @@ using Xunit;
 
 namespace GSSystemAnalyzer.Tests.Soak;
 
-// Soak / leak-detection tests.
-// Excluded from the normal test run and selected in CI via:
-//   dotnet test --filter Category=Soak
-//
 // NOTE on DTO names: the mocked return types below (NukePreviewDto / NukeResultDto)
 // must match the ACTUAL return types of INukeProtocolService.PreviewNukeAsync and
 // ObliterateNodeAsync in your codebase. Adjust the type/property names if yours differ


### PR DESCRIPTION
# Fix Scan Cache Wipe on Restart & Implement Max Cached Scans

## Description

This PR fixes a bug where the scan cache (`scanner_memory.json`) was being incorrectly wiped on every backend restart regardless of the TTL setting. It also implements the `MaxCacheScans` setting which was previously declared but ignored.

### Root Causes Addressed:
1. **Cache Wipe Bug**: `CacheEntry.LastUpdated` was being stamped with the folder's last-modified time on disk, and `PruneStaleCacheEntries()` was using this same field for TTL expiry. Since folders are rarely modified within the TTL window, almost every entry looked expired on startup, causing a full cache wipe and rescan.
2. **Dead Setting**: `CacheSettingDto.MaxCacheScans` was never read or enforced anywhere in the engine.

### Changes:
- **Separated timestamps in `CacheEntry`**: 
  - Kept `LastUpdated` for content-staleness detection (when the folder changed on disk).
  - Added `CachedAtUtc` for TTL expiry (when we actually scanned the folder).
- **Added `ScanRoot` to `CacheEntry`**: Tags each cached folder with its top-level scan root (e.g., drive or browsed folder) to allow evicting entire scans rather than individual folders.
- **Implemented `EnforceMaxCacheScans()`**: Keeps only the `N` most-recent scan roots in the cache, successfully enforcing the settings.
- **Updated `CalculateMissingSizesAsync` & `GetDirectorySize`**: Calculates the `scanRoot` and propagates it recursively to properly tag all newly cached folders.
- **Added Unit Tests**: Created `CacheTtlTests.cs` to verify both the new TTL pruning logic and the maximum scan eviction logic.

## ⚠️ One-time Migration Note

Existing `scanner_memory.json` entries will deserialize with `CachedAtUtc = DateTime.MinValue` and `ScanRoot = null`. On the **first** startup after this change, they'll all be pruned once (because they look infinitely old), causing a single full rescan. From then on, the cache will properly survive restarts within the TTL window. This is expected and harmless.
