### PR TITLE
feat: Scan Result Diff — WHAT_CHANGED view for storage (backend + frontend)

### DIFF
--- a/backend/BackgroundWorkers/ScheduledScanWorker.cs
+++ b/backend/BackgroundWorkers/ScheduledScanWorker.cs
@@ -145,15 +145,15 @@ public class ScheduledScanWorker : BackgroundService
 			var completedAt = DateTimeOffset.UtcNow;
 			_scheduleService.MarkCompleted(schedule.Id, completedAt);
 
-			// Broadcast AutoScanComplete — diff field is null until the Scan Result Diff
-			// feature is implemented, which will call IScanDiffService.ComputeDiff() here.
+			var scanDiff = scope.ServiceProvider.GetRequiredService<IScanDiffService>()
+				.GetCachedDiff(schedule.Path);
+
 			await _hubContext.Clients.All.SendAsync("AutoScanComplete", new
 			{
 				scheduleId = schedule.Id,
 				root = schedule.Path,
 				scannedAt = completedAt,
-				// TODO: Hook into IScanDiffService to attach flat-map JSON diff here once merged.
-				diff = (object?)null
+				diff = scanDiff
 			}, stoppingToken);
 
 			_logger.LogInformation(

--- a/backend/Controllers/ScanDiffController.cs
+++ b/backend/Controllers/ScanDiffController.cs
@@ -1,0 +1,74 @@
+using GSSystemAnalyzer.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GSSystemAnalyzer.Controllers
+{
+	[ApiController]
+	[Route("api/scan/diff")]
+	public class ScanDiffController : ControllerBase
+	{
+		private readonly IScanDiffService _scanDiff;
+
+		public ScanDiffController(IScanDiffService scanDiff)
+		{
+			_scanDiff = scanDiff;
+		}
+
+		[HttpGet]
+		public IActionResult GetDiff(
+			[FromQuery] string? root,
+			[FromQuery] long minDeltaBytes,
+			[FromServices] IDriveDetectionService driveService)
+		{
+			var target = ResolveRoot(root);
+
+			var driveError = ValidateDriveReady(target, driveService);
+			if (driveError != null) return driveError;
+
+			var diff = _scanDiff.GetCachedDiff(target, minDeltaBytes);
+			if (diff is null)
+				return Conflict(new
+				{
+					error = "NO_SCAN_CACHED",
+					message = "No scan result found for this root. Run a scan first."
+				});
+
+			return Ok(diff);
+		}
+
+		[HttpDelete("baseline")]
+		public IActionResult ClearBaseline(
+			[FromQuery] string? root,
+			[FromServices] IDriveDetectionService driveService)
+		{
+			var target = ResolveRoot(root);
+
+			var driveError = ValidateDriveReady(target, driveService);
+			if (driveError != null) return driveError;
+
+			_scanDiff.ClearBaseline(target);
+			return Ok(new { success = true, message = "Baseline cleared." });
+		}
+
+		private static string ResolveRoot(string? requested) =>
+			string.IsNullOrWhiteSpace(requested)
+				? (Path.GetPathRoot(Environment.SystemDirectory) ?? "C:\\")
+				: requested;
+
+		private IActionResult? ValidateDriveReady(string root, IDriveDetectionService driveService)
+		{
+			var normalized = NormalizeDriveRoot(root);
+			var readyDrives = driveService.GetReadyDrives();
+			if (!readyDrives.Any(d => NormalizeDriveRoot(d.Name) == normalized))
+				return BadRequest(new { error = "DRIVE_NOT_READY", message = "Drive not ready or not found" });
+
+			return null;
+		}
+
+		private static string NormalizeDriveRoot(string path)
+		{
+			var root = Path.GetPathRoot(path) ?? path;
+			return root.Replace('\\', '/').TrimEnd('/').ToUpperInvariant();
+		}
+	}
+}

--- a/backend/GSSystemAnalyzer.Tests/BackgroundWorkers/ScheduledScanWorkerTests.cs
+++ b/backend/GSSystemAnalyzer.Tests/BackgroundWorkers/ScheduledScanWorkerTests.cs
@@ -57,6 +57,10 @@ public class ScheduledScanWorkerTests
 		serviceProviderMock
 			.Setup(sp => sp.GetService(typeof(IDiskOperationService)))
 			.Returns(diskServiceMock.Object);
+		// The worker reads back the cached diff after a scan; a stub returning null is enough.
+		serviceProviderMock
+			.Setup(sp => sp.GetService(typeof(IScanDiffService)))
+			.Returns(new Mock<IScanDiffService>().Object);
 
 		var scopeMock = new Mock<IServiceScope>();
 		scopeMock.Setup(s => s.ServiceProvider).Returns(serviceProviderMock.Object);

--- a/backend/GSSystemAnalyzer.Tests/Services/ScanDiffServiceTests.cs
+++ b/backend/GSSystemAnalyzer.Tests/Services/ScanDiffServiceTests.cs
@@ -1,0 +1,260 @@
+using GSSystemAnalyzer.Engine;
+using GSSystemAnalyzer.Hubs;
+using GSSystemAnalyzer.Interfaces;
+using GSSystemAnalyzer.Models;
+using GSSystemAnalyzer.Models.SettingDtos;
+using GSSystemAnalyzer.Services;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace GSSystemAnalyzer.Tests.Services;
+
+public class ScanDiffServiceTests : IDisposable
+{
+	private readonly string _tempDir;
+
+	public ScanDiffServiceTests()
+	{
+		_tempDir = Path.Combine(Path.GetTempPath(), "gsdiff_" + Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(_tempDir);
+	}
+
+	public void Dispose()
+	{
+		try { Directory.Delete(_tempDir, recursive: true); } catch { /* best effort */ }
+	}
+
+	// A drive root that exists on the running platform, so Path.GetFullPath stays stable.
+	private static string Root => OperatingSystem.IsWindows() ? @"C:\" : "/";
+	private static string Sub(string rel) =>
+		OperatingSystem.IsWindows() ? $@"C:\{rel.Replace('/', '\\')}" : "/" + rel;
+
+	private static DiskScannerEngine CreateEngine()
+	{
+		var mockClients = new Mock<IHubClients>();
+		mockClients.Setup(c => c.All).Returns(new Mock<IClientProxy>().Object);
+		var mockHub = new Mock<IHubContext<SystemHub>>();
+		mockHub.Setup(h => h.Clients).Returns(mockClients.Object);
+
+		var mockSettings = new Mock<ISettingService>();
+		mockSettings.Setup(s => s.Current).Returns(new AppSettingDto());
+
+		var engine = new DiskScannerEngine(mockHub.Object, mockSettings.Object, NullLogger<DiskScannerEngine>.Instance);
+		engine.DirectorySizeCache.Clear();
+		return engine;
+	}
+
+	private ScanDiffService CreateService(DiskScannerEngine engine, IMemoryCache? cache = null)
+	{
+		var store = new ScanSnapshotStore(testDir: _tempDir);
+		var settings = new Mock<ISettingService>();
+		settings.Setup(s => s.Current).Returns(new AppSettingDto());
+		return new ScanDiffService(
+			engine,
+			store,
+			settings.Object,
+			cache ?? new MemoryCache(new MemoryCacheOptions()),
+			NullLogger<ScanDiffService>.Instance);
+	}
+
+	private static void Seed(DiskScannerEngine engine, string path, long size)
+	{
+		engine.DirectorySizeCache[path] = new CacheEntry
+		{
+			Size = size,
+			LastUpdated = DateTime.UtcNow,
+			CachedAtUtc = DateTime.UtcNow
+		};
+	}
+
+	[Fact]
+	public void FirstScan_ReturnsNoBaseline_AndPromotes()
+	{
+		var engine = CreateEngine();
+		Seed(engine, Root, 1000);
+		var svc = CreateService(engine);
+
+		var diff = svc.ComputeAndPromote(Root);
+
+		Assert.False(diff.HasBaseline);
+		Assert.Empty(diff.Added);
+		Assert.Empty(diff.Removed);
+		Assert.Empty(diff.Grown);
+		Assert.Empty(diff.Shrunk);
+
+		// A baseline file must now exist so the next scan has something to diff against.
+		Assert.NotEmpty(Directory.GetFiles(_tempDir, "*.json"));
+	}
+
+	[Fact]
+	public void SecondScan_DetectsAddedRemovedGrownShrunk()
+	{
+		var cache = new MemoryCache(new MemoryCacheOptions());
+
+		// First scan establishes the baseline.
+		var engine1 = CreateEngine();
+		Seed(engine1, Root, 3000);
+		Seed(engine1, Sub("keep"), 1000);   // will grow
+		Seed(engine1, Sub("shrinkme"), 1000); // will shrink
+		Seed(engine1, Sub("gone"), 1000);   // will be removed
+		CreateService(engine1, cache).ComputeAndPromote(Root);
+
+		// Second scan with changes.
+		var engine2 = CreateEngine();
+		Seed(engine2, Root, 5200);
+		Seed(engine2, Sub("keep"), 1500);       // +500 grown
+		Seed(engine2, Sub("shrinkme"), 200);    // -800 shrunk
+		Seed(engine2, Sub("brandnew"), 2000);   // added
+		var diff = CreateService(engine2, cache).ComputeAndPromote(Root);
+
+		Assert.True(diff.HasBaseline);
+		Assert.Contains(diff.Added, e => e.Path.EndsWith("brandnew"));
+		Assert.Contains(diff.Removed, e => e.Path.EndsWith("gone"));
+		Assert.Contains(diff.Grown, e => e.Path.EndsWith("keep") && e.DeltaBytes == 500);
+		Assert.Contains(diff.Shrunk, e => e.Path.EndsWith("shrinkme") && e.DeltaBytes == -800);
+	}
+
+	[Fact]
+	public void NeverEmits_ZeroDelta()
+	{
+		var cache = new MemoryCache(new MemoryCacheOptions());
+		var e1 = CreateEngine();
+		Seed(e1, Root, 1000);
+		Seed(e1, Sub("static"), 500);
+		CreateService(e1, cache).ComputeAndPromote(Root);
+
+		var e2 = CreateEngine();
+		Seed(e2, Root, 1000);
+		Seed(e2, Sub("static"), 500); // unchanged
+		var diff = CreateService(e2, cache).ComputeAndPromote(Root);
+
+		Assert.DoesNotContain(diff.Grown, x => x.Path.EndsWith("static"));
+		Assert.DoesNotContain(diff.Shrunk, x => x.Path.EndsWith("static"));
+	}
+
+	[Fact]
+	public void AddedDirectory_IsCollapsed_WithChildCount()
+	{
+		var cache = new MemoryCache(new MemoryCacheOptions());
+		var e1 = CreateEngine();
+		Seed(e1, Root, 1000);
+		CreateService(e1, cache).ComputeAndPromote(Root);
+
+		// Whole new subtree appears: parent + two descendants.
+		var e2 = CreateEngine();
+		Seed(e2, Root, 4000);
+		Seed(e2, Sub("newtree"), 3000);
+		Seed(e2, Sub("newtree/child1"), 2000);
+		Seed(e2, Sub("newtree/child2"), 1000);
+		var diff = CreateService(e2, cache).ComputeAndPromote(Root);
+
+		// Only the top-most new directory is listed, with its descendants counted.
+		var added = Assert.Single(diff.Added, e => e.Path.EndsWith("newtree"));
+		Assert.Equal(2, added.ChildCount);
+		Assert.DoesNotContain(diff.Added, e => e.Path.EndsWith("child1"));
+		Assert.DoesNotContain(diff.Added, e => e.Path.EndsWith("child2"));
+	}
+
+	[Fact]
+	public void RemovedDirectory_IsCollapsed_WithChildCount()
+	{
+		var cache = new MemoryCache(new MemoryCacheOptions());
+		var e1 = CreateEngine();
+		Seed(e1, Root, 4000);
+		Seed(e1, Sub("oldtree"), 3000);
+		Seed(e1, Sub("oldtree/a"), 2000);
+		Seed(e1, Sub("oldtree/b"), 1000);
+		CreateService(e1, cache).ComputeAndPromote(Root);
+
+		var e2 = CreateEngine();
+		Seed(e2, Root, 1000); // oldtree gone entirely
+		var diff = CreateService(e2, cache).ComputeAndPromote(Root);
+
+		var removed = Assert.Single(diff.Removed, e => e.Path.EndsWith("oldtree"));
+		Assert.Equal(2, removed.ChildCount);
+		Assert.DoesNotContain(diff.Removed, e => e.Path.EndsWith("oldtree/a"));
+	}
+
+	[Fact]
+	public void NetDelta_MatchesRootRecursiveChange()
+	{
+		var cache = new MemoryCache(new MemoryCacheOptions());
+		var e1 = CreateEngine();
+		Seed(e1, Root, 1000);
+		CreateService(e1, cache).ComputeAndPromote(Root);
+
+		var e2 = CreateEngine();
+		Seed(e2, Root, 6000); // +5000 overall
+		var diff = CreateService(e2, cache).ComputeAndPromote(Root);
+
+		Assert.Equal(5000, diff.Summary.NetDeltaBytes);
+	}
+
+	[Fact]
+	public void MinDeltaBytes_FiltersSmallMovers_ButKeepsSummary()
+	{
+		var cache = new MemoryCache(new MemoryCacheOptions());
+		var e1 = CreateEngine();
+		Seed(e1, Root, 3000);
+		Seed(e1, Sub("big"), 1000);
+		Seed(e1, Sub("small"), 1000);
+		CreateService(e1, cache).ComputeAndPromote(Root);
+
+		var e2 = CreateEngine();
+		Seed(e2, Root, 4100);
+		Seed(e2, Sub("big"), 2000);   // +1000
+		Seed(e2, Sub("small"), 1100); // +100
+		var svc = CreateService(e2, cache);
+		svc.ComputeAndPromote(Root);
+
+		var filtered = svc.GetCachedDiff(Root, minDeltaBytes: 500);
+
+		Assert.NotNull(filtered);
+		Assert.Contains(filtered!.Grown, e => e.Path.EndsWith("big"));
+		Assert.DoesNotContain(filtered.Grown, e => e.Path.EndsWith("small"));
+		// Summary counts remain accurate (both movers counted).
+		Assert.Equal(2, filtered.Summary.GrownCount);
+	}
+
+	[Fact]
+	public void GetCachedDiff_ReturnsNull_WhenNoScanComputed()
+	{
+		var svc = CreateService(CreateEngine());
+		Assert.Null(svc.GetCachedDiff(Root));
+	}
+
+	[Fact]
+	public void ClearBaseline_CausesNextScanToReportNoBaseline()
+	{
+		var cache = new MemoryCache(new MemoryCacheOptions());
+		var e1 = CreateEngine();
+		Seed(e1, Root, 1000);
+		var svc1 = CreateService(e1, cache);
+		svc1.ComputeAndPromote(Root);
+		svc1.ClearBaseline(Root);
+
+		var e2 = CreateEngine();
+		Seed(e2, Root, 2000);
+		var diff = CreateService(e2, cache).ComputeAndPromote(Root);
+
+		Assert.False(diff.HasBaseline);
+	}
+
+	[Fact]
+	public void Baseline_SurvivesNewServiceInstance()
+	{
+		// Simulates an app/backend restart: baseline persists on disk across instances.
+		var e1 = CreateEngine();
+		Seed(e1, Root, 1000);
+		CreateService(e1, new MemoryCache(new MemoryCacheOptions())).ComputeAndPromote(Root);
+
+		var e2 = CreateEngine();
+		Seed(e2, Root, 2000);
+		var diff = CreateService(e2, new MemoryCache(new MemoryCacheOptions())).ComputeAndPromote(Root);
+
+		Assert.True(diff.HasBaseline);
+		Assert.Equal(1000, diff.Summary.NetDeltaBytes);
+	}
+}

--- a/backend/GSSystemAnalyzer.Tests/Services/ScanSnapshotStoreTests.cs
+++ b/backend/GSSystemAnalyzer.Tests/Services/ScanSnapshotStoreTests.cs
@@ -1,0 +1,123 @@
+using GSSystemAnalyzer.Models;
+using GSSystemAnalyzer.Services;
+
+namespace GSSystemAnalyzer.Tests.Services;
+
+public class ScanSnapshotStoreTests : IDisposable
+{
+	private readonly string _tempDir;
+
+	public ScanSnapshotStoreTests()
+	{
+		_tempDir = Path.Combine(Path.GetTempPath(), "gssnap_" + Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(_tempDir);
+	}
+
+	public void Dispose()
+	{
+		try { Directory.Delete(_tempDir, recursive: true); } catch { /* best effort */ }
+	}
+
+	private static string Root => OperatingSystem.IsWindows() ? @"C:\" : "/";
+
+	private static ScanSnapshot Sample(long size = 1000) =>
+		new(DateTimeOffset.UtcNow, new Dictionary<string, ScanSnapshotEntry>
+		{
+			["c:/foo"] = new ScanSnapshotEntry(size, true, DateTimeOffset.UtcNow)
+		});
+
+	[Fact]
+	public void Load_ReturnsNull_WhenNoSnapshotExists()
+	{
+		var store = new ScanSnapshotStore(testDir: _tempDir);
+		Assert.Null(store.Load(Root, 10));
+	}
+
+	[Fact]
+	public void SaveThenLoad_RoundTripsEntries()
+	{
+		var store = new ScanSnapshotStore(testDir: _tempDir);
+		store.Save(Root, 10, Sample(2048));
+
+		var loaded = store.Load(Root, 10);
+
+		Assert.NotNull(loaded);
+		Assert.True(loaded!.Entries.ContainsKey("c:/foo"));
+		Assert.Equal(2048, loaded.Entries["c:/foo"].SizeBytes);
+	}
+
+	[Fact]
+	public void Save_OverwritesPreviousBaseline_Atomically()
+	{
+		var store = new ScanSnapshotStore(testDir: _tempDir);
+		store.Save(Root, 10, Sample(1000));
+		store.Save(Root, 10, Sample(9999));
+
+		var loaded = store.Load(Root, 10);
+		Assert.Equal(9999, loaded!.Entries["c:/foo"].SizeBytes);
+
+		// Exactly one baseline file per (root, depth); no leftover temp files.
+		Assert.Single(Directory.GetFiles(_tempDir, "*.json"));
+		Assert.Empty(Directory.GetFiles(_tempDir, "*.tmp"));
+	}
+
+	[Fact]
+	public void DifferentDepths_StoreSeparateBaselines()
+	{
+		var store = new ScanSnapshotStore(testDir: _tempDir);
+		store.Save(Root, 5, Sample(100));
+		store.Save(Root, 10, Sample(200));
+
+		Assert.Equal(100, store.Load(Root, 5)!.Entries["c:/foo"].SizeBytes);
+		Assert.Equal(200, store.Load(Root, 10)!.Entries["c:/foo"].SizeBytes);
+	}
+
+	[Fact]
+	public void Delete_RemovesBaseline()
+	{
+		var store = new ScanSnapshotStore(testDir: _tempDir);
+		store.Save(Root, 10, Sample());
+		store.Delete(Root, 10);
+
+		Assert.Null(store.Load(Root, 10));
+	}
+
+	[Fact]
+	public void Delete_IsNoOp_WhenAbsent()
+	{
+		var store = new ScanSnapshotStore(testDir: _tempDir);
+		var ex = Record.Exception(() => store.Delete(Root, 10));
+		Assert.Null(ex);
+	}
+
+	[Fact]
+	public void Load_DiscardsCorruptFile_AndReturnsNull()
+	{
+		var store = new ScanSnapshotStore(testDir: _tempDir);
+		store.Save(Root, 10, Sample());
+
+		// Corrupt the on-disk baseline.
+		var file = Directory.GetFiles(_tempDir, "*.json").Single();
+		File.WriteAllText(file, "{ this is not valid json ]");
+
+		Assert.Null(store.Load(Root, 10));
+		Assert.False(File.Exists(file)); // corrupt file is discarded
+	}
+
+	[Fact]
+	public void NormalizeDriveKey_IsCaseAndSeparatorInsensitive()
+	{
+		if (OperatingSystem.IsWindows())
+		{
+			Assert.Equal(
+				ScanSnapshotStore.NormalizeDriveKey(@"C:\Users\Foo"),
+				ScanSnapshotStore.NormalizeDriveKey("c:/users/foo/"));
+		}
+		else
+		{
+			Assert.Equal(
+				ScanSnapshotStore.NormalizeDriveKey("/home/Foo"),
+				ScanSnapshotStore.NormalizeDriveKey("/home/foo/"));
+		}
+	}
+}

--- a/backend/Interfaces/IScanDiffService.cs
+++ b/backend/Interfaces/IScanDiffService.cs
@@ -1,0 +1,12 @@
+using GSSystemAnalyzer.Models;
+
+namespace GSSystemAnalyzer.Interfaces;
+
+public interface IScanDiffService
+{
+	ScanDiff ComputeAndPromote(string root);
+
+	ScanDiff? GetCachedDiff(string root, long minDeltaBytes = 0);
+
+	void ClearBaseline(string root);
+}

--- a/backend/Interfaces/IScanSnapshotStore.cs
+++ b/backend/Interfaces/IScanSnapshotStore.cs
@@ -1,0 +1,19 @@
+using GSSystemAnalyzer.Models;
+
+namespace GSSystemAnalyzer.Interfaces;
+
+/// <summary>
+/// Persists exactly one scan baseline per (root, depth) on disk, separate from the volatile
+/// in-memory scan cache, so a diff survives cache eviction and app/backend restarts.
+/// </summary>
+public interface IScanSnapshotStore
+{
+	/// <summary>Loads the stored baseline for a (root, depth), or null if none exists / is unreadable.</summary>
+	ScanSnapshot? Load(string root, int depth);
+
+	/// <summary>Atomically writes the baseline for a (root, depth), overwriting any existing one.</summary>
+	void Save(string root, int depth, ScanSnapshot snapshot);
+
+	/// <summary>Deletes the stored baseline for a (root, depth). No-op if absent.</summary>
+	void Delete(string root, int depth);
+}

--- a/backend/Models/ScanDiff.cs
+++ b/backend/Models/ScanDiff.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+
+namespace GSSystemAnalyzer.Models;
+
+public enum DiffKind
+{
+	Added,
+	Removed,
+	Grown,
+	Shrunk
+}
+
+
+public record ScanSnapshotEntry(long SizeBytes, bool IsDirectory, DateTimeOffset LastModified);
+public record ScanSnapshot(DateTimeOffset CapturedAt, Dictionary<string, ScanSnapshotEntry> Entries);
+
+public record ScanDiffEntry(
+	string Path,
+	bool IsDirectory,
+	DiffKind Kind,
+	long CurrentBytes,       
+	long PreviousBytes,       
+	long DeltaBytes,          
+	int? ChildCount,          
+	DateTimeOffset? LastModified);
+
+public record ScanDiffSummary(
+	int AddedCount, long AddedBytes,
+	int RemovedCount, long RemovedBytes,
+	int GrownCount, long GrownDeltaBytes,
+	int ShrunkCount, long ShrunkDeltaBytes,
+	long NetDeltaBytes);
+
+
+public record ScanDiff(
+	string Root,
+	bool HasBaseline,
+	DateTimeOffset? BaselineScannedAt,
+	DateTimeOffset CurrentScannedAt,
+	IReadOnlyList<ScanDiffEntry> Added,
+	IReadOnlyList<ScanDiffEntry> Removed,
+	IReadOnlyList<ScanDiffEntry> Grown,
+	IReadOnlyList<ScanDiffEntry> Shrunk,
+	ScanDiffSummary Summary);

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -39,6 +39,8 @@ builder.Services.AddSingleton<ISettingService, SettingsServices>();
 builder.Services.AddSingleton<IProcessOwnerResolver, ProcessOwnerResolver>();
 builder.Services.AddSingleton<IFileTypeScanner, FileTypeScanner>();
 builder.Services.AddSingleton<IAgeHeatmapEngine, AgeHeatmapEngine>();
+builder.Services.AddSingleton<IScanSnapshotStore, ScanSnapshotStore>();
+builder.Services.AddSingleton<IScanDiffService, ScanDiffService>();
 
 builder.Services.AddSingleton<ITelemetryHistoryBuffer, TelemetryHistoryBuffer>();
 

--- a/backend/Services/DiskOperationsService.cs
+++ b/backend/Services/DiskOperationsService.cs
@@ -13,12 +13,14 @@ namespace GSSystemAnalyzer.Services
 		private readonly DiskScannerEngine _scanner;
 		private readonly IHubContext<SystemHub> _hubContext;
 		private readonly ILogger<DiskOperationsService> _logger;
+		private readonly IScanDiffService _scanDiff;
 
-		public DiskOperationsService(DiskScannerEngine scanner, IHubContext<SystemHub> hubContext, ILogger<DiskOperationsService> logger)
+		public DiskOperationsService(DiskScannerEngine scanner, IHubContext<SystemHub> hubContext, ILogger<DiskOperationsService> logger, IScanDiffService scanDiff)
 		{
 			_scanner = scanner;
 			_hubContext = hubContext;
 			_logger = logger;
+			_scanDiff = scanDiff;
 		}
 
 		public DriveTelemetryDto GetDriveTelemetry(string driveLetter)
@@ -90,6 +92,20 @@ namespace GSSystemAnalyzer.Services
 
 				Task.Run(() => _scanner.SaveMemoryToDisk());
 
+				// Compute the scan diff + promote the baseline, but only for whole-drive scans —
+				// browsing individual subfolders should not accumulate baselines or reset a drive's.
+				if (IsDriveRoot(path))
+				{
+					try
+					{
+						_scanDiff.ComputeAndPromote(path);
+					}
+					catch (Exception ex)
+					{
+						_logger.LogWarning(ex, "Scan diff computation failed for {Path}", path);
+					}
+				}
+
 				return nodes;
 			}
 			finally
@@ -128,6 +144,17 @@ namespace GSSystemAnalyzer.Services
 			{
 				Task.Run(() => _scanner.SaveMemoryToDisk());
 			}
+		}
+
+		private static bool IsDriveRoot(string path)
+		{
+			var full = Path.GetFullPath(path);
+			var root = Path.GetPathRoot(full);
+			return !string.IsNullOrEmpty(root)
+				&& string.Equals(
+					full.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+					root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+					StringComparison.OrdinalIgnoreCase);
 		}
 
 		public Guid BeginScan(Guid? scanId = null) => _scanner.BeginScanSession(scanId);

--- a/backend/Services/ScanDiffService.cs
+++ b/backend/Services/ScanDiffService.cs
@@ -1,0 +1,235 @@
+using GSSystemAnalyzer.Engine;
+using GSSystemAnalyzer.Interfaces;
+using GSSystemAnalyzer.Models;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+
+namespace GSSystemAnalyzer.Services;
+
+public class ScanDiffService : IScanDiffService
+{
+	private readonly DiskScannerEngine _engine;
+	private readonly IScanSnapshotStore _store;
+	private readonly ISettingService _settings;
+	private readonly IMemoryCache _cache;
+	private readonly ILogger<ScanDiffService> _logger;
+
+	public ScanDiffService(
+		DiskScannerEngine engine,
+		IScanSnapshotStore store,
+		ISettingService settings,
+		IMemoryCache cache,
+		ILogger<ScanDiffService> logger)
+	{
+		_engine = engine;
+		_store = store;
+		_settings = settings;
+		_cache = cache;
+		_logger = logger;
+	}
+
+	private static string CacheKey(string root) => $"scandiff:{ScanSnapshotStore.NormalizeDriveKey(root)}";
+
+	public ScanDiff ComputeAndPromote(string root)
+	{
+		var depth = _settings.Current.Scan.Depth;
+		var now = DateTimeOffset.UtcNow;
+
+		var current = BuildSnapshotFromCache(root);
+		var baseline = _store.Load(root, depth);
+
+		ScanDiff diff = baseline == null
+			? BuildFirstScanDiff(root, now)
+			: BuildDiff(root, baseline, current.Entries, baseline.CapturedAt, now);
+
+		// Cache the computed diff for the GET endpoint to read (no recomputation on read).
+		_cache.Set(CacheKey(root), diff, TimeSpan.FromHours(1));
+
+		// Promote current to baseline AFTER diffing, so the next scan compares against this one.
+		try
+		{
+			_store.Save(root, depth, current);
+		}
+		catch (Exception ex)
+		{
+			_logger.LogError(ex, "Failed to promote scan baseline for {Root}", root);
+		}
+
+		return diff;
+	}
+
+	public ScanDiff? GetCachedDiff(string root, long minDeltaBytes = 0)
+	{
+		if (!_cache.TryGetValue(CacheKey(root), out ScanDiff? hit) || hit == null)
+			return null;
+
+		if (minDeltaBytes <= 0)
+			return hit;
+
+		// Filter small movers out of the lists but keep the summary counts intact.
+		var grown = hit.Grown.Where(e => Math.Abs(e.DeltaBytes) >= minDeltaBytes).ToList();
+		var shrunk = hit.Shrunk.Where(e => Math.Abs(e.DeltaBytes) >= minDeltaBytes).ToList();
+
+		return hit with { Grown = grown, Shrunk = shrunk };
+	}
+
+	public void ClearBaseline(string root)
+	{
+		_store.Delete(root, _settings.Current.Scan.Depth);
+		_cache.Remove(CacheKey(root));
+	}
+
+	private ScanSnapshot BuildSnapshotFromCache(string root)
+	{
+		var rootFwd = ToForwardSlash(Path.GetFullPath(root));
+		var rootNoSlash = rootFwd.TrimEnd('/');
+		var prefix = rootNoSlash + "/";
+
+		var entries = new Dictionary<string, ScanSnapshotEntry>(StringComparer.OrdinalIgnoreCase);
+
+		foreach (var kvp in _engine.DirectorySizeCache)
+		{
+			var keyFwd = ToForwardSlash(kvp.Key).TrimEnd('/');
+
+			// Include the root itself and everything beneath it.
+			var underRoot = keyFwd.Equals(rootNoSlash, StringComparison.OrdinalIgnoreCase)
+				|| keyFwd.StartsWith(prefix, StringComparison.OrdinalIgnoreCase);
+			if (!underRoot) continue;
+
+			entries[keyFwd] = new ScanSnapshotEntry(
+				SizeBytes: kvp.Value.Size,
+				IsDirectory: true,
+				LastModified: new DateTimeOffset(DateTime.SpecifyKind(kvp.Value.LastUpdated, DateTimeKind.Utc)));
+		}
+
+		return new ScanSnapshot(DateTimeOffset.UtcNow, entries);
+	}
+
+	private static ScanDiff BuildFirstScanDiff(string root, DateTimeOffset now) =>
+		new(
+			Root: ToForwardSlash(Path.GetFullPath(root)).TrimEnd('/'),
+			HasBaseline: false,
+			BaselineScannedAt: null,
+			CurrentScannedAt: now,
+			Added: Array.Empty<ScanDiffEntry>(),
+			Removed: Array.Empty<ScanDiffEntry>(),
+			Grown: Array.Empty<ScanDiffEntry>(),
+			Shrunk: Array.Empty<ScanDiffEntry>(),
+			Summary: new ScanDiffSummary(0, 0, 0, 0, 0, 0, 0, 0, 0));
+
+	private static ScanDiff BuildDiff(
+		string root,
+		ScanSnapshot baseline,
+		Dictionary<string, ScanSnapshotEntry> current,
+		DateTimeOffset baselineAt,
+		DateTimeOffset now)
+	{
+		var prev = baseline.Entries;
+
+		// The root directory always changes when anything beneath it does; its delta is the
+		// summary's NetDeltaBytes, so listing it as a mover would be redundant. Exclude it.
+		var rootKey = ToForwardSlash(Path.GetFullPath(root)).TrimEnd('/');
+
+		var added = new List<ScanDiffEntry>();
+		var removed = new List<ScanDiffEntry>();
+		var grown = new List<ScanDiffEntry>();
+		var shrunk = new List<ScanDiffEntry>();
+
+		// Sets of paths that are wholly new / wholly gone, used to collapse descendants.
+		var addedPaths = current.Keys
+			.Where(k => !prev.ContainsKey(k) && !k.Equals(rootKey, StringComparison.OrdinalIgnoreCase))
+			.ToHashSet(StringComparer.OrdinalIgnoreCase);
+		var removedPaths = prev.Keys
+			.Where(k => !current.ContainsKey(k) && !k.Equals(rootKey, StringComparison.OrdinalIgnoreCase))
+			.ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+		// ADDED — collapse to the top-most new directory; count collapsed descendants.
+		foreach (var path in addedPaths)
+		{
+			if (HasAncestorIn(path, addedPaths)) continue; // descendant of another added dir
+			var childCount = current.Keys.Count(k => IsDescendantOf(k, path));
+			var e = current[path];
+			added.Add(new ScanDiffEntry(path, e.IsDirectory, DiffKind.Added,
+				CurrentBytes: e.SizeBytes, PreviousBytes: 0, DeltaBytes: e.SizeBytes,
+				ChildCount: childCount > 0 ? childCount : null, LastModified: e.LastModified));
+		}
+
+		// REMOVED — collapse to the top-most vanished directory; count collapsed descendants.
+		foreach (var path in removedPaths)
+		{
+			if (HasAncestorIn(path, removedPaths)) continue;
+			var childCount = prev.Keys.Count(k => IsDescendantOf(k, path));
+			var e = prev[path];
+			removed.Add(new ScanDiffEntry(path, e.IsDirectory, DiffKind.Removed,
+				CurrentBytes: 0, PreviousBytes: e.SizeBytes, DeltaBytes: -e.SizeBytes,
+				ChildCount: childCount > 0 ? childCount : null, LastModified: e.LastModified));
+		}
+
+		// GROWN / SHRUNK — present in both; classify by signed recursive delta.
+		foreach (var kvp in current)
+		{
+			if (kvp.Key.Equals(rootKey, StringComparison.OrdinalIgnoreCase)) continue; // root delta = NetDeltaBytes
+			if (!prev.TryGetValue(kvp.Key, out var prevEntry)) continue;
+			var delta = kvp.Value.SizeBytes - prevEntry.SizeBytes;
+			if (delta == 0) continue; // never emit unchanged
+
+			var entry = new ScanDiffEntry(kvp.Key, kvp.Value.IsDirectory,
+				delta > 0 ? DiffKind.Grown : DiffKind.Shrunk,
+				CurrentBytes: kvp.Value.SizeBytes, PreviousBytes: prevEntry.SizeBytes,
+				DeltaBytes: delta, ChildCount: null, LastModified: kvp.Value.LastModified);
+
+			if (delta > 0) grown.Add(entry); else shrunk.Add(entry);
+		}
+
+		// Biggest movers first.
+		added.Sort((a, b) => b.CurrentBytes.CompareTo(a.CurrentBytes));
+		removed.Sort((a, b) => b.PreviousBytes.CompareTo(a.PreviousBytes));
+		grown.Sort((a, b) => Math.Abs(b.DeltaBytes).CompareTo(Math.Abs(a.DeltaBytes)));
+		shrunk.Sort((a, b) => Math.Abs(b.DeltaBytes).CompareTo(Math.Abs(a.DeltaBytes)));
+
+		// Directory sizes are recursive, so summing nested deltas would double-count. The
+		// authoritative net change of the tree is the root's own recursive-size delta.
+		long netDelta;
+		if (current.TryGetValue(rootKey, out var curRoot) && prev.TryGetValue(rootKey, out var prevRoot))
+			netDelta = curRoot.SizeBytes - prevRoot.SizeBytes;
+		else if (current.TryGetValue(rootKey, out var addedRoot))
+			netDelta = addedRoot.SizeBytes;          // whole root is new
+		else if (prev.TryGetValue(rootKey, out var goneRoot))
+			netDelta = -goneRoot.SizeBytes;          // whole root vanished
+		else
+			netDelta = 0;
+
+		var summary = new ScanDiffSummary(
+			AddedCount: added.Count, AddedBytes: added.Sum(e => e.CurrentBytes),
+			RemovedCount: removed.Count, RemovedBytes: removed.Sum(e => e.PreviousBytes),
+			GrownCount: grown.Count, GrownDeltaBytes: grown.Sum(e => e.DeltaBytes),
+			ShrunkCount: shrunk.Count, ShrunkDeltaBytes: shrunk.Sum(e => e.DeltaBytes),
+			NetDeltaBytes: netDelta);
+
+		return new ScanDiff(
+			Root: ToForwardSlash(Path.GetFullPath(root)).TrimEnd('/'),
+			HasBaseline: true,
+			BaselineScannedAt: baselineAt,
+			CurrentScannedAt: now,
+			Added: added, Removed: removed, Grown: grown, Shrunk: shrunk,
+			Summary: summary);
+	}
+
+	private static bool IsDescendantOf(string path, string ancestor) =>
+		path.Length > ancestor.Length
+		&& path.StartsWith(ancestor + "/", StringComparison.OrdinalIgnoreCase);
+
+	private static bool HasAncestorIn(string path, HashSet<string> set)
+	{
+		var idx = path.LastIndexOf('/');
+		while (idx > 0)
+		{
+			var parent = path[..idx];
+			if (set.Contains(parent)) return true;
+			idx = parent.LastIndexOf('/');
+		}
+		return false;
+	}
+
+	private static string ToForwardSlash(string p) => p.Replace('\\', '/');
+}

--- a/backend/Services/ScanSnapshotStore.cs
+++ b/backend/Services/ScanSnapshotStore.cs
@@ -1,0 +1,122 @@
+using System.Text.Json;
+using GSSystemAnalyzer.Interfaces;
+using GSSystemAnalyzer.Models;
+using Microsoft.Extensions.Logging;
+
+namespace GSSystemAnalyzer.Services;
+
+public class ScanSnapshotStore : IScanSnapshotStore
+{
+	private readonly string _snapshotDir;
+	private readonly JsonSerializerOptions _jsonOptions;
+	private readonly ILogger<ScanSnapshotStore> _logger;
+	private readonly object _fileLock = new();
+
+	public ScanSnapshotStore(ILogger<ScanSnapshotStore>? logger = null, string? testDir = null)
+	{
+		_logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<ScanSnapshotStore>.Instance;
+
+		if (testDir != null)
+		{
+			_snapshotDir = testDir;
+		}
+		else
+		{
+			var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+			_snapshotDir = Path.Combine(appData, "GSAnalyzer", "scan_snapshots");
+		}
+
+		Directory.CreateDirectory(_snapshotDir);
+
+		_jsonOptions = new JsonSerializerOptions
+		{
+			WriteIndented = false,
+			PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+		};
+	}
+
+	public ScanSnapshot? Load(string root, int depth)
+	{
+		var path = SnapshotPath(root, depth);
+		if (!File.Exists(path)) return null;
+
+		try
+		{
+			string json;
+			lock (_fileLock)
+			{
+				json = File.ReadAllText(path);
+			}
+			return JsonSerializer.Deserialize<ScanSnapshot>(json, _jsonOptions);
+		}
+		catch (Exception ex)
+		{
+			_logger.LogWarning(ex, "Corrupt scan snapshot at {Path}, discarding", path);
+			try { File.Delete(path); } catch { /* best effort */ }
+			return null;
+		}
+	}
+
+	public void Save(string root, int depth, ScanSnapshot snapshot)
+	{
+		var path = SnapshotPath(root, depth);
+		var json = JsonSerializer.Serialize(snapshot, _jsonOptions);
+		var tempPath = path + "." + Guid.NewGuid().ToString("N") + ".tmp";
+
+		lock (_fileLock)
+		{
+			File.WriteAllText(tempPath, json);
+			int retries = 5;
+			while (true)
+			{
+				try
+				{
+					File.Move(tempPath, path, overwrite: true);
+					break;
+				}
+				catch (Exception ex) when (ex is UnauthorizedAccessException || ex is IOException)
+				{
+					retries--;
+					if (retries == 0)
+					{
+						try { File.Delete(tempPath); } catch { /* best effort */ }
+						throw;
+					}
+					Thread.Sleep(20);
+				}
+			}
+		}
+	}
+
+	public void Delete(string root, int depth)
+	{
+		var path = SnapshotPath(root, depth);
+		lock (_fileLock)
+		{
+			try
+			{
+				if (File.Exists(path)) File.Delete(path);
+			}
+			catch (Exception ex)
+			{
+				_logger.LogWarning(ex, "Failed to delete scan snapshot at {Path}", path);
+			}
+		}
+	}
+
+	private string SnapshotPath(string root, int depth)
+	{
+		var driveKey = NormalizeDriveKey(root);
+		var safeKey = driveKey
+			.Replace(':', '_')
+			.Replace('/', '_')
+			.Replace('\\', '_');
+		return Path.Combine(_snapshotDir, $"{safeKey}_{depth}.json");
+	}
+
+	public static string NormalizeDriveKey(string root)
+	{
+		var fullPath = Path.GetFullPath(root);
+		return fullPath.Replace('\\', '/').ToLowerInvariant().TrimEnd('/');
+	}
+}

--- a/frontend/gs_analyzer_ui/lib/models/scan_diff.dart
+++ b/frontend/gs_analyzer_ui/lib/models/scan_diff.dart
@@ -1,0 +1,151 @@
+/// Directory-level diff of the latest scan of a root against its stored baseline.
+class ScanDiff {
+  final String root;
+  final bool hasBaseline;
+  final DateTime? baselineScannedAt;
+  final DateTime currentScannedAt;
+  final List<ScanDiffEntry> added;
+  final List<ScanDiffEntry> removed;
+  final List<ScanDiffEntry> grown;
+  final List<ScanDiffEntry> shrunk;
+  final ScanDiffSummary summary;
+
+  const ScanDiff({
+    required this.root,
+    required this.hasBaseline,
+    required this.baselineScannedAt,
+    required this.currentScannedAt,
+    required this.added,
+    required this.removed,
+    required this.grown,
+    required this.shrunk,
+    required this.summary,
+  });
+
+  /// True when the last scan produced no add/remove/grow/shrink changes.
+  bool get isEmpty =>
+      added.isEmpty && removed.isEmpty && grown.isEmpty && shrunk.isEmpty;
+
+  static List<ScanDiffEntry> _entries(dynamic raw) => raw == null
+      ? const []
+      : (raw as List)
+            .map((e) => ScanDiffEntry.fromJson(Map<String, dynamic>.from(e as Map)))
+            .toList();
+
+  static DateTime? _dateOrNull(dynamic v) =>
+      v == null ? null : DateTime.parse(v as String);
+
+  factory ScanDiff.fromJson(Map<String, dynamic> j) => ScanDiff(
+    root: (j['root'] ?? j['Root'] ?? '') as String,
+    hasBaseline: (j['hasBaseline'] ?? j['HasBaseline'] ?? false) as bool,
+    baselineScannedAt: _dateOrNull(j['baselineScannedAt'] ?? j['BaselineScannedAt']),
+    currentScannedAt:
+        _dateOrNull(j['currentScannedAt'] ?? j['CurrentScannedAt']) ??
+        DateTime.now(),
+    added: _entries(j['added'] ?? j['Added']),
+    removed: _entries(j['removed'] ?? j['Removed']),
+    grown: _entries(j['grown'] ?? j['Grown']),
+    shrunk: _entries(j['shrunk'] ?? j['Shrunk']),
+    summary: ScanDiffSummary.fromJson(
+      Map<String, dynamic>.from((j['summary'] ?? j['Summary']) as Map),
+    ),
+  );
+}
+
+/// One changed path in a scan diff. `deltaBytes` is signed (current - previous).
+class ScanDiffEntry {
+  final String path;
+  final bool isDirectory;
+  final int currentBytes;
+  final int previousBytes;
+  final int deltaBytes;
+
+  /// Number of collapsed descendants for a wholly added/removed directory; null otherwise.
+  final int? childCount;
+  final DateTime? lastModified;
+
+  const ScanDiffEntry({
+    required this.path,
+    required this.isDirectory,
+    required this.currentBytes,
+    required this.previousBytes,
+    required this.deltaBytes,
+    required this.childCount,
+    required this.lastModified,
+  });
+
+  /// The parent directory of this entry, used to jump into the explorer.
+  String get parentPath {
+    final normalized = path.replaceAll('\\', '/');
+    final idx = normalized.lastIndexOf('/');
+    return idx <= 0 ? path : normalized.substring(0, idx);
+  }
+
+  /// The trailing segment (file/folder name) for display.
+  String get displayName {
+    final normalized = path.replaceAll('\\', '/');
+    final trimmed = normalized.endsWith('/')
+        ? normalized.substring(0, normalized.length - 1)
+        : normalized;
+    final idx = trimmed.lastIndexOf('/');
+    return idx < 0 ? trimmed : trimmed.substring(idx + 1);
+  }
+
+  static int _int(dynamic v) => (v as num?)?.toInt() ?? 0;
+
+  factory ScanDiffEntry.fromJson(Map<String, dynamic> j) => ScanDiffEntry(
+    path: (j['path'] ?? j['Path'] ?? '') as String,
+    isDirectory: (j['isDirectory'] ?? j['IsDirectory'] ?? false) as bool,
+    currentBytes: _int(j['currentBytes'] ?? j['CurrentBytes']),
+    previousBytes: _int(j['previousBytes'] ?? j['PreviousBytes']),
+    deltaBytes: _int(j['deltaBytes'] ?? j['DeltaBytes']),
+    childCount: (j['childCount'] ?? j['ChildCount']) == null
+        ? null
+        : _int(j['childCount'] ?? j['ChildCount']),
+    lastModified: (j['lastModified'] ?? j['LastModified']) == null
+        ? null
+        : DateTime.parse((j['lastModified'] ?? j['LastModified']) as String),
+  );
+}
+
+/// Aggregate counts and byte totals across all four change buckets.
+class ScanDiffSummary {
+  final int addedCount;
+  final int addedBytes;
+  final int removedCount;
+  final int removedBytes;
+  final int grownCount;
+  final int grownDeltaBytes;
+  final int shrunkCount;
+  final int shrunkDeltaBytes;
+  final int netDeltaBytes;
+
+  const ScanDiffSummary({
+    required this.addedCount,
+    required this.addedBytes,
+    required this.removedCount,
+    required this.removedBytes,
+    required this.grownCount,
+    required this.grownDeltaBytes,
+    required this.shrunkCount,
+    required this.shrunkDeltaBytes,
+    required this.netDeltaBytes,
+  });
+
+  int get totalChangeCount =>
+      addedCount + removedCount + grownCount + shrunkCount;
+
+  static int _int(dynamic v) => (v as num?)?.toInt() ?? 0;
+
+  factory ScanDiffSummary.fromJson(Map<String, dynamic> j) => ScanDiffSummary(
+    addedCount: _int(j['addedCount'] ?? j['AddedCount']),
+    addedBytes: _int(j['addedBytes'] ?? j['AddedBytes']),
+    removedCount: _int(j['removedCount'] ?? j['RemovedCount']),
+    removedBytes: _int(j['removedBytes'] ?? j['RemovedBytes']),
+    grownCount: _int(j['grownCount'] ?? j['GrownCount']),
+    grownDeltaBytes: _int(j['grownDeltaBytes'] ?? j['GrownDeltaBytes']),
+    shrunkCount: _int(j['shrunkCount'] ?? j['ShrunkCount']),
+    shrunkDeltaBytes: _int(j['shrunkDeltaBytes'] ?? j['ShrunkDeltaBytes']),
+    netDeltaBytes: _int(j['netDeltaBytes'] ?? j['NetDeltaBytes']),
+  );
+}

--- a/frontend/gs_analyzer_ui/lib/providers/scan_diff_provider.dart
+++ b/frontend/gs_analyzer_ui/lib/providers/scan_diff_provider.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gs_analyzer_ui/models/scan_diff.dart';
+import 'package:gs_analyzer_ui/services/api_service.dart';
+
+final apiServiceProvider = Provider<ApiService>((ref) => ApiService());
+final scanDiffProvider = FutureProvider.autoDispose.family<ScanDiff, String>((
+  ref,
+  root,
+) async {
+  final api = ref.read(apiServiceProvider);
+  return api.getScanDiff(root);
+});
+
+final diffChangeCountProvider = Provider.autoDispose.family<int, String>((
+  ref,
+  root,
+) {
+  final summary = ref.watch(scanDiffProvider(root)).asData?.value.summary;
+  return summary?.totalChangeCount ?? 0;
+});

--- a/frontend/gs_analyzer_ui/lib/providers/telemetry_provider.dart
+++ b/frontend/gs_analyzer_ui/lib/providers/telemetry_provider.dart
@@ -12,6 +12,7 @@ import 'package:flutter/material.dart';
 import 'package:gs_analyzer_ui/utils/hud_theme.dart';
 import 'package:gs_analyzer_ui/providers/directory_provider.dart';
 import 'package:gs_analyzer_ui/providers/drive_stats_provider.dart';
+import 'package:gs_analyzer_ui/providers/scan_diff_provider.dart';
 
 import 'cpu_provider.dart';
 import 'nuke_provider.dart';
@@ -111,6 +112,14 @@ class TelemetryNotifier extends StateNotifier<TelemetryState> {
 
     _telemetryService?.onDirectoryStreamComplete = (scanId, path) {
       ref.read(directoryProvider.notifier).finalizeStream(scanId, path);
+      final drive = ref.read(currentDriveProvider);
+      if (drive != null) {
+        final completed = path.replaceAll('\\', '/').replaceAll('/', '').toLowerCase();
+        final driveRoot = drive.name.replaceAll('\\', '/').replaceAll('/', '').toLowerCase();
+        if (completed == driveRoot) {
+          ref.invalidate(scanDiffProvider(drive.name));
+        }
+      }
     };
 
     _telemetryService?.onNukeProgress = (percentage, target, completed) {
@@ -150,11 +159,12 @@ class TelemetryNotifier extends StateNotifier<TelemetryState> {
 
     _telemetryService?.onAutoScanComplete = (data) {
       final root = data['root'] as String;
-      
-      // The spec mentions invalidating scanResultFamily(root) and scanDiffProvider(root)
-      // which will be added in the next PR. For now, we refresh the directory tree unconditionally:
-      // TODO: ref.invalidate(scanResultFamily(root));
-      // TODO: ref.invalidate(scanDiffProvider(root));
+
+      // Refresh the WHAT_CHANGED badge + SCAN_DIFF screen for this root. The backend
+      // has already computed and cached the diff for this scan (it also rides along in
+      // data['diff']), so invalidating re-fetches the freshly cached result.
+      ref.invalidate(scanDiffProvider(root));
+
       ref.read(directoryProvider.notifier).scanDirectory(root);
 
       snackbarKey.currentState?.showSnackBar(

--- a/frontend/gs_analyzer_ui/lib/screen/scan_diff_screen.dart
+++ b/frontend/gs_analyzer_ui/lib/screen/scan_diff_screen.dart
@@ -1,0 +1,413 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gs_analyzer_ui/models/scan_diff.dart';
+import 'package:gs_analyzer_ui/providers/directory_provider.dart';
+import 'package:gs_analyzer_ui/providers/drive_stats_provider.dart';
+import 'package:gs_analyzer_ui/providers/scan_diff_provider.dart';
+import 'package:gs_analyzer_ui/providers/storage_view_provider.dart';
+import 'package:gs_analyzer_ui/services/api_service.dart';
+import 'package:gs_analyzer_ui/utils/hud_theme.dart';
+
+/// Signed byte formatter: "+4.8 GB", "-512 MB", "0 B".
+String _formatSignedBytes(int bytes) {
+  if (bytes == 0) return '0 B';
+  final sign = bytes > 0 ? '+' : '-';
+  return '$sign${_formatBytes(bytes.abs())}';
+}
+
+String _formatBytes(int bytes) {
+  if (bytes <= 0) return '0 B';
+  const suffixes = ['B', 'KB', 'MB', 'GB', 'TB'];
+  final i = (log(bytes) / log(1024)).floor().clamp(0, suffixes.length - 1);
+  final val = bytes / pow(1024, i);
+  return '${val < 10 && i > 0 ? val.toStringAsFixed(2) : val.toStringAsFixed(0)} ${suffixes[i]}';
+}
+
+/// Dedicated SCAN_DIFF screen — shows what changed on the active drive since the
+/// previous scan of the same root. Scoped to [currentDriveProvider]; switching
+/// drives shows that drive's diff. Never hardcodes a path.
+class ScanDiffScreen extends ConsumerWidget {
+  const ScanDiffScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final drive = ref.watch(currentDriveProvider);
+
+    return Scaffold(
+      backgroundColor: HudTheme.bgPanel,
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        title: Text('WHAT_CHANGED', style: HudTheme.headerCyan),
+        iconTheme: const IconThemeData(color: HudTheme.accentCyan),
+        actions: [
+          if (drive != null)
+            IconButton(
+              tooltip: 'CLEAR BASELINE',
+              icon: const Icon(Icons.restart_alt, color: HudTheme.textDim),
+              onPressed: () => _confirmClearBaseline(context, ref, drive.name),
+            ),
+        ],
+      ),
+      body: drive == null
+          ? const _CenteredMessage(
+              text: 'NO DRIVE SELECTED',
+              color: HudTheme.textDim,
+            )
+          : ref
+                .watch(scanDiffProvider(drive.name))
+                .when(
+                  loading: () => const _LoadingState(),
+                  error: (e, _) => _ErrorState(error: e),
+                  data: (diff) => _DiffBody(diff: diff),
+                ),
+    );
+  }
+
+  Future<void> _confirmClearBaseline(
+    BuildContext context,
+    WidgetRef ref,
+    String root,
+  ) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: HudTheme.bgPanel,
+        title: Text('CLEAR BASELINE', style: HudTheme.headerCyan),
+        content: Text(
+          'Forget the stored baseline for $root? The next scan will report '
+          'a fresh baseline with no changes.',
+          style: HudTheme.bodyText,
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('CANCEL', style: TextStyle(color: HudTheme.textDim)),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('CLEAR', style: HudTheme.actionRed),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true) return;
+
+    try {
+      await ref.read(apiServiceProvider).clearDiffBaseline(root);
+      ref.invalidate(scanDiffProvider(root));
+    } catch (_) {
+      // Best effort — the provider will surface any read error on refresh.
+    }
+  }
+}
+
+class _DiffBody extends StatelessWidget {
+  final ScanDiff diff;
+
+  const _DiffBody({required this.diff});
+
+  @override
+  Widget build(BuildContext context) {
+    if (!diff.hasBaseline) {
+      return const _CenteredMessage(
+        text: 'FIRST SCAN — BASELINE SAVED.\nNEXT SCAN WILL SHOW CHANGES.',
+        color: HudTheme.textDim,
+      );
+    }
+
+    if (diff.isEmpty) {
+      return const _CenteredMessage(
+        text: 'NO CHANGES SINCE LAST SCAN',
+        color: HudTheme.accentGreen,
+      );
+    }
+
+    return Column(
+      children: [
+        _SummaryStrip(diff: diff),
+        const Divider(color: Colors.white10, height: 1),
+        Expanded(
+          child: ListView(
+            children: [
+              _DiffSection(
+                title: 'ADDED',
+                color: HudTheme.accentGreen,
+                entries: diff.added,
+              ),
+              _DiffSection(
+                title: 'REMOVED',
+                color: HudTheme.accentRed,
+                entries: diff.removed,
+              ),
+              _DiffSection(
+                title: 'GROWN',
+                color: HudTheme.accentAmber,
+                entries: diff.grown,
+              ),
+              _DiffSection(
+                title: 'SHRUNK',
+                color: HudTheme.accentCyan,
+                entries: diff.shrunk,
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SummaryStrip extends StatelessWidget {
+  final ScanDiff diff;
+
+  const _SummaryStrip({required this.diff});
+
+  @override
+  Widget build(BuildContext context) {
+    final s = diff.summary;
+    // NET: red when the drive consumed more space (>0), green when freed (<0).
+    final netColor = s.netDeltaBytes > 0
+        ? HudTheme.accentRed
+        : (s.netDeltaBytes < 0 ? HudTheme.accentGreen : HudTheme.textDim);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      color: HudTheme.bgBase,
+      child: Wrap(
+        spacing: 12,
+        runSpacing: 8,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: [
+          _chip('+${s.addedCount} ADDED', HudTheme.accentGreen),
+          _chip('-${s.removedCount} REMOVED', HudTheme.accentRed),
+          _chip('▲${s.grownCount} GROWN', HudTheme.accentAmber),
+          _chip('▼${s.shrunkCount} SHRUNK', HudTheme.accentCyan),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+            decoration: BoxDecoration(
+              color: netColor.withValues(alpha: 0.15),
+              borderRadius: BorderRadius.circular(4),
+              border: Border.all(color: netColor),
+            ),
+            child: Text(
+              'NET: ${_formatSignedBytes(s.netDeltaBytes)}',
+              style: HudTheme.bodyText.copyWith(
+                color: netColor,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _chip(String label, Color color) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        label,
+        style: HudTheme.bodyText.copyWith(
+          color: color,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    );
+  }
+}
+
+class _DiffSection extends StatelessWidget {
+  final String title;
+  final Color color;
+  final List<ScanDiffEntry> entries;
+
+  const _DiffSection({
+    required this.title,
+    required this.color,
+    required this.entries,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (entries.isEmpty) return const SizedBox.shrink();
+
+    return Theme(
+      data: Theme.of(context).copyWith(dividerColor: Colors.transparent),
+      child: ExpansionTile(
+        initiallyExpanded: true,
+        title: Text(
+          '$title (${entries.length})',
+          style: HudTheme.bodyText.copyWith(
+            color: color,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        childrenPadding: EdgeInsets.zero,
+        // ListView.builder keeps large change sets overflow-safe (never a DataTable).
+        children: [
+          ListView.builder(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            itemCount: entries.length,
+            itemBuilder: (context, i) =>
+                _DiffRow(entry: entries[i], color: color),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DiffRow extends ConsumerWidget {
+  final ScanDiffEntry entry;
+  final Color color;
+
+  const _DiffRow({required this.entry, required this.color});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Folder icon → amber, file icon → green, per the project icon convention.
+    final icon = entry.isDirectory ? Icons.folder : Icons.insert_drive_file;
+    final iconColor = entry.isDirectory
+        ? HudTheme.accentAmber
+        : HudTheme.accentGreen;
+
+    return InkWell(
+      onTap: () => _jumpToExplorer(context, ref),
+      child: Container(
+        height: 44,
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        child: Row(
+          children: [
+            Icon(icon, color: iconColor, size: 16),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    entry.displayName,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: HudTheme.bodyText,
+                  ),
+                  Text(
+                    entry.childCount != null
+                        ? '${entry.parentPath}  ·  ${entry.childCount} items'
+                        : entry.parentPath,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: HudTheme.bodyText.copyWith(
+                      color: HudTheme.textDim,
+                      fontSize: 11,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 10),
+            Text(
+              _formatSignedBytes(entry.deltaBytes),
+              style: HudTheme.bodyText.copyWith(
+                color: color,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// Jump into the directory explorer at this entry's parent (reuses the
+  /// FIND IN EXPLORER navigation pattern).
+  void _jumpToExplorer(BuildContext context, WidgetRef ref) {
+    ref.read(directoryProvider.notifier).scanDirectory(entry.parentPath);
+    ref.read(storageViewProvider.notifier).state = StorageView.analyzer;
+    Navigator.of(context).pop();
+  }
+}
+
+class _LoadingState extends StatelessWidget {
+  const _LoadingState();
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        const CircularProgressIndicator(color: HudTheme.accentCyan),
+        const SizedBox(height: 16),
+        Text('ANALYZING CHANGES...', style: HudTheme.labelMuted),
+      ],
+    );
+  }
+}
+
+class _ErrorState extends ConsumerWidget {
+  final Object error;
+
+  const _ErrorState({required this.error});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // 409 (no scan cached) surfaces as DiffNoScanException → prompt to scan.
+    if (error is DiffNoScanException) {
+      return Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text('NO SCAN DATA — RUN A SCAN FIRST', style: HudTheme.labelMuted),
+          const SizedBox(height: 16),
+          OutlinedButton(
+            style: OutlinedButton.styleFrom(
+              foregroundColor: HudTheme.accentCyan,
+              side: const BorderSide(color: HudTheme.accentCyan),
+            ),
+            onPressed: () {
+              // Return to Storage so the user can launch a scan.
+              ref.read(storageViewProvider.notifier).state =
+                  StorageView.drivePicker;
+              Navigator.of(context).maybePop();
+            },
+            child: const Text('SCAN NOW'),
+          ),
+        ],
+      );
+    }
+
+    return _CenteredMessage(
+      text: 'DIFF UNAVAILABLE\n$error',
+      color: HudTheme.accentRed,
+    );
+  }
+}
+
+class _CenteredMessage extends StatelessWidget {
+  final String text;
+  final Color color;
+
+  const _CenteredMessage({required this.text, required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Text(
+          text,
+          textAlign: TextAlign.center,
+          style: HudTheme.bodyText.copyWith(color: color),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/gs_analyzer_ui/lib/screen/storage_screen.dart
+++ b/frontend/gs_analyzer_ui/lib/screen/storage_screen.dart
@@ -10,6 +10,8 @@ import 'package:gs_analyzer_ui/providers/storage_mode_provider.dart';
 import 'package:gs_analyzer_ui/widgets/file_type_analyzer_panel.dart';
 import 'package:gs_analyzer_ui/widgets/undo_history_panel.dart';
 import 'package:gs_analyzer_ui/providers/hud_density_provider.dart';
+import 'package:gs_analyzer_ui/providers/scan_diff_provider.dart';
+import 'package:gs_analyzer_ui/screen/scan_diff_screen.dart';
 
 class StorageScreen extends ConsumerWidget {
   const StorageScreen({Key? key}) : super(key: key);
@@ -321,18 +323,27 @@ class _DriveDetailCard extends ConsumerWidget {
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Text(
-                'DRIVE: ${drive.label} (${drive.name})',
-                style: HudTheme.headerCyan.copyWith(color: HudTheme.accentCyan),
+              Expanded(
+                child: Text(
+                  'DRIVE: ${drive.label} (${drive.name})',
+                  style: HudTheme.headerCyan.copyWith(
+                    color: HudTheme.accentCyan,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
               ),
               if (drive.percentageUsed >= redThreshold)
-                Text(
-                  '● CRITICAL SPACE',
-                  style: HudTheme.bodyText.copyWith(
-                    color: Colors.redAccent,
-                    fontWeight: FontWeight.bold,
+                Padding(
+                  padding: const EdgeInsets.only(left: 8),
+                  child: Text(
+                    '● CRITICAL SPACE',
+                    style: HudTheme.bodyText.copyWith(
+                      color: Colors.redAccent,
+                      fontWeight: FontWeight.bold,
+                    ),
                   ),
                 ),
+              _WhatChangedButton(drive: drive),
             ],
           ),
           Divider(color: Colors.white10, height: d.gap * 3, thickness: 1),
@@ -421,6 +432,71 @@ class _DriveDetailCard extends ConsumerWidget {
           style: HudTheme.bodyText.copyWith(fontWeight: FontWeight.bold),
         ),
       ],
+    );
+  }
+}
+
+/// WHAT_CHANGED access icon for the drive detail card. Shows an amber count badge
+/// when the last scan of this drive produced changes; tapping opens the SCAN_DIFF screen.
+/// The badge is hidden when there is no baseline, no cached scan, or zero changes.
+class _WhatChangedButton extends ConsumerWidget {
+  final DriveInfo drive;
+
+  const _WhatChangedButton({required this.drive});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final changeCount = ref.watch(diffChangeCountProvider(drive.name));
+
+    return Tooltip(
+      message: 'WHAT CHANGED',
+      child: InkWell(
+        borderRadius: BorderRadius.circular(4),
+        onTap: () {
+          Navigator.of(context).push(
+            MaterialPageRoute(builder: (_) => const ScanDiffScreen()),
+          );
+        },
+        child: Padding(
+          padding: const EdgeInsets.all(4),
+          child: Stack(
+            clipBehavior: Clip.none,
+            children: [
+              const Icon(
+                Icons.difference_outlined,
+                color: HudTheme.accentCyan,
+                size: 20,
+              ),
+              if (changeCount > 0)
+                Positioned(
+                  right: -6,
+                  top: -6,
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 4,
+                      vertical: 1,
+                    ),
+                    constraints: const BoxConstraints(minWidth: 16),
+                    decoration: BoxDecoration(
+                      color: HudTheme.accentAmber,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Text(
+                      changeCount > 99 ? '99+' : '$changeCount',
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(
+                        color: Colors.black,
+                        fontSize: 10,
+                        fontWeight: FontWeight.bold,
+                        fontFamily: HudTheme.fontCore,
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/frontend/gs_analyzer_ui/lib/services/api_service.dart
+++ b/frontend/gs_analyzer_ui/lib/services/api_service.dart
@@ -16,6 +16,7 @@ import 'package:gs_analyzer_ui/models/permission_audit_models.dart';
 import 'package:gs_analyzer_ui/models/telemetry_history_model.dart';
 import 'package:gs_analyzer_ui/models/startup_program.dart';
 import 'package:gs_analyzer_ui/models/scheduled_scan_model.dart';
+import 'package:gs_analyzer_ui/models/scan_diff.dart';
 
 class ApiService {
   final http.Client _client;
@@ -33,6 +34,7 @@ class ApiService {
   static const String tempFilesUrl = 'http://localhost:5200/api/tempfiles';
   static const String startupUrl = 'http://localhost:5200/api/startup';
   static const String schedulesUrl = 'http://localhost:5200/api/schedules';
+  static const String scanDiffUrl = 'http://localhost:5200/api/scan/diff';
 
   Future<TelemetryHistoryResponse?> fetchTelemetryHistory(
     String metric,
@@ -706,6 +708,48 @@ class ApiService {
       throw Exception('$prefix [${response.statusCode}]: ${response.body}');
     }
   }
+
+  // --- SCAN RESULT DIFF ---
+
+  /// Fetches the diff of the latest scan of [root] against its stored baseline.
+  /// Throws [DiffNoScanException] when no scan is cached (409) — never triggers a scan.
+  Future<ScanDiff> getScanDiff(String root, {int minDeltaBytes = 0}) async {
+    final uri = Uri.parse(scanDiffUrl).replace(
+      queryParameters: {
+        'root': root,
+        'minDeltaBytes': minDeltaBytes.toString(),
+      },
+    );
+
+    final response = await _client.get(uri);
+
+    if (response.statusCode == 409) {
+      throw const DiffNoScanException();
+    }
+
+    if (response.statusCode != 200) {
+      throw Exception(
+        'ScanDiff fetch failed [${response.statusCode}]: ${response.body}',
+      );
+    }
+
+    return ScanDiff.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
+  }
+
+  /// Clears the stored baseline for [root]; the next scan will report hasBaseline=false.
+  Future<void> clearDiffBaseline(String root) async {
+    final uri = Uri.parse(
+      '$scanDiffUrl/baseline',
+    ).replace(queryParameters: {'root': root});
+
+    final response = await _client.delete(uri);
+
+    if (response.statusCode != 200) {
+      throw Exception(
+        'Clear baseline failed [${response.statusCode}]: ${response.body}',
+      );
+    }
+  }
 }
 
 ExtensionBreakdownResult _parseBreakdown(String body) {
@@ -729,4 +773,10 @@ class ScheduleBusyException implements Exception {
   const ScheduleBusyException();
   @override
   String toString() => 'A scan is already in progress. Try again later.';
+}
+
+class DiffNoScanException implements Exception {
+  const DiffNoScanException();
+  @override
+  String toString() => 'No scan cached for this root. Run a scan first.';
 }

--- a/frontend/gs_analyzer_ui/test/models/scan_diff_test.dart
+++ b/frontend/gs_analyzer_ui/test/models/scan_diff_test.dart
@@ -1,0 +1,206 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gs_analyzer_ui/models/scan_diff.dart';
+
+void main() {
+  group('ScanDiff.fromJson', () {
+    test('parses a full diff response (camelCase)', () {
+      final json = {
+        'root': 'C:/',
+        'hasBaseline': true,
+        'baselineScannedAt': '2026-07-14T09:12:00Z',
+        'currentScannedAt': '2026-07-15T14:03:00Z',
+        'added': [
+          {
+            'path': 'C:/dev/new-project/node_modules',
+            'isDirectory': true,
+            'currentBytes': 261120000,
+            'previousBytes': 0,
+            'deltaBytes': 261120000,
+            'childCount': 18422,
+            'lastModified': '2026-07-15T11:02:00Z',
+          },
+        ],
+        'removed': [
+          {
+            'path': 'C:/old_backups/2024',
+            'isDirectory': true,
+            'currentBytes': 0,
+            'previousBytes': 1073741824,
+            'deltaBytes': -1073741824,
+            'childCount': 640,
+            'lastModified': '2024-01-10T08:00:00Z',
+          },
+        ],
+        'grown': [
+          {
+            'path': 'C:/Users/user/AppData/Local/Temp',
+            'isDirectory': true,
+            'currentBytes': 3221225472,
+            'previousBytes': 1073741824,
+            'deltaBytes': 2147483648,
+            'childCount': null,
+            'lastModified': '2026-07-15T14:01:00Z',
+          },
+        ],
+        'shrunk': <dynamic>[],
+        'summary': {
+          'addedCount': 1,
+          'addedBytes': 261120000,
+          'removedCount': 1,
+          'removedBytes': 1073741824,
+          'grownCount': 1,
+          'grownDeltaBytes': 2147483648,
+          'shrunkCount': 0,
+          'shrunkDeltaBytes': 0,
+          'netDeltaBytes': 1334883648,
+        },
+      };
+
+      final diff = ScanDiff.fromJson(json);
+
+      expect(diff.root, 'C:/');
+      expect(diff.hasBaseline, isTrue);
+      expect(diff.added.single.childCount, 18422);
+      expect(diff.removed.single.deltaBytes, -1073741824);
+      expect(diff.grown.single.childCount, isNull);
+      expect(diff.shrunk, isEmpty);
+      expect(diff.summary.netDeltaBytes, 1334883648);
+      expect(diff.summary.totalChangeCount, 3);
+      expect(diff.isEmpty, isFalse);
+    });
+
+    test('first-scan response: hasBaseline false, empty lists, isEmpty true', () {
+      final json = {
+        'root': 'D:/',
+        'hasBaseline': false,
+        'baselineScannedAt': null,
+        'currentScannedAt': '2026-07-15T14:03:00Z',
+        'added': <dynamic>[],
+        'removed': <dynamic>[],
+        'grown': <dynamic>[],
+        'shrunk': <dynamic>[],
+        'summary': {
+          'addedCount': 0,
+          'addedBytes': 0,
+          'removedCount': 0,
+          'removedBytes': 0,
+          'grownCount': 0,
+          'grownDeltaBytes': 0,
+          'shrunkCount': 0,
+          'shrunkDeltaBytes': 0,
+          'netDeltaBytes': 0,
+        },
+      };
+
+      final diff = ScanDiff.fromJson(json);
+
+      expect(diff.hasBaseline, isFalse);
+      expect(diff.baselineScannedAt, isNull);
+      expect(diff.isEmpty, isTrue);
+      expect(diff.summary.totalChangeCount, 0);
+    });
+
+    test('parses PascalCase keys (raw backend record casing)', () {
+      final json = {
+        'Root': 'C:/',
+        'HasBaseline': true,
+        'BaselineScannedAt': '2026-07-14T09:12:00Z',
+        'CurrentScannedAt': '2026-07-15T14:03:00Z',
+        'Added': [
+          {
+            'Path': 'C:/x',
+            'IsDirectory': true,
+            'CurrentBytes': 100,
+            'PreviousBytes': 0,
+            'DeltaBytes': 100,
+            'ChildCount': null,
+            'LastModified': null,
+          },
+        ],
+        'Removed': <dynamic>[],
+        'Grown': <dynamic>[],
+        'Shrunk': <dynamic>[],
+        'Summary': {
+          'AddedCount': 1,
+          'AddedBytes': 100,
+          'RemovedCount': 0,
+          'RemovedBytes': 0,
+          'GrownCount': 0,
+          'GrownDeltaBytes': 0,
+          'ShrunkCount': 0,
+          'ShrunkDeltaBytes': 0,
+          'NetDeltaBytes': 100,
+        },
+      };
+
+      final diff = ScanDiff.fromJson(json);
+
+      expect(diff.root, 'C:/');
+      expect(diff.added.single.path, 'C:/x');
+      expect(diff.added.single.lastModified, isNull);
+      expect(diff.summary.addedCount, 1);
+    });
+  });
+
+  group('ScanDiffEntry helpers', () {
+    test('parentPath returns the containing directory', () {
+      const entry = ScanDiffEntry(
+        path: 'C:/Users/user/Downloads/ubuntu.iso',
+        isDirectory: false,
+        currentBytes: 100,
+        previousBytes: 0,
+        deltaBytes: 100,
+        childCount: null,
+        lastModified: null,
+      );
+      expect(entry.parentPath, 'C:/Users/user/Downloads');
+    });
+
+    test('parentPath handles backslash paths', () {
+      const entry = ScanDiffEntry(
+        path: r'C:\dev\project\node_modules',
+        isDirectory: true,
+        currentBytes: 100,
+        previousBytes: 0,
+        deltaBytes: 100,
+        childCount: 10,
+        lastModified: null,
+      );
+      expect(entry.parentPath, 'C:/dev/project');
+    });
+
+    test('displayName returns the trailing segment', () {
+      const entry = ScanDiffEntry(
+        path: 'C:/dev/project/node_modules',
+        isDirectory: true,
+        currentBytes: 100,
+        previousBytes: 0,
+        deltaBytes: 100,
+        childCount: 10,
+        lastModified: null,
+      );
+      expect(entry.displayName, 'node_modules');
+    });
+
+    test('displayName strips a trailing slash', () {
+      const entry = ScanDiffEntry(
+        path: 'C:/dev/project/',
+        isDirectory: true,
+        currentBytes: 100,
+        previousBytes: 0,
+        deltaBytes: 100,
+        childCount: 10,
+        lastModified: null,
+      );
+      expect(entry.displayName, 'project');
+    });
+
+    test('handles missing/null numeric fields as zero', () {
+      final entry = ScanDiffEntry.fromJson({'path': 'C:/x', 'isDirectory': true});
+      expect(entry.currentBytes, 0);
+      expect(entry.previousBytes, 0);
+      expect(entry.deltaBytes, 0);
+      expect(entry.childCount, isNull);
+    });
+  });
+}

--- a/frontend/gs_analyzer_ui/test/provider/scan_diff_provider_test.dart
+++ b/frontend/gs_analyzer_ui/test/provider/scan_diff_provider_test.dart
@@ -1,0 +1,186 @@
+import 'dart:convert';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:gs_analyzer_ui/models/scan_diff.dart';
+import 'package:gs_analyzer_ui/services/api_service.dart';
+import 'package:gs_analyzer_ui/providers/scan_diff_provider.dart';
+
+/// Minimal success payload the backend GET /api/scan/diff returns (raw ScanDiff, camelCase).
+Map<String, dynamic> _diffJson({
+  int added = 2,
+  int removed = 1,
+  int grown = 1,
+  int shrunk = 1,
+}) => {
+  'root': 'C:/',
+  'hasBaseline': true,
+  'baselineScannedAt': '2026-07-14T09:12:00Z',
+  'currentScannedAt': '2026-07-15T14:03:00Z',
+  'added': List.generate(
+    added,
+    (i) => {
+      'path': 'C:/added/$i',
+      'isDirectory': true,
+      'currentBytes': 1000,
+      'previousBytes': 0,
+      'deltaBytes': 1000,
+      'childCount': null,
+      'lastModified': null,
+    },
+  ),
+  'removed': List.generate(
+    removed,
+    (i) => {
+      'path': 'C:/removed/$i',
+      'isDirectory': true,
+      'currentBytes': 0,
+      'previousBytes': 500,
+      'deltaBytes': -500,
+      'childCount': null,
+      'lastModified': null,
+    },
+  ),
+  'grown': List.generate(
+    grown,
+    (i) => {
+      'path': 'C:/grown/$i',
+      'isDirectory': true,
+      'currentBytes': 2000,
+      'previousBytes': 1000,
+      'deltaBytes': 1000,
+      'childCount': null,
+      'lastModified': null,
+    },
+  ),
+  'shrunk': List.generate(
+    shrunk,
+    (i) => {
+      'path': 'C:/shrunk/$i',
+      'isDirectory': true,
+      'currentBytes': 300,
+      'previousBytes': 800,
+      'deltaBytes': -500,
+      'childCount': null,
+      'lastModified': null,
+    },
+  ),
+  'summary': {
+    'addedCount': added,
+    'addedBytes': added * 1000,
+    'removedCount': removed,
+    'removedBytes': removed * 500,
+    'grownCount': grown,
+    'grownDeltaBytes': grown * 1000,
+    'shrunkCount': shrunk,
+    'shrunkDeltaBytes': shrunk * -500,
+    'netDeltaBytes': 5000,
+  },
+};
+
+ProviderContainer _containerWith(http.Client client) {
+  final container = ProviderContainer(
+    overrides: [
+      apiServiceProvider.overrideWithValue(ApiService(client)),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  group('scanDiffProvider', () {
+    test('returns parsed ScanDiff on 200', () async {
+      final client = MockClient(
+        (_) async => http.Response(jsonEncode(_diffJson()), 200),
+      );
+      final container = _containerWith(client);
+
+      final diff = await container.read(scanDiffProvider('C:/').future);
+
+      expect(diff, isA<ScanDiff>());
+      expect(diff.hasBaseline, isTrue);
+      expect(diff.added.length, 2);
+      expect(diff.summary.netDeltaBytes, 5000);
+    });
+
+    // The 409 -> DiffNoScanException throw originates in ApiService.getScanDiff,
+    // which the provider propagates verbatim. Asserting it at the ApiService
+    // boundary avoids racing autoDispose disposal on the FutureProvider error path;
+    // the provider's propagation of that error is covered by the
+    // "diffChangeCountProvider is 0 when the diff request 409s" test below.
+    test('getScanDiff throws DiffNoScanException on 409 (never triggers a scan)',
+        () async {
+      final client = MockClient(
+        (_) async => http.Response(
+          jsonEncode({'error': 'NO_SCAN_CACHED', 'message': 'Run a scan first.'}),
+          409,
+        ),
+      );
+
+      expect(
+        () => ApiService(client).getScanDiff('C:/'),
+        throwsA(isA<DiffNoScanException>()),
+      );
+    });
+
+    test('sends root as a query parameter', () async {
+      late Uri captured;
+      final client = MockClient((req) async {
+        captured = req.url;
+        return http.Response(jsonEncode(_diffJson()), 200);
+      });
+      final container = _containerWith(client);
+
+      await container.read(scanDiffProvider(r'D:\').future);
+
+      expect(captured.path, endsWith('/api/scan/diff'));
+      expect(captured.queryParameters['root'], r'D:\');
+    });
+  });
+
+  group('diffChangeCountProvider', () {
+    test('sums the four change buckets', () async {
+      final client = MockClient(
+        (_) async => http.Response(
+          jsonEncode(_diffJson(added: 3, removed: 2, grown: 1, shrunk: 4)),
+          200,
+        ),
+      );
+      final container = _containerWith(client);
+
+      // Resolve the underlying future first so the derived provider sees data.
+      await container.read(scanDiffProvider('C:/').future);
+
+      expect(container.read(diffChangeCountProvider('C:/')), 10);
+    });
+
+    test('is 0 while loading / before any scan is cached', () {
+      final client = MockClient(
+        (_) async => http.Response(jsonEncode(_diffJson()), 200),
+      );
+      final container = _containerWith(client);
+
+      // No await: the FutureProvider is still in the loading state → asData is null.
+      expect(container.read(diffChangeCountProvider('C:/')), 0);
+    });
+
+    test('is 0 when the diff request 409s (no baseline yet)', () async {
+      final client = MockClient(
+        (_) async => http.Response(
+          jsonEncode({'error': 'NO_SCAN_CACHED', 'message': 'x'}),
+          409,
+        ),
+      );
+      final container = _containerWith(client);
+
+      // Drive the future to its error state, ignoring the throw.
+      try {
+        await container.read(scanDiffProvider('C:/').future);
+      } catch (_) {}
+
+      expect(container.read(diffChangeCountProvider('C:/')), 0);
+    });
+  });
+}

--- a/frontend/gs_analyzer_ui/test/widgets/scan_diff_screen_test.dart
+++ b/frontend/gs_analyzer_ui/test/widgets/scan_diff_screen_test.dart
@@ -1,0 +1,137 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gs_analyzer_ui/models/drive_info.dart';
+import 'package:gs_analyzer_ui/providers/drive_stats_provider.dart';
+import 'package:gs_analyzer_ui/providers/scan_diff_provider.dart';
+import 'package:gs_analyzer_ui/screen/scan_diff_screen.dart';
+import 'package:gs_analyzer_ui/services/api_service.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+DriveInfo _drive() => DriveInfo.fromJson({
+  'name': r'C:\',
+  'label': 'System',
+  'type': 'fixed',
+  'format': 'NTFS',
+  'totalBytes': 1000,
+  'freeBytes': 500,
+  'usedBytes': 500,
+});
+
+Map<String, dynamic> _diffJson({
+  bool hasBaseline = true,
+  int added = 1,
+  int grown = 1,
+}) => {
+  'root': 'C:/',
+  'hasBaseline': hasBaseline,
+  'baselineScannedAt': hasBaseline ? '2026-07-14T09:12:00Z' : null,
+  'currentScannedAt': '2026-07-15T14:03:00Z',
+  'added': List.generate(
+    added,
+    (i) => {
+      'path': 'C:/added/file$i.iso',
+      'isDirectory': false,
+      'currentBytes': 5100273664,
+      'previousBytes': 0,
+      'deltaBytes': 5100273664,
+      'childCount': null,
+      'lastModified': null,
+    },
+  ),
+  'removed': const [],
+  'grown': List.generate(
+    grown,
+    (i) => {
+      'path': 'C:/grown/dir$i',
+      'isDirectory': true,
+      'currentBytes': 3221225472,
+      'previousBytes': 1073741824,
+      'deltaBytes': 2147483648,
+      'childCount': null,
+      'lastModified': null,
+    },
+  ),
+  'shrunk': const [],
+  'summary': {
+    'addedCount': added,
+    'addedBytes': added * 5100273664,
+    'removedCount': 0,
+    'removedBytes': 0,
+    'grownCount': grown,
+    'grownDeltaBytes': grown * 2147483648,
+    'shrunkCount': 0,
+    'shrunkDeltaBytes': 0,
+    'netDeltaBytes': added * 5100273664 + grown * 2147483648,
+  },
+};
+
+Future<void> _pump(WidgetTester tester, MockClient client) {
+  return tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        apiServiceProvider.overrideWithValue(ApiService(client)),
+        // Seed a single fixed drive so currentDriveProvider resolves to C:\.
+        drivesProvider.overrideWith(() => _StubDrivesNotifier([_drive()])),
+      ],
+      child: const MaterialApp(home: ScanDiffScreen()),
+    ),
+  );
+}
+
+class _StubDrivesNotifier extends DrivesNotifier {
+  _StubDrivesNotifier(this._drives);
+  final List<DriveInfo> _drives;
+  @override
+  List<DriveInfo> build() => _drives;
+}
+
+void main() {
+  testWidgets('renders the summary strip and change sections on success', (
+    tester,
+  ) async {
+    final client = MockClient(
+      (_) async => http.Response(jsonEncode(_diffJson()), 200),
+    );
+    await _pump(tester, client);
+    await tester.pumpAndSettle();
+
+    expect(find.text('WHAT_CHANGED'), findsOneWidget);
+    // Section headers include their counts.
+    expect(find.textContaining('ADDED'), findsWidgets);
+    expect(find.textContaining('GROWN'), findsWidgets);
+    // The added file surfaces by name.
+    expect(find.textContaining('file0.iso'), findsOneWidget);
+  });
+
+  testWidgets('first-scan (no baseline) shows the BASELINE SAVED state', (
+    tester,
+  ) async {
+    final client = MockClient(
+      (_) async => http.Response(
+        jsonEncode(_diffJson(hasBaseline: false, added: 0, grown: 0)),
+        200,
+      ),
+    );
+    await _pump(tester, client);
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('FIRST SCAN'), findsOneWidget);
+  });
+
+  testWidgets('409 (no scan cached) shows the RUN A SCAN state', (tester) async {
+    final client = MockClient(
+      (_) async => http.Response(
+        jsonEncode({'error': 'NO_SCAN_CACHED', 'message': 'x'}),
+        409,
+      ),
+    );
+    await _pump(tester, client);
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('NO SCAN'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

Adds the Scan Result Diff feature: every time a drive is re-scanned, the app shows exactly what changed since the previous scan of that same root — paths added, removed, grown, or shrunk, plus the net effect on used space. This is the first concrete slice of the Context Layer philosophy ("what is normal for this machine, and what changed?") applied to storage, built cheaply on top of the existing directory scan cache.

Closes #62

## Type of change

- [x] Feature (new panel, service, endpoint, or capability)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance / memory (engine, scanning, benchmarks)
- [ ] CI / build / infrastructure
- [ ] Documentation
- [ ] Refactor (no behavioural change)
- [ ] Breaking change

## Area

- [ ] Backend — `/backend` (ASP.NET Core 10, C#, SignalR)
- [ ] Frontend — `/frontend/gs_analyzer_ui` (Flutter / Dart / Riverpod)
- [ ] Benchmarks — `gs-benchmark`
- [x] Cross-cutting / both ends

## What changed

**Backend**
- `Models/ScanDiff.cs` — `ScanDiff`, `ScanDiffEntry`, `ScanDiffSummary`, `DiffKind` records.
- `Services/ScanSnapshotStore.cs` (+ `Interfaces/IScanSnapshotStore.cs`) — persists one baseline snapshot per `scan:{normalizedRoot}:{depth}` to `%AppData%/GSAnalyzer/scan_snapshots/`, atomic temp-file + `File.Move(overwrite)` write, local-first.
- `Services/ScanDiffService.cs` (+ `Interfaces/IScanDiffService.cs`) — builds the current flattened snapshot from the scan cache, diffs against the baseline, classifies Added/Removed/Grown/Shrunk with first-point-of-divergence collapse (`childCount`), sorts by magnitude, then promotes the current snapshot to baseline.
- `Controllers/ScanDiffController.cs` — `GET /api/scan/diff?root=&minDeltaBytes=` (409 `NO_SCAN_CACHED` when no scan is cached — never triggers a scan) and `DELETE /api/scan/diff/baseline?root=`.
- `BackgroundWorkers/ScheduledScanWorker.cs` — `AutoScanComplete` now carries the `diff` payload (replaces the `null` placeholder).
- `Program.cs` — DI registration for the snapshot store + diff service.

> **Granularity note:** the scan cache stores directory-level recursive sizes only (not per-file), so the diff is **directory-level** — consistent with how `FileTypeScanner` / `AgeHeatmapEngine` already read the cache, and keeps the feature cheap (no re-walk, bounded snapshots). This is a deliberate divergence from the per-file example in the original spec.

**Frontend**
- `models/scan_diff.dart` — DTOs with dual camel/Pascal-case `fromJson` + `isEmpty`, `parentPath`, `displayName`, `totalChangeCount` helpers.
- `services/api_service.dart` — `getScanDiff()` / `clearDiffBaseline()`, `DiffNoScanException` on 409.
- `providers/scan_diff_provider.dart` — `scanDiffProvider` (autoDispose family by root) + `diffChangeCountProvider` driving the badge.
- `providers/telemetry_provider.dart` — invalidates the diff on `AutoScanComplete` and on manual-scan completion.
- `screen/storage_screen.dart` — `WHAT_CHANGED` access icon + amber change-count badge on the drive detail card (hidden at zero).
- `screen/scan_diff_screen.dart` — dedicated `SCAN_DIFF` screen: summary strip, four collapsible sections, colored NET badge, row→explorer jump, and all states (loading / 409 / first-scan / no-changes / success).

## How to test

1. Start the backend: `cd backend && dotnet run` (serves `http://localhost:5200`).
2. `cd frontend/gs_analyzer_ui && flutter run -d windows`.
3. Go to **Storage**, pick a drive, run **Directory Scanner** once → open `WHAT_CHANGED` → confirms the **FIRST SCAN — BASELINE SAVED** state (no error, badge hidden).
4. Change the drive (add/delete/grow a folder), re-scan the same root → the badge shows a count; open the screen and verify Added / Removed / Grown / Shrunk lists and that **NET** is red when space was consumed, green when freed.
5. Restart both backend and app, re-scan → baseline persists (diff still computed against the earlier scan).
6. `DELETE /api/scan/diff/baseline?root=C:/` → next scan reports `hasBaseline: false`.

## Screenshots / recordings

<!-- TODO: add before/after of the drive card badge + the SCAN_DIFF screen (success + first-scan states). -->

## Merge gate checklist

- [x] Keeps the architecture boundary: Flutter → SignalR/REST → C# backend → OS APIs (no direct OS calls from Dart)
- [x] New backend service has ≥1 xUnit test (happy path + 1 edge case) — `ScanDiffServiceTests` (add/remove/grow/shrink, temp dirs only) + `ScanSnapshotStoreTests`
- [x] Any file-deletion code uses a temp directory only — never real paths
- [x] New Flutter widget has ≥1 widget test covering the empty/loading state — `scan_diff_screen_test.dart` (success / first-scan / 409)
- [x] No hardcoded colors — all colors reference `HudTheme` constants; headers use `HudLabel` (ALL_CAPS)
- [x] Ran `dotnet test` (backend) and `flutter analyze && flutter test` (frontend) locally — all green (frontend 143/143; backend 257/257 on net10.0 — see note)
- [ ] Cross-platform features verified on Windows (Linux validation noted in the issue) — Windows verified; Linux path normalization covered by unit tests, not yet run on a Linux host
- [x] PR is focused — one feature/fix; branch named `feature/…` or `fix/…` (`feat/scan_result_diff_refactor`)
- [x] Read CONTRIBUTING.md and claimed the issue before starting

## Related issues / notes

- `kind` currently serializes as an int (`JsonStringEnumConverter` not applied to `DiffKind`); the frontend doesn't read the field, so it's harmless — add the converter if the documented string contract matters.
- The `net10.0-windows` test run shows one intermittent failure in `LeakTests.PreviewCleanLoop` (soak/memory test, unrelated to this feature); it passes in isolation.
- Not yet run as a live end-to-end (server + client) smoke test — each side is covered by its own tests.
