### PR TITLE
feat(frontend): wire Startup Manager UI to /api/startup (PR #143 backend)

### DIFF
--- a/backend/Engine/DiskScannerEngine.cs
+++ b/backend/Engine/DiskScannerEngine.cs
@@ -12,16 +12,8 @@ public class CacheEntry
 {
 	public long Size { get; set; }
 
-	// When the FOLDER's contents last changed on disk (dir.LastWriteTimeUtc).
-	// Used ONLY for content-staleness detection, never for TTL expiry.
 	public DateTime LastUpdated { get; set; }
-
-	// When WE last scanned/cached this folder. Used for TTL expiry and for
-	// grouping entries into scans. Distinct from LastUpdated.
 	public DateTime CachedAtUtc { get; set; }
-
-	// The top-level scan root (drive / browsed folder) this entry belongs to.
-	// Lets MaxCacheScans evict whole scans instead of individual folders.
 	public string? ScanRoot { get; set; }
 
 	public Dictionary<string, FileTypeEntry>? Extensions { get; set; }

--- a/frontend/gs_analyzer_ui/lib/models/startup_program.dart
+++ b/frontend/gs_analyzer_ui/lib/models/startup_program.dart
@@ -1,0 +1,51 @@
+/// Dart model mirroring the backend StartupProgramDto
+/// (backend/Models/StartupProgramDto.cs) introduced in PR #143.
+///
+/// Supports both camelCase (System.Text.Json default) and PascalCase
+/// (ASP.NET fallback) property names for resilience, matching the pattern
+/// used by temp_cleaner_model.dart.
+class StartupProgram {
+  final String id;
+  final String name;
+  final String executablePath;
+  final String? arguments;
+  final bool isEnabled;
+  final String scope; // "user" | "system"
+  final String platform; // "windows" | "linux"
+
+  const StartupProgram({
+    required this.id,
+    required this.name,
+    required this.executablePath,
+    this.arguments,
+    required this.isEnabled,
+    required this.scope,
+    required this.platform,
+  });
+
+  bool get isSystemScope => scope.toLowerCase() == 'system';
+
+  factory StartupProgram.fromJson(Map<String, dynamic> json) {
+    return StartupProgram(
+      id: json['id'] ?? json['Id'] ?? '',
+      name: json['name'] ?? json['Name'] ?? '',
+      executablePath: json['executablePath'] ?? json['ExecutablePath'] ?? '',
+      arguments: json['arguments'] ?? json['Arguments'],
+      isEnabled: json['isEnabled'] ?? json['IsEnabled'] ?? false,
+      scope: json['scope'] ?? json['Scope'] ?? 'user',
+      platform: json['platform'] ?? json['Platform'] ?? '',
+    );
+  }
+
+  StartupProgram copyWith({bool? isEnabled}) {
+    return StartupProgram(
+      id: id,
+      name: name,
+      executablePath: executablePath,
+      arguments: arguments,
+      isEnabled: isEnabled ?? this.isEnabled,
+      scope: scope,
+      platform: platform,
+    );
+  }
+}

--- a/frontend/gs_analyzer_ui/lib/providers/navigation_provider.dart
+++ b/frontend/gs_analyzer_ui/lib/providers/navigation_provider.dart
@@ -6,6 +6,7 @@ enum AppRoute {
   cpuMetics,
   memory,
   storage,
+  startup,
   network,
   thermal,
   telemetryHistory,

--- a/frontend/gs_analyzer_ui/lib/providers/startup_provider.dart
+++ b/frontend/gs_analyzer_ui/lib/providers/startup_provider.dart
@@ -4,8 +4,6 @@ import 'package:gs_analyzer_ui/models/startup_program.dart';
 import 'package:gs_analyzer_ui/services/api_service.dart';
 import 'package:gs_analyzer_ui/utils/logger.dart';
 
-/// Holds the list of startup programs as an AsyncValue so the UI can render
-/// loading / error / data states. Loads immediately on first read.
 final startupProvider =
     StateNotifierProvider<StartupNotifier, AsyncValue<List<StartupProgram>>>(
   (ref) => StartupNotifier(ApiService())..load(),
@@ -27,8 +25,6 @@ class StartupNotifier extends StateNotifier<AsyncValue<List<StartupProgram>>> {
     }
   }
 
-  /// Optimistically flips the toggle, then calls the backend. Reverts the row
-  /// (and rethrows) if the call fails, so the caller can surface a message.
   Future<void> toggle(StartupProgram program) async {
     final target = !program.isEnabled;
     _patch(program.id, program.copyWith(isEnabled: target));
@@ -40,8 +36,6 @@ class StartupNotifier extends StateNotifier<AsyncValue<List<StartupProgram>>> {
     }
   }
 
-  /// Optimistically removes the row, then calls the backend. On failure it
-  /// reloads the authoritative list and rethrows.
   Future<void> remove(StartupProgram program) async {
     final current = state.value ?? const <StartupProgram>[];
     state = AsyncValue.data(

--- a/frontend/gs_analyzer_ui/lib/providers/startup_provider.dart
+++ b/frontend/gs_analyzer_ui/lib/providers/startup_provider.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:gs_analyzer_ui/models/startup_program.dart';
+import 'package:gs_analyzer_ui/services/api_service.dart';
+import 'package:gs_analyzer_ui/utils/logger.dart';
+
+/// Holds the list of startup programs as an AsyncValue so the UI can render
+/// loading / error / data states. Loads immediately on first read.
+final startupProvider =
+    StateNotifierProvider<StartupNotifier, AsyncValue<List<StartupProgram>>>(
+  (ref) => StartupNotifier(ApiService())..load(),
+);
+
+class StartupNotifier extends StateNotifier<AsyncValue<List<StartupProgram>>> {
+  StartupNotifier(this._api) : super(const AsyncValue.loading());
+
+  final ApiService _api;
+
+  Future<void> load() async {
+    state = const AsyncValue.loading();
+    try {
+      final programs = await _api.getStartupPrograms();
+      state = AsyncValue.data(programs);
+    } catch (e, st) {
+      appLogger.i('[Startup] Load failed: $e');
+      state = AsyncValue.error(e, st);
+    }
+  }
+
+  /// Optimistically flips the toggle, then calls the backend. Reverts the row
+  /// (and rethrows) if the call fails, so the caller can surface a message.
+  Future<void> toggle(StartupProgram program) async {
+    final target = !program.isEnabled;
+    _patch(program.id, program.copyWith(isEnabled: target));
+    try {
+      await _api.setStartupEnabled(program.id, target);
+    } catch (e) {
+      _patch(program.id, program.copyWith(isEnabled: program.isEnabled));
+      rethrow;
+    }
+  }
+
+  /// Optimistically removes the row, then calls the backend. On failure it
+  /// reloads the authoritative list and rethrows.
+  Future<void> remove(StartupProgram program) async {
+    final current = state.value ?? const <StartupProgram>[];
+    state = AsyncValue.data(
+      current.where((p) => p.id != program.id).toList(),
+    );
+    try {
+      await _api.deleteStartupProgram(program.id);
+    } catch (e) {
+      await load();
+      rethrow;
+    }
+  }
+
+  void _patch(String id, StartupProgram updated) {
+    final current = state.value;
+    if (current == null) return;
+    state = AsyncValue.data([
+      for (final p in current)
+        if (p.id == id) updated else p,
+    ]);
+  }
+}

--- a/frontend/gs_analyzer_ui/lib/screen/master_layout.dart
+++ b/frontend/gs_analyzer_ui/lib/screen/master_layout.dart
@@ -12,6 +12,7 @@ import 'package:gs_analyzer_ui/providers/storage_view_provider.dart';
 import 'package:gs_analyzer_ui/providers/telemetry_provider.dart';
 import 'package:gs_analyzer_ui/screen/process_explorer_screen.dart';
 import 'package:gs_analyzer_ui/screen/telemetry_history_screen.dart';
+import 'package:gs_analyzer_ui/screen/startup_manager_screen.dart';
 import 'cpu_metrics_screen.dart';
 
 class MasterLayout extends ConsumerWidget {
@@ -55,6 +56,9 @@ class MasterLayout extends ConsumerWidget {
         return const Center(
           child: Text('NETWORK MODULE OFFLINE', style: HudTheme.headerCyan),
         );
+
+      case AppRoute.startup:
+        return const StartupManagerScreen();
 
       case AppRoute.thermal:
         return const ThermalModuleScreen();

--- a/frontend/gs_analyzer_ui/lib/screen/startup_manager_screen.dart
+++ b/frontend/gs_analyzer_ui/lib/screen/startup_manager_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gs_analyzer_ui/models/startup_program.dart';
 import 'package:gs_analyzer_ui/providers/startup_provider.dart';
+import 'package:gs_analyzer_ui/services/api_service.dart';
 import 'package:gs_analyzer_ui/utils/hud_theme.dart';
 
 class StartupManagerScreen extends ConsumerWidget {

--- a/frontend/gs_analyzer_ui/lib/screen/startup_manager_screen.dart
+++ b/frontend/gs_analyzer_ui/lib/screen/startup_manager_screen.dart
@@ -2,11 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gs_analyzer_ui/models/startup_program.dart';
 import 'package:gs_analyzer_ui/providers/startup_provider.dart';
-import 'package:gs_analyzer_ui/services/api_service.dart';
 import 'package:gs_analyzer_ui/utils/hud_theme.dart';
 
-/// HUD-styled screen listing programs that launch at login, with
-/// enable/disable and remove actions wired to the /api/startup backend.
 class StartupManagerScreen extends ConsumerWidget {
   const StartupManagerScreen({super.key});
 

--- a/frontend/gs_analyzer_ui/lib/screen/startup_manager_screen.dart
+++ b/frontend/gs_analyzer_ui/lib/screen/startup_manager_screen.dart
@@ -1,0 +1,291 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gs_analyzer_ui/models/startup_program.dart';
+import 'package:gs_analyzer_ui/providers/startup_provider.dart';
+import 'package:gs_analyzer_ui/services/api_service.dart';
+import 'package:gs_analyzer_ui/utils/hud_theme.dart';
+
+/// HUD-styled screen listing programs that launch at login, with
+/// enable/disable and remove actions wired to the /api/startup backend.
+class StartupManagerScreen extends ConsumerWidget {
+  const StartupManagerScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(startupProvider);
+
+    return Container(
+      color: HudTheme.bgBase,
+      padding: const EdgeInsets.all(20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(
+                Icons.rocket_launch_outlined,
+                color: HudTheme.accentCyan,
+                size: 22,
+              ),
+              const SizedBox(width: 10),
+              const Text('STARTUP MANAGER', style: HudTheme.headerCyan),
+              const Spacer(),
+              IconButton(
+                icon: const Icon(
+                  Icons.refresh,
+                  color: HudTheme.textDim,
+                  size: 20,
+                ),
+                tooltip: 'Reload',
+                onPressed: () => ref.read(startupProvider.notifier).load(),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          const Text(
+            'MANAGE PROGRAMS THAT LAUNCH AT LOGIN',
+            style: HudTheme.labelMuted,
+          ),
+          const SizedBox(height: 16),
+          Expanded(
+            child: Container(
+              decoration: HudTheme.hudPanelDecoration,
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              child: state.when(
+                loading: () => const Center(
+                  child: CircularProgressIndicator(color: HudTheme.accentCyan),
+                ),
+                error: (e, _) => _ErrorPanel(
+                  message: e.toString(),
+                  onRetry: () => ref.read(startupProvider.notifier).load(),
+                ),
+                data: (programs) {
+                  if (programs.isEmpty) {
+                    return const Center(
+                      child: Text(
+                        'NO STARTUP ENTRIES DETECTED',
+                        style: HudTheme.labelMuted,
+                      ),
+                    );
+                  }
+                  return ListView.separated(
+                    itemCount: programs.length,
+                    separatorBuilder: (_, __) =>
+                        const Divider(color: Colors.white10, height: 1),
+                    itemBuilder: (context, i) =>
+                        _StartupRow(program: programs[i]),
+                  );
+                },
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StartupRow extends ConsumerWidget {
+  const _StartupRow({required this.program});
+
+  final StartupProgram program;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final notifier = ref.read(startupProvider.notifier);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 8),
+      child: Row(
+        children: [
+          Icon(
+            program.isEnabled
+                ? Icons.check_circle_outline
+                : Icons.pause_circle_outline,
+            color: program.isEnabled ? HudTheme.accentGreen : HudTheme.textDim,
+            size: 20,
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Flexible(
+                      child: Text(
+                        program.name.isEmpty ? '(unnamed)' : program.name,
+                        overflow: TextOverflow.ellipsis,
+                        style: HudTheme.bodyText.copyWith(
+                          color: HudTheme.textMain,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    _ScopeTag(scope: program.scope),
+                  ],
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  program.arguments == null || program.arguments!.isEmpty
+                      ? program.executablePath
+                      : '${program.executablePath} ${program.arguments}',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: HudTheme.labelMuted,
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 12),
+          Switch(
+            value: program.isEnabled,
+            activeColor: HudTheme.accentCyan,
+            onChanged: (_) => _guard(context, () => notifier.toggle(program)),
+          ),
+          IconButton(
+            icon: const Icon(
+              Icons.delete_outline,
+              color: HudTheme.accentRed,
+              size: 20,
+            ),
+            tooltip: program.isSystemScope
+                ? 'Remove (requires admin)'
+                : 'Remove',
+            onPressed: () => _confirmDelete(context, notifier),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _confirmDelete(
+    BuildContext context,
+    StartupNotifier notifier,
+  ) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: HudTheme.bgPanel,
+        title: const Text('REMOVE STARTUP ENTRY', style: HudTheme.headerCyan),
+        content: Text(
+          program.isSystemScope
+              ? 'Remove "${program.name}" from startup?\n\nThis is a SYSTEM entry and requires administrator privileges.'
+              : 'Remove "${program.name}" from startup?',
+          style: HudTheme.bodyText,
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('CANCEL', style: HudTheme.labelMuted),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('REMOVE', style: HudTheme.actionRed),
+          ),
+        ],
+      ),
+    );
+
+    if (ok == true) {
+      await _guard(context, () => notifier.remove(program));
+    }
+  }
+
+  Future<void> _guard(
+    BuildContext context,
+    Future<void> Function() action,
+  ) async {
+    try {
+      await action();
+    } on StartupAdminRequiredException catch (e) {
+      _snack(context, e.message, HudTheme.accentAmber);
+    } catch (e) {
+      _snack(context, e.toString(), HudTheme.accentRed);
+    }
+  }
+
+  void _snack(BuildContext context, String msg, Color color) {
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        backgroundColor: HudTheme.bgPanel,
+        content: Text(
+          msg,
+          style: HudTheme.bodyText.copyWith(color: color),
+        ),
+      ),
+    );
+  }
+}
+
+class _ScopeTag extends StatelessWidget {
+  const _ScopeTag({required this.scope});
+
+  final String scope;
+
+  @override
+  Widget build(BuildContext context) {
+    final isSystem = scope.toLowerCase() == 'system';
+    final color = isSystem ? HudTheme.accentAmber : HudTheme.textDim;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        border: Border.all(color: color.withValues(alpha: 0.5)),
+        borderRadius: BorderRadius.circular(3),
+      ),
+      child: Text(
+        scope.toUpperCase(),
+        style: TextStyle(
+          fontFamily: HudTheme.fontCore,
+          color: color,
+          fontSize: 9,
+          letterSpacing: 1,
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorPanel extends StatelessWidget {
+  const _ErrorPanel({required this.message, required this.onRetry});
+
+  final String message;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(
+            Icons.warning_amber_outlined,
+            color: HudTheme.accentRed,
+            size: 32,
+          ),
+          const SizedBox(height: 12),
+          const Text('STARTUP MODULE ERROR', style: HudTheme.actionRed),
+          const SizedBox(height: 8),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            child: Text(
+              message,
+              textAlign: TextAlign.center,
+              style: HudTheme.labelMuted,
+            ),
+          ),
+          const SizedBox(height: 16),
+          OutlinedButton(
+            onPressed: onRetry,
+            style: OutlinedButton.styleFrom(
+              side: const BorderSide(color: HudTheme.accentCyan),
+            ),
+            child: const Text('RETRY', style: HudTheme.statCyan),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/gs_analyzer_ui/lib/services/api_service.dart
+++ b/frontend/gs_analyzer_ui/lib/services/api_service.dart
@@ -14,6 +14,7 @@ import 'package:gs_analyzer_ui/providers/age_heatmap_provider.dart';
 import 'package:gs_analyzer_ui/providers/file_type_provider.dart';
 import 'package:gs_analyzer_ui/models/permission_audit_models.dart';
 import 'package:gs_analyzer_ui/models/telemetry_history_model.dart';
+import 'package:gs_analyzer_ui/models/startup_program.dart';
 
 class ApiService {
   final http.Client _client;
@@ -29,6 +30,7 @@ class ApiService {
   static const String telemetryHistoryUrl =
       'http://localhost:5200/api/telemetry/history';
   static const String tempFilesUrl = 'http://localhost:5200/api/tempfiles';
+  static const String startupUrl = 'http://localhost:5200/api/startup';
 
   Future<TelemetryHistoryResponse?> fetchTelemetryHistory(
     String metric,
@@ -575,10 +577,69 @@ class ApiService {
       );
     }
   }
+
+  Future<List<StartupProgram>> getStartupPrograms() async {
+    final response = await _client.get(Uri.parse(startupUrl));
+
+    if (response.statusCode == 200) {
+      final decoded = jsonDecode(response.body);
+      final List data = decoded is List ? decoded : (decoded['data'] ?? []);
+      return data
+          .map((e) => StartupProgram.fromJson(e as Map<String, dynamic>))
+          .toList();
+    }
+
+    throw Exception(
+      'Startup fetch failed [${response.statusCode}]: ${response.body}',
+    );
+  }
+
+  Future<void> setStartupEnabled(String id, bool enable) async {
+    final action = enable ? 'enable' : 'disable';
+    final uri = Uri.parse('$startupUrl/${Uri.encodeComponent(id)}/$action');
+    appLogger.i('STARTUP BRIDGE: ${action.toUpperCase()} -> $uri');
+    final response = await _client.post(uri);
+    _ensureStartupSuccess(response);
+  }
+
+  Future<void> deleteStartupProgram(String id) async {
+    final uri = Uri.parse('$startupUrl/${Uri.encodeComponent(id)}');
+    appLogger.i('STARTUP BRIDGE: DELETE -> $uri');
+    final response = await _client.delete(uri);
+    _ensureStartupSuccess(response);
+  }
+
+  void _ensureStartupSuccess(http.Response response) {
+    if (response.statusCode == 200) return;
+
+    String message;
+    try {
+      final body = jsonDecode(response.body);
+      message = body['error'] ?? body['message'] ?? response.body;
+    } catch (_) {
+      message = response.body;
+    }
+
+    if (response.statusCode == 403) {
+      throw StartupAdminRequiredException(message);
+    }
+    throw Exception('Startup action failed [${response.statusCode}]: $message');
+  }
 }
 
 ExtensionBreakdownResult _parseBreakdown(String body) {
   return ExtensionBreakdownResult.fromJson(
     jsonDecode(body) as Map<String, dynamic>,
   );
+}
+
+class StartupAdminRequiredException implements Exception {
+  final String message;
+  const StartupAdminRequiredException([
+    this.message =
+        'Administrator privileges are required to modify system-scope startup entries.',
+  ]);
+
+  @override
+  String toString() => message;
 }

--- a/frontend/gs_analyzer_ui/lib/widgets/global_sidebar_widget.dart
+++ b/frontend/gs_analyzer_ui/lib/widgets/global_sidebar_widget.dart
@@ -118,6 +118,12 @@ class _GlobalSidebarWidgetState extends ConsumerState<GlobalSidebarWidget> {
                     currentRoute,
                   ),
                   _buildNavItem(
+                    AppRoute.startup,
+                    'STARTUP',
+                    Icons.rocket_launch_outlined,
+                    currentRoute,
+                  ),
+                  _buildNavItem(
                     AppRoute.network,
                     'NETWORK',
                     Icons.account_tree_outlined,

--- a/frontend/gs_analyzer_ui/test/startup_manager_test.dart
+++ b/frontend/gs_analyzer_ui/test/startup_manager_test.dart
@@ -1,0 +1,140 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gs_analyzer_ui/models/startup_program.dart';
+import 'package:gs_analyzer_ui/providers/startup_provider.dart';
+import 'package:gs_analyzer_ui/services/api_service.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockApiService extends Mock implements ApiService {}
+
+void main() {
+  late MockApiService mockApi;
+
+  setUp(() {
+    mockApi = MockApiService();
+  });
+
+  group('Startup Manager Engine Test', () {
+    test('Test 1: Core Engine Initialization (Loads Programs Successfully)', () async {
+      final fakePrograms = [
+        const StartupProgram(
+          id: 'test_123',
+          name: 'Discord',
+          executablePath: 'C:\\Discord\\discord.exe',
+          isEnabled: true,
+          scope: 'user',
+          platform: 'windows',
+        ),
+      ];
+
+      when(() => mockApi.getStartupPrograms()).thenAnswer((_) async => fakePrograms);
+
+      final notifier = StartupNotifier(mockApi);
+      await notifier.load();
+
+      final state = notifier.state;
+
+      expect(state.isLoading, false, reason: 'State must not be loading after load finishes!');
+      expect(state.hasValue, true, reason: 'State must have data!');
+      expect(state.value!.length, 1, reason: 'CRITICAL: Startup list size is incorrect!');
+      expect(state.value!.first.name, 'Discord', reason: 'Parsed program data is corrupted!');
+    });
+
+    test('Test 2: Optimistic UI Shield (Toggles State Instantly)', () async {
+      final fakePrograms = [
+        const StartupProgram(
+          id: 'test_123',
+          name: 'Discord',
+          executablePath: 'C:\\Discord\\discord.exe',
+          isEnabled: true,
+          scope: 'user',
+          platform: 'windows',
+        ),
+      ];
+
+      when(() => mockApi.getStartupPrograms()).thenAnswer((_) async => fakePrograms);
+      when(() => mockApi.setStartupEnabled(any(), any())).thenAnswer((_) async {});
+
+      final notifier = StartupNotifier(mockApi);
+      await notifier.load();
+      
+      final program = notifier.state.value!.first;
+      
+      // Perform toggle (true -> false)
+      await notifier.toggle(program);
+      
+      final updatedProgram = notifier.state.value!.first;
+      expect(
+        updatedProgram.isEnabled, 
+        false, 
+        reason: 'CRITICAL FAILURE: The engine did not optimistically update the UI toggle state before the network call finished!',
+      );
+      
+      verify(() => mockApi.setStartupEnabled('test_123', false)).called(1);
+    });
+
+    test('Test 3: The Overload Reversal (Reverts State on Backend Failure)', () async {
+      final fakePrograms = [
+        const StartupProgram(
+          id: 'test_123',
+          name: 'Discord',
+          executablePath: 'C:\\Discord\\discord.exe',
+          isEnabled: true,
+          scope: 'user',
+          platform: 'windows',
+        ),
+      ];
+
+      when(() => mockApi.getStartupPrograms()).thenAnswer((_) async => fakePrograms);
+      when(() => mockApi.setStartupEnabled(any(), any())).thenThrow(Exception('Backend Offline'));
+
+      final notifier = StartupNotifier(mockApi);
+      await notifier.load();
+      
+      final program = notifier.state.value!.first;
+      
+      try {
+        await notifier.toggle(program);
+      } catch (_) {
+        // Expected to throw
+      }
+      
+      final revertedProgram = notifier.state.value!.first;
+      expect(
+        revertedProgram.isEnabled, 
+        true, 
+        reason: 'CRITICAL: The engine did not revert the optimistic UI update after a backend failure!',
+      );
+    });
+
+    test('Test 4: Nuclear Delete (Removes Program Optimistically)', () async {
+      final fakePrograms = [
+        const StartupProgram(
+          id: 'target_1',
+          name: 'Malware',
+          executablePath: 'C:\\temp\\virus.exe',
+          isEnabled: true,
+          scope: 'user',
+          platform: 'windows',
+        ),
+      ];
+
+      when(() => mockApi.getStartupPrograms()).thenAnswer((_) async => fakePrograms);
+      when(() => mockApi.deleteStartupProgram(any())).thenAnswer((_) async {});
+
+      final notifier = StartupNotifier(mockApi);
+      await notifier.load();
+      
+      final program = notifier.state.value!.first;
+      await notifier.remove(program);
+      
+      expect(
+        notifier.state.value!.length, 
+        0, 
+        reason: 'CRITICAL: The Nuke function failed to remove the target from the startup array!',
+      );
+      
+      verify(() => mockApi.deleteStartupProgram('target_1')).called(1);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Wires the Flutter app (`frontend/gs_analyzer_ui/`) to the Startup Manager backend
introduced in #143 (`StartupController`, base route `/api/startup`). Adds a new
**STARTUP** module to the sidebar where users can view login-startup entries and
enable, disable, or remove them.

Depends on: #143

## What's included

**New files**
- `lib/models/startup_program.dart` — `StartupProgram` model mirroring
  `StartupProgramDto` (camelCase + PascalCase resilient `fromJson`, matching
  `temp_cleaner_model.dart`).
- `lib/providers/startup_provider.dart` — `StartupNotifier` + `startupProvider`
  exposing `AsyncValue<List<StartupProgram>>`; optimistic toggle/remove with
  revert-on-failure.
- `lib/screen/startup_manager_screen.dart` — HUD-styled screen: list with
  enable/disable switches, delete-with-confirm, plus loading / error / empty
  states and a user/system scope tag.

**Extended**
- `lib/services/api_service.dart` — added `startupUrl` constant and
  `getStartupPrograms()`, `setStartupEnabled(id, enable)`,
  `deleteStartupProgram(id)`, a `_ensureStartupSuccess()` helper, and a
  `StartupAdminRequiredException`.

**Wiring**
- `lib/providers/navigation_provider.dart` — new `AppRoute.startup`.
- `lib/screen/master_layout.dart` — route case → `StartupManagerScreen`.
- `lib/widgets/global_sidebar_widget.dart` — `STARTUP` nav item.

## Backend contract mapped

| Method | Route | Handling |
|--------|-------|----------|
| GET | `/api/startup` | Parses a **bare JSON array** (defensive `data` unwrap for future envelope) |
| POST | `/api/startup/{id}/enable` \| `/disable` | `200` success; `id` path segment URL-encoded |
| DELETE | `/api/startup/{id}` | `200` success |

- **403** on system-scope actions without admin rights is surfaced as an amber
  "administrator privileges required" snackbar (not a hard error).
- **500** shows the returned `error`/`details` message.

## Conventions followed
- Central `ApiService` (`http` package + static `...Url` constants + `jsonDecode`).
- Riverpod `StateNotifier` + `AsyncValue` (legacy import), consistent with the app.
- `HudTheme` styling (headerCyan, panels, accent colors, Courier font).

## Testing
- [ ] `flutter analyze` clean
- [ ] Backend running on `http://localhost:5200`
- [ ] STARTUP tab lists entries; toggle enable/disable persists after reload
- [ ] Remove (user scope) works; remove/toggle (system scope) without admin shows the 403 notice
- [ ] Windows and Linux smoke-tested