### PR TITLE
chore: remove unused ScanDirectoryR from DiskScannerEngine

### DIFF
--- a/backend/Engine/DiskScannerEngine.cs
+++ b/backend/Engine/DiskScannerEngine.cs
@@ -275,53 +275,6 @@ public class DiskScannerEngine : IDiskScannerEngine
 		return size;
 	}
 
-	// TODO: Clean up this determining which Scan directory works better.
-	private long ScanDirectoryR(DirectoryInfo dir, CancellationToken token, int currentDepth = 1)
-	{
-		token.ThrowIfCancellationRequested();
-
-		var config = _settings.Current.Scan;
-
-		if (currentDepth > config.Depth) return 0;
-
-		var normalizedPath = dir.FullName.Replace("\\", "/");
-		if (config.ExcludedPaths.Any(p => normalizedPath.StartsWith(p, StringComparison.OrdinalIgnoreCase)))
-		{
-			return 0;
-		}
-
-		long size = 0;
-
-		var option = new EnumerationOptions
-		{
-			IgnoreInaccessible = true,
-			ReturnSpecialDirectories = false,
-			AttributesToSkip = 0
-		};
-
-		if (config.SkipHiddenFiles) option.AttributesToSkip |= FileAttributes.Hidden;
-		if (config.SkipSystemFiles) option.AttributesToSkip |= FileAttributes.System;
-
-		try
-		{
-			foreach (var file in dir.EnumerateFiles("*", option))
-			{
-				size += file.Length;
-				Interlocked.Increment(ref _scannedFilesCount);
-			}
-
-			foreach (var subDir in dir.EnumerateDirectories("*", option))
-			{
-				size += ScanDirectoryR(subDir, token, currentDepth + 1);
-			}
-		}
-		catch (UnauthorizedAccessException)
-		{
-		}
-
-		return size;
-	}
-
 	public void SaveMemoryToDisk()
 	{
 		lock (_fileWriteLock)


### PR DESCRIPTION
Closes #145

## Change
Deleted the private, never-called `ScanDirectoryR` method (and its `// TODO` comment) from `backend/Engine/DiskScannerEngine.cs`. The active size-calculation path is `GetDirectorySize` (called from `CalculateMissingSizesAsync`); `ScanDirectoryR` duplicated that logic and had zero callers anywhere in the project.

Pure deletion, no logic changes.

## Verification
- `grep -rn "ScanDirectoryR"` across the repo: only the method's own definition (now removed) and its self-recursive call.
- `dotnet build`: succeeds, 0 errors, same 65 pre-existing warnings before and after (confirmed by diffing counts on both states) — no new warnings introduced.
- `dotnet test`: ran the full suite before and after; the same set of environment-specific failures (WMI/thermal-sensor Windows APIs, locale-dependent number formatting, drive-mount assumptions) is present on both — none reference `ScanDirectoryR` or the disk scanner's recursion path, confirming this change introduces no regressions.